### PR TITLE
add 'tags' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ udillyties/
 .cache
 /doc/_build/*
 *pycache*
+tags


### PR DESCRIPTION
vim creates a tags file for syntax highlighting. we want to ignore it