### PR TITLE
Bug/156/exciter bpms

### DIFF
--- a/omc3/model/accelerators/accelerator.py
+++ b/omc3/model/accelerators/accelerator.py
@@ -55,7 +55,7 @@ class Accelerator(object):
         params.add_parameter(name="drv_tunes", type=float, nargs=2,
                              help="Driven tunes without integer part.", )
         params.add_parameter(name="driven_excitation", type=str, choices=("acd", "adt"),
-                             help="Driven tunes without integer part.", )
+                             help="Denotes driven excitation by AC-dipole (acd) or by ADT (adt)", )
         params.add_parameter(name="dpp", default=0.0, type=float, help="Delta p/p to use.",)
         params.add_parameter(name="energy", type=float, help="Energy in Tev.", )
         params.add_parameter(name="modifiers", type=str,

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -103,15 +103,13 @@ class Lhc(Accelerator):
             raise AcceleratorDefinitionError("Beam parameter has to be one of (1, 2)")
         self._beam = value
 
-    @classmethod
-    def get_file(cls, filename):
-        return os.path.join(CURRENT_DIR, cls.NAME, filename)
+    def get_file(self, filename):
+        return os.path.join(CURRENT_DIR, self.NAME, filename)
 
-    @classmethod
-    def get_lhc_error_dir(cls):
+    @staticmethod
+    def get_lhc_error_dir():
         return os.path.join(LHC_DIR, "systematic_errors")
 
-    @classmethod
     def get_variables(self, frm=None, to=None, classes=None):
         correctors_dir = os.path.join(LHC_DIR, "2012", "correctors")  # not a bug
         all_corrs = _merge_jsons(
@@ -143,8 +141,7 @@ class Lhc(Accelerator):
         ))
         return _list_intersect_keep_order(vars_by_position, vars_by_class)
 
-    @classmethod
-    def get_ips(cls):
+    def get_ips(self):
         """ Returns an iterable with this accelerator IPs.
 
         Returns:
@@ -153,11 +150,11 @@ class Lhc(Accelerator):
         """
         for ip in Lhc.LHC_IPS:
             yield ("IP{}".format(ip),
-                   Lhc.NORMAL_IP_BPMS.format(side="L", ip=ip, beam=cls.beam),
-                   Lhc.NORMAL_IP_BPMS.format(side="R", ip=ip, beam=cls.beam))
+                   Lhc.NORMAL_IP_BPMS.format(side="L", ip=ip, beam=self.beam),
+                   Lhc.NORMAL_IP_BPMS.format(side="R", ip=ip, beam=self.beam))
             yield ("IP{}_DOROS".format(ip),
-                   Lhc.DOROS_IP_BPMS.format(side="L", ip=ip, beam=cls.beam),
-                   Lhc.DOROS_IP_BPMS.format(side="R", ip=ip, beam=cls.beam))
+                   Lhc.DOROS_IP_BPMS.format(side="L", ip=ip, beam=self.beam),
+                   Lhc.DOROS_IP_BPMS.format(side="R", ip=ip, beam=self.beam))
 
     def log_status(self):
         LOGGER.info(f"  model dir = {self.model_dir}")

--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -36,6 +36,16 @@ class Ps(Accelerator):
     def get_file(cls, filename):
         return os.path.join(CURRENT_DIR, cls.NAME, filename)
 
+    def get_exciter_bpm(self, plane, bpms):
+        if not self.excitation:
+            return None
+        plane_to_hv = dict(X="h", Y="v")
+        bpms_to_find = ["PR.BPM00", "PR.BPM03"]
+        found_bpms = [bpm for bpm in bpms_to_find if bpm in bpms]
+        if not len(found_bpms):
+            raise KeyError
+        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{plane_to_hv[plane]}acmap"
+
 
 class _PsSegmentMixin(object):
 

--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -8,7 +8,7 @@ import os
 from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import Accelerator
-
+from omc3.model.constants import PLANE_TO_HV
 LOGGER = logging.getLogger(__name__)
 CURRENT_DIR = os.path.dirname(__file__)
 
@@ -39,12 +39,11 @@ class Ps(Accelerator):
     def get_exciter_bpm(self, plane, bpms):
         if not self.excitation:
             return None
-        plane_to_hv = dict(X="h", Y="v")
         bpms_to_find = ["PR.BPM00", "PR.BPM03"]
         found_bpms = [bpm for bpm in bpms_to_find if bpm in bpms]
         if not len(found_bpms):
             raise KeyError
-        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{plane_to_hv[plane]}acmap"
+        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{PLANE_TO_HV[plane]}ACMAP"
 
 
 class _PsSegmentMixin(object):

--- a/omc3/model/accelerators/psbooster.py
+++ b/omc3/model/accelerators/psbooster.py
@@ -9,7 +9,7 @@ from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import (Accelerator,
                                                  AcceleratorDefinitionError)
-
+from omc3.model.constants import PLANE_TO_HV
 LOGGER = logging.getLogger(__name__)
 CURRENT_DIR = os.path.dirname(__file__)
 
@@ -57,12 +57,11 @@ class Psbooster(Accelerator):
     def get_exciter_bpm(self, plane, bpms):
         if not self.excitation:
             return None
-        plane_to_hv = dict(X="h", Y="v")
         bpms_to_find = [f"BR{self.ring}.BPM3L3", f"BR{self.ring}.BPM4L3"]
         found_bpms = [bpm for bpm in bpms_to_find if bpm in bpms]
         if not len(found_bpms):
             raise KeyError
-        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{plane_to_hv[plane]}acmap"
+        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{PLANE_TO_HV[plane]}ACMAP"
 
 
 class _PsboosterSegmentMixin(object):

--- a/omc3/model/accelerators/psbooster.py
+++ b/omc3/model/accelerators/psbooster.py
@@ -54,6 +54,16 @@ class Psbooster(Accelerator):
     def get_file(cls, filename):
         return os.path.join(CURRENT_DIR, cls.NAME, filename)
 
+    def get_exciter_bpm(self, plane, bpms):
+        if not self.excitation:
+            return None
+        plane_to_hv = dict(X="h", Y="v")
+        bpms_to_find = [f"BR{self.ring}.BPM3L3", f"BR{self.ring}.BPM4L3"]
+        found_bpms = [bpm for bpm in bpms_to_find if bpm in bpms]
+        if not len(found_bpms):
+            raise KeyError
+        return (list(bpms).index(found_bpms[0]), found_bpms[0]), f"{plane_to_hv[plane]}acmap"
+
 
 class _PsboosterSegmentMixin(object):
 

--- a/omc3/model/constants.py
+++ b/omc3/model/constants.py
@@ -15,3 +15,4 @@ LHC_MACROS = "lhc.macros.madx"
 
 B2_SETTINGS_MADX = "b2_settings.madx"
 B2_ERRORS_TFS = "b2_errors.tfs"
+PLANE_TO_HV = dict(X="H", Y="V")

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -7,9 +7,10 @@ from omc3.utils import iotools
 
 BASE_OUTPUT = abspath(join(dirname(__file__), pardir, "model"))
 COMP_MODEL = join(dirname(__file__), pardir, "inputs", "models", "25cm_beam1")
+PS_MODEL = join(dirname(__file__), pardir, pardir, "omc3", "model", "accelerators", "ps", "2018", "strength")
 
 
-def _create_input():
+def _create_input_lhc():
     iotools.create_dirs(BASE_OUTPUT)
     iotools.copy_item(join(COMP_MODEL, "opticsfile.24_ctpps2"), join(BASE_OUTPUT, "strengths.madx"))
     iotools.write_string_into_new_file(join(BASE_OUTPUT, MODIFIERS_MADX),
@@ -18,8 +19,42 @@ def _create_input():
     iotools.write_string_into_new_file(join(BASE_OUTPUT, "extracted_mqts.str"), "\n")
 
 
+def _create_input_ps():
+    iotools.create_dirs(BASE_OUTPUT)
+    iotools.copy_item(join(PS_MODEL, "elements.str"), join(BASE_OUTPUT, "elements.str"))
+    iotools.copy_item(join(PS_MODEL, "PS_LE_LHC_low_chroma.str"), join(BASE_OUTPUT, "strengths.madx"))
+    iotools.write_string_into_new_file(join(BASE_OUTPUT, MODIFIERS_MADX),
+                                       f"call, file='{join(BASE_OUTPUT, 'elements.str')}';\n"
+                                       f"call, file='{join(BASE_OUTPUT, 'strengths.madx')}';\n")
+
+
+def test_booster_creation_nominal():
+    iotools.create_dirs(BASE_OUTPUT)
+    iotools.write_string_into_new_file(join(BASE_OUTPUT, MODIFIERS_MADX), "\n")
+    opt_dict = dict(type="nominal", accel="psbooster", ring=1,
+                    nat_tunes=[4.21, 4.27], drv_tunes=[0.205, 0.274], driven_excitation="acd",
+                    dpp=0.0, energy=0.16, modifiers=join(BASE_OUTPUT, MODIFIERS_MADX),
+                    fullresponse=True, outputdir=BASE_OUTPUT,
+                    writeto=join(BASE_OUTPUT, "job.twiss.madx"),
+                    logfile=join(BASE_OUTPUT, "madx_log.txt"))
+    create_instance_and_model(opt_dict)
+    _clean_up(BASE_OUTPUT)
+
+
+def test_ps_creation_nominal():
+    _create_input_ps()
+    opt_dict = dict(type="nominal", accel="ps", nat_tunes=[6.32, 6.29], drv_tunes=[0.325, 0.284],
+                    driven_excitation="acd",
+                    dpp=0.0, energy=1.4, modifiers=join(BASE_OUTPUT, MODIFIERS_MADX),
+                    fullresponse=True, outputdir=BASE_OUTPUT,
+                    writeto=join(BASE_OUTPUT, "job.twiss.madx"),
+                    logfile=join(BASE_OUTPUT, "madx_log.txt"))
+    create_instance_and_model(opt_dict)
+    _clean_up(BASE_OUTPUT)
+
+
 def test_lhc_creation_nominal():
-    _create_input()
+    _create_input_lhc()
     opt_dict = dict(type="nominal", accel="lhc", year="2018", ats=True, beam=1,
                     nat_tunes=[0.31, 0.32], drv_tunes=[0.298, 0.335], driven_excitation="acd",
                     dpp=0.0, energy=6.5, modifiers=join(BASE_OUTPUT, MODIFIERS_MADX),
@@ -31,7 +66,7 @@ def test_lhc_creation_nominal():
 
 
 def test_lhc_creation_best_knowledge():
-    _create_input()
+    _create_input_lhc()
     opt_dict = dict(type="best_knowledge", accel="lhc", year="2018", ats=True, beam=1,
                     nat_tunes=[0.31, 0.32], dpp=0.0, energy=6.5,
                     modifiers=join(BASE_OUTPUT, MODIFIERS_MADX), outputdir=BASE_OUTPUT,


### PR DESCRIPTION
Added exciter BPMs (closest to AC-dipoles) for PS and PSBooster - fixes #156 
Added simple model creation tests for PS and PSBooster
   model creation test reflect what is the needed pre-processing (i.e. modifiers.madx file)
Changed the classmethods in LHC acelerator class - fixes #159 
