### PR TITLE
Requirement Printer

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -1,0 +1,84 @@
+"""
+Requirement Printer
+"""
+import argparse
+from contextlib import suppress
+
+from setup import ALL_DEPENDENCIES
+
+KEYMAP = {'install': 'install_requires',
+          'test': 'tests_require',
+          'setup': 'setup_requires'}
+
+
+def print_requirements():
+    """
+    Prints the requirements for this package.
+
+    Use either 'install', 'test', 'setup' (if present in setup.py)
+    or one of the keys in 'extras_require'.
+    If no key is given ALL dependencies are printed.
+
+    """
+    keys = _parse_args()
+    _check_keys(keys)
+
+    if len(keys) == 0:
+        keys = _get_all_dependency_keys()
+
+    dependencies = []
+    for k in keys:
+        dependencies += _get_dependencies(k)
+    _print(dependencies)
+
+
+# Helper -----------------------------------------------------------------------
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description='Print arguments for this package'
+    )
+    parser.add_argument('keys',
+                        type=str, nargs='*', default=[],
+                        metavar="KEY",
+                        help="The requirements you want.")
+    return parser.parse_args().keys
+
+
+def _get_all_dependency_keys():
+    """ Returns a list of all usable dependency keys for this package."""
+    deps = [k for k, v in KEYMAP.items() if v in ALL_DEPENDENCIES]
+    deps += ALL_DEPENDENCIES.get('extras_require', [])
+    return deps
+
+
+def _get_dependencies(key):
+    """ Return the dependencies for that key. """
+    with suppress(KeyError):
+        return ALL_DEPENDENCIES[KEYMAP[key]]
+
+    with suppress(KeyError):
+        return ALL_DEPENDENCIES['extras_require'][key]
+
+    raise KeyError(f"'{key}' does not have requirements in this package.")
+
+
+def _check_keys(keys):
+    """ Check if the keys given are valid. """
+    unknown_reqs = [k for k in keys if k not in _get_all_dependency_keys()]
+    if unknown_reqs:
+        raise KeyError(f"The keys {unknown_reqs} do not have requirements "
+                       "in this package.")
+
+
+def _print(_list):
+    """ Print a unique and alphabetically sorted list."""
+    print("\n".join(sorted(set(_list))))
+
+
+# __main__ ---------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    print_requirements()

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import setuptools
 from setuptools.command.test import test as TestCommand
 
 
+# Additional Commands ----------------------------------------------------------
+
 class PyTest(TestCommand):
     """ Allows passing commandline arguments to pytest. """
     user_options = [('pytest-args=', 'a', "Arguments to pass into pytest")]
@@ -24,6 +26,7 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args.split())
         sys.exit(errno)
 
+# Meta-Data --------------------------------------------------------------------
 
 # The directory containing this file
 TOPLEVEL_DIR = pathlib.Path(__file__).parent.absolute()
@@ -37,6 +40,8 @@ with ABOUT_FILE.open("r") as f:
 
 with README.open("r") as docs:
     long_description = docs.read()
+
+# Dependencies -----------------------------------------------------------------
 
 # Dependencies for the package itself
 DEPENDENCIES = [
@@ -62,39 +67,46 @@ TEST_DEPENDENCIES = [
 ]
 
 # pytest-runner to be able to run pytest via setuptools
-SETUP_REQUIRES = ["pytest-runner"]
+SETUP_DEPENDENCIES = ["pytest-runner"]
 
 # Extra dependencies for tools
 EXTRA_DEPENDENCIES = {"doc": ["sphinx", "travis-sphinx", "sphinx_rtd_theme"]}
 
-
-setuptools.setup(
-    name=ABOUT_OMC3["__title__"],
-    version=ABOUT_OMC3["__version__"],
-    description=ABOUT_OMC3["__description__"],
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author=ABOUT_OMC3["__author__"],
-    author_email=ABOUT_OMC3["__author_email__"],
-    url=ABOUT_OMC3["__url__"],
-    packages=setuptools.find_packages(exclude=["tests*", "doc"]),
-    python_requires=">=3.6",
-    license=ABOUT_OMC3["__license__"],
-    cmdclass={'pytest': PyTest},  # pass test arguments
-    classifiers=[
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Natural Language :: English",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Topic :: Scientific/Engineering :: Visualization",
-    ],
+# Gather as if you would in setup()
+ALL_DEPENDENCIES = dict(
     install_requires=DEPENDENCIES,
     tests_require=DEPENDENCIES + TEST_DEPENDENCIES,
     extras_require=EXTRA_DEPENDENCIES,
-    setup_requires=SETUP_REQUIRES,
+    setup_requires=SETUP_DEPENDENCIES,
 )
+
+# __main __ --------------------------------------------------------------------
+
+if __name__ == '__main__':
+    setuptools.setup(
+        name=ABOUT_OMC3["__title__"],
+        version=ABOUT_OMC3["__version__"],
+        description=ABOUT_OMC3["__description__"],
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        author=ABOUT_OMC3["__author__"],
+        author_email=ABOUT_OMC3["__author_email__"],
+        url=ABOUT_OMC3["__url__"],
+        packages=setuptools.find_packages(exclude=["tests*", "doc"]),
+        python_requires=">=3.6",
+        license=ABOUT_OMC3["__license__"],
+        cmdclass={'pytest': PyTest},  # pass test arguments
+        classifiers=[
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+            "Natural Language :: English",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Topic :: Scientific/Engineering :: Physics",
+            "Topic :: Scientific/Engineering :: Visualization",
+        ],
+        **ALL_DEPENDENCIES,
+    )


### PR DESCRIPTION
I had to make a new script for that, as adding commands in to setup.py, as envisioned in #181 was not possible (e.g. 
`setup.py requirements install` also runs install,  
`setup.py requirements --install` needs an argument for `--install`).

Please comment!

Usecase:

```
python requirements.py install > reqs.txt
python -m pip install -r reqs.txt
``` 