### PR TITLE
#181 Easier dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,37 @@ Coding style guide is found [here](https://twiki.cern.ch/twiki/bin/view/BEABP/Py
 - [Beta-Beat Source](https://github.com/pylhc/Beta-Beat.src)
 - [optics functions](https://github.com/pylhc/optics_functions)
 
+## Hints for Developers
+
+### Install in Editable Mode
+
+In case you want to install `omc3` as a development package
+from the current folder, you can use:
+
+```
+git clone https://github.com/pylhc/omc3
+pip install --editable omc3
+```
+
+This installs the package as a link into the python environment and any changes 
+are reflected immediately, without the need to reinstall.
+
+#### Dependencies
+```
+pip install --editable omc3
+```
+will also install the required dependencies. 
+
+If you want to install more dependencies, you can use for example:
+```
+pip install --editable omc3[test]
+pip install --editable omc3[setup]
+pip install --editable omc3[test,doc]
+pip install --editable omc3[all]
+```
+ where the last one installs **all** dependencies defined in `setup.py`.
+ 
+ Note that the default dependencies and omc3-as-link are also always installed.
 
 ## Authors
 

--- a/setup.py
+++ b/setup.py
@@ -48,17 +48,17 @@ with README.open("r") as docs:
 
 # Dependencies for the package itself
 DEPENDENCIES = [
-    "matplotlib==3.2.*",
-    "Pillow>=6.0.0",  # not our dependency but older versions crash with mpl
-    "numpy>=1.14.1",
+    "matplotlib>=3.2.0",
+    "Pillow>=6.2.2",  # not our dependency but older versions crash with mpl
+    "numpy>=1.18.0",
     "pandas==0.25.*",
-    "scipy>=1.0.0",
-    "scikit-learn>=0.20.3",
+    "scipy>=1.4.0",
+    "scikit-learn>=0.22.0",
     "tfs-pandas>=1.0.3",
     "generic-parser>=1.0.6",
     "sdds>=0.1.3",
     "pytz>=2018.9",
-    "h5py>=2.7.0",
+    "h5py>=2.9.0",
     "pytimber>=2.8.0",
 ]
 
@@ -69,8 +69,8 @@ EXTRA_DEPENDENCIES = {
     ],
     "test": [
         "pytest>=5.2",
-        "pytest-cov>=2.6",
-        "hypothesis>=3.23.0",
+        "pytest-cov>=2.7",
+        "hypothesis>=5.0.0",
         "attrs>=19.2.0",
     ],
     "doc": [

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ with README.open("r") as docs:
 
 # Dependencies for the package itself
 DEPENDENCIES = [
-    "matplotlib>=3.1.0",
-    "pillow>=6.0.0",  # not our dependency but older versions crash with mpl
+    "matplotlib==3.2.*",
+    "Pillow>=6.0.0",  # not our dependency but older versions crash with mpl
     "numpy>=1.14.1",
     "pandas==0.25.*",
     "scipy>=1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import pathlib
+import shlex
 import sys
 
 import setuptools
@@ -6,7 +7,13 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
-    """ Allows passing commandline arguments to pytest. """
+    """ Allows passing commandline arguments to pytest.
+
+        e.g. `python setup.py test -a='-o python_classes=BasicTests'`
+        or   `python setup.py pytest -a '-o python_classes="BasicTests ExtendedTests"'
+        or   `python setup.py test --pytest-args='--collect-only'`
+
+    """
     user_options = [('pytest-args=', 'a', "Arguments to pass into pytest")]
 
     def initialize_options(self):
@@ -21,7 +28,8 @@ class PyTest(TestCommand):
     def run_tests(self):
         import pytest
 
-        errno = pytest.main(self.pytest_args.split())
+        # shlex.split() preserves quotes
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
 
@@ -40,7 +48,8 @@ with README.open("r") as docs:
 
 # Dependencies for the package itself
 DEPENDENCIES = [
-    "matplotlib>=3.1.0",
+    "matplotlib==3.1.0",
+    "pillow>=7.0.0",  # not our dependency but older versions crash with mpl
     "numpy>=1.14.1",
     "pandas==0.25.*",
     "scipy>=1.0.0",
@@ -53,19 +62,26 @@ DEPENDENCIES = [
     "pytimber>=2.8.0",
 ]
 
-# Dependencies that should only be installed for test purposes
-TEST_DEPENDENCIES = [
-    "pytest>=5.2",
-    "pytest-cov>=2.6",
-    "hypothesis>=3.23.0",
-    "attrs>=19.2.0",
-]
-
-# pytest-runner to be able to run pytest via setuptools
-SETUP_REQUIRES = ["pytest-runner"]
-
-# Extra dependencies for tools
-EXTRA_DEPENDENCIES = {"doc": ["sphinx", "travis-sphinx", "sphinx_rtd_theme"]}
+# Extra dependencies
+EXTRA_DEPENDENCIES = {
+    "setup": [
+        "pytest-runner"
+    ],
+    "test": [
+        "pytest>=5.2",
+        "pytest-cov>=2.6",
+        "hypothesis>=3.23.0",
+        "attrs>=19.2.0",
+    ],
+    "doc": [
+        "sphinx",
+        "travis-sphinx",
+        "sphinx_rtd_theme"
+    ],
+}
+EXTRA_DEPENDENCIES.update(
+    {'all': [elem for list_ in EXTRA_DEPENDENCIES.values() for elem in list_]}
+)
 
 
 setuptools.setup(
@@ -94,7 +110,7 @@ setuptools.setup(
         "Topic :: Scientific/Engineering :: Visualization",
     ],
     install_requires=DEPENDENCIES,
-    tests_require=DEPENDENCIES + TEST_DEPENDENCIES,
+    tests_require=EXTRA_DEPENDENCIES['test'],
+    setup_requires=EXTRA_DEPENDENCIES['setup'],
     extras_require=EXTRA_DEPENDENCIES,
-    setup_requires=SETUP_REQUIRES,
 )

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ with README.open("r") as docs:
 
 # Dependencies for the package itself
 DEPENDENCIES = [
-    "matplotlib==3.1.0",
-    "pillow>=7.0.0",  # not our dependency but older versions crash with mpl
+    "matplotlib>=3.1.0",
+    "pillow>=6.0.0",  # not our dependency but older versions crash with mpl
     "numpy>=1.14.1",
     "pandas==0.25.*",
     "scipy>=1.0.0",


### PR DESCRIPTION
* Changed dependency layout
* added 'all'
* some pytest-args examples

Controversial:
* added pillow-requirement as old version kept crashing with matplotlib (https://github.com/matplotlib/matplotlib/issues/14263 )