### PR TITLE
Fix set-env use

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,16 +53,16 @@ jobs:
 
       - name: Set up env for CodeClimate (push)
         run: |
-          echo "::set-env name=GIT_BRANCH::$GITHUB_REF"
-          echo "::set-env name=GIT_COMMIT_SHA::$GITHUB_SHA"
+          echo "GIT_BRANCH=$GITHUB_REF" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
         if: github.event_name == 'push'
 
       - name: Set up env for CodeClimate (pull_request)
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "::set-env name=GIT_BRANCH::$GITHUB_HEAD_REF"
-          echo "::set-env name=GIT_COMMIT_SHA::$PR_HEAD_SHA"
+          echo "GIT_BRANCH=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$PR_HEAD_SHA" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
 
       - name: Prepare CodeClimate binary

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload documentation to gh-pages
         if: ${{ success() }}
-        uses: JamesIves/github-pages-deploy-action@3.6.1
+        uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Should fix the `set-env` use in the `coverage` workflow.
Hopefully fix the warning in the `documentation` workflow by updating the used version of the `github-pages-deploy-action`.

Need to open this PR to trigger the first one.