### PR TITLE
Tech dependency for pytimber

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install --editable omc3
 
 You can install extra dependencies (as defined in `setup.py`) suited to your use case with the following commands:
 ```
-pip install --editable omc3[tech]
+pip install --editable omc3[tech]  # requires to be inside the CERN network
 pip install --editable omc3[test]
 pip install --editable omc3[test,doc]
 pip install --editable omc3[all]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pip install --editable omc3
 
 You can install extra dependencies (as defined in `setup.py`) suited to your use case with the following commands:
 ```
+pip install --editable omc3[tech]
 pip install --editable omc3[test]
 pip install --editable omc3[test,doc]
 pip install --editable omc3[all]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install --editable omc3
 
 You can install extra dependencies (as defined in `setup.py`) suited to your use case with the following commands:
 ```
-pip install --editable omc3[tech]  # requires to be inside the CERN network
+pip install --editable omc3[cern]  # requires to be inside the CERN network
 pip install --editable omc3[test]
 pip install --editable omc3[test,doc]
 pip install --editable omc3[all]

--- a/doc/modules/utils.rst
+++ b/doc/modules/utils.rst
@@ -14,6 +14,10 @@ Utils
     :members:
 
 
+.. automodule:: omc3.utils.mock
+    :members:
+
+
 .. automodule:: omc3.utils.outliers
     :members:
 

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -31,9 +31,9 @@ the measurements.
 
   Choices: ``['cut', 'minmax', 'outliers']``
   Default: ``outliers``
-- **bbq_in**: Fill number of desired data to extract from ``Timber`` (requires the [tech] extra and access to
-  the CERN network) or path to presaved bbq-tfs-file. Use the string 'kick' to use the timestamps
-  in the kickfile for timber extraction. Not giving this parameter skips bbq compensation.
+- **bbq_in**: Fill number of desired data to extract from ``Timber`` (requires installing with the [tech]
+  extra and access to the CERN network) or path to presaved bbq-tfs-file. Use the string 'kick' to use the
+  timestamps in the kickfile for timber extraction. Not giving this parameter skips bbq compensation.
 
 - **debug**: Activates Debug mode
 

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -318,20 +318,21 @@ def _check_analyse_opt(opt):
 
 def _get_bbq_data(beam, input_, kick_df):
     """Return BBQ data from input, either file or timber fill."""
-    if not timber_extract:
-        LOG.error("The pytimber package does not seem to be installed but is needed for this function. "
-                  "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
-                  "technical network.")
-        raise ImportError("The pytimber package is needed for this operation but can't be found.")
     try:
         fill_number = int(input_)
     except ValueError:
         # input is a string
         if input_ == "kick":
+            if not timber_extract:
+                LOG.error(
+                    "The pytimber package does not seem to be installed but is needed for this function. "
+                    "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
+                    "technical network.")
+                raise ImportError("The pytimber package is needed for this operation but can't be found.")
             LOG.debug("Getting timber data from kick-times.")
             timber_keys, bbq_cols = _get_timber_keys_and_bbq_columns(beam)
-            t_start = min(kick_df.index.values)
-            t_end = max(kick_df.index.values)
+            t_start = min(kick_df.index.to_numpy())
+            t_end = max(kick_df.index.to_numpy())
             data = timber_extract.extract_between_times(t_start-DTIME, t_end+DTIME,
                                                         keys=timber_keys,
                                                         names=dict(zip(timber_keys, bbq_cols)))
@@ -344,6 +345,11 @@ def _get_bbq_data(beam, input_, kick_df):
     else:
         # input is a number
         LOG.debug(f"Getting timber data from fill '{input_:d}'")
+        if not timber_extract:
+            LOG.error("The pytimber package does not seem to be installed but is needed for this function. "
+                      "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
+                      "technical network.")
+            raise ImportError("The pytimber package is needed for this operation but can't be found.")
         timber_keys, bbq_cols = _get_timber_keys_and_bbq_columns(beam)
         data = timber_extract.lhc_fill_to_tfs(fill_number,
                                               keys=timber_keys,

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -31,7 +31,7 @@ the measurements.
 
   Choices: ``['cut', 'minmax', 'outliers']``
   Default: ``outliers``
-- **bbq_in**: Fill number of desired data to extract from ``Timber`` (requires installing with the [tech]
+- **bbq_in**: Fill number of desired data to extract from ``Timber`` (requires installing with the [cern]
   extra and access to the CERN network) or path to presaved bbq-tfs-file. Use the string 'kick' to use the
   timestamps in the kickfile for timber extraction. Not giving this parameter skips bbq compensation.
 

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -72,7 +72,7 @@ from generic_parser.entrypoint_parser import entrypoint, EntryPointParameters, s
 
 from omc3.definitions import formats
 from omc3.definitions.constants import PLANES
-from omc3.tune_analysis import timber_extract, fitting_tools, kick_file_modifiers
+from omc3.tune_analysis import fitting_tools, kick_file_modifiers
 from omc3.tune_analysis.constants import (get_kick_out_name, get_bbq_out_name,
                                           get_mav_col, get_timber_bbq_key,
                                           get_bbq_col)
@@ -81,6 +81,11 @@ from omc3.tune_analysis.kick_file_modifiers import (read_timed_dataframe,
                                                     read_two_kick_files_from_folder
                                                     )
 from omc3.utils.logging_tools import get_logger, list2str, DebugMode
+
+try:
+    from omc3.tune_analysis import timber_extract
+except ImportError:
+    timber_extract = None
 
 # Globals ----------------------------------------------------------------------
 
@@ -313,6 +318,11 @@ def _check_analyse_opt(opt):
 
 def _get_bbq_data(beam, input_, kick_df):
     """Return BBQ data from input, either file or timber fill."""
+    if not timber_extract:
+        LOG.error("The pytimber package does not seem to be installed but is needed for this function. "
+                  "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
+                  "technical network.")
+        raise ImportError("The pytimber package is needed for this operation but can't be found.")
     try:
         fill_number = int(input_)
     except ValueError:

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -72,7 +72,7 @@ from generic_parser.entrypoint_parser import entrypoint, EntryPointParameters, s
 
 from omc3.definitions import formats
 from omc3.definitions.constants import PLANES
-from omc3.tune_analysis import fitting_tools, kick_file_modifiers
+from omc3.tune_analysis import timber_extract, fitting_tools, kick_file_modifiers
 from omc3.tune_analysis.constants import (get_kick_out_name, get_bbq_out_name,
                                           get_mav_col, get_timber_bbq_key,
                                           get_bbq_col)
@@ -82,10 +82,6 @@ from omc3.tune_analysis.kick_file_modifiers import (read_timed_dataframe,
                                                     )
 from omc3.utils.logging_tools import get_logger, list2str, DebugMode
 
-try:
-    from omc3.tune_analysis import timber_extract
-except ImportError:
-    timber_extract = None
 
 # Globals ----------------------------------------------------------------------
 
@@ -323,12 +319,6 @@ def _get_bbq_data(beam, input_, kick_df):
     except ValueError:
         # input is a string
         if input_ == "kick":
-            if not timber_extract:
-                LOG.error(
-                    "The pytimber package does not seem to be installed but is needed for this function. "
-                    "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
-                    "technical network.")
-                raise ImportError("The pytimber package is needed for this operation but can't be found.")
             LOG.debug("Getting timber data from kick-times.")
             timber_keys, bbq_cols = _get_timber_keys_and_bbq_columns(beam)
             t_start = min(kick_df.index.to_numpy())
@@ -345,11 +335,6 @@ def _get_bbq_data(beam, input_, kick_df):
     else:
         # input is a number
         LOG.debug(f"Getting timber data from fill '{input_:d}'")
-        if not timber_extract:
-            LOG.error("The pytimber package does not seem to be installed but is needed for this function. "
-                      "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
-                      "technical network.")
-            raise ImportError("The pytimber package is needed for this operation but can't be found.")
         timber_keys, bbq_cols = _get_timber_keys_and_bbq_columns(beam)
         data = timber_extract.lhc_fill_to_tfs(fill_number,
                                               keys=timber_keys,

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -31,8 +31,8 @@ the measurements.
 
   Choices: ``['cut', 'minmax', 'outliers']``
   Default: ``outliers``
-- **bbq_in**: Fill number of desired data to extract from timber
-  or path to presaved bbq-tfs-file. Use the string 'kick' to use the timestamps
+- **bbq_in**: Fill number of desired data to extract from ``Timber`` (requires the [tech] extra and access to
+  the CERN network) or path to presaved bbq-tfs-file. Use the string 'kick' to use the timestamps
   in the kickfile for timber extraction. Not giving this parameter skips bbq compensation.
 
 - **debug**: Activates Debug mode

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -2,15 +2,13 @@
 Timber Extraction
 -----------------
 
-Tools to extract data from ``Timber``.
+Tools to extract data from ``Timber``. It is a bit heavy on the LHC side at the moment.
 
-Please note: this module requires the ``pytimber`` package to access ``Timber`` functionality,
+**Please note**: this module requires the ``pytimber`` package to access ``Timber`` functionality,
 both of which are only possible from inside the CERN network.
 
-To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the `tech` extra
-dependency (`pip install omc3[tech]`).
-
-It is a bit heavy on the LHC side at the moment.
+To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the [tech] extra
+dependency (``pip install omc3[tech]``).
 """
 import re
 

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -4,6 +4,12 @@ Timber Extraction
 
 Tools to extract data from ``Timber``.
 
+Please note: this module requires the ``pytimber`` package to access ``Timber`` functionality,
+both of which are only possible from inside the CERN network.
+
+To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the `tech` extra
+dependency (`pip install omc3[tech]`).
+
 It is a bit heavy on the LHC side at the moment.
 """
 import re

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -24,7 +24,7 @@ END_TIME = const.get_tend_head()
 LOG = logging_tools.get_logger(__name__)
 
 
-def lhc_fill_to_tfs(fill_number, keys=None, names=None):
+def lhc_fill_to_tfs(fill_number, keys=None, names=None) -> tfs.TfsDataFrame:
     """
     Extracts data for keys of fill from ``Timber``.
 
@@ -35,13 +35,13 @@ def lhc_fill_to_tfs(fill_number, keys=None, names=None):
 
     Returns: tfs pandas dataframe.
     """
-    db = pytimber.LoggingDB()
+    db = pytimber.LoggingDB(source="nxcals")
     t_start, t_end = get_fill_times(db, fill_number)
     out_df = extract_between_times(t_start, t_end, keys, names)
     return out_df
 
 
-def extract_between_times(t_start, t_end, keys=None, names=None):
+def extract_between_times(t_start, t_end, keys=None, names=None) -> tfs.TfsDataFrame:
     """
     Extracts data for keys between t_start and t_end from timber.
 
@@ -53,7 +53,7 @@ def extract_between_times(t_start, t_end, keys=None, names=None):
 
     Returns: tfs pandas dataframe.
     """
-    db = pytimber.LoggingDB()
+    db = pytimber.LoggingDB(source="nxcals")
     if keys is None:
         keys = get_tune_and_coupling_variables(db)
 
@@ -77,7 +77,7 @@ def extract_between_times(t_start, t_end, keys=None, names=None):
     return out_df
 
 
-def get_tune_and_coupling_variables(db):
+def get_tune_and_coupling_variables(db: pytimber.LoggingDB) -> list:
     """
     Returns the tune and coupling variable names.
 
@@ -96,7 +96,7 @@ def get_tune_and_coupling_variables(db):
     return bbq_vars
 
 
-def get_fill_times(db, fill_number):
+def get_fill_times(db: pytimber.LoggingDB, fill_number: int) -> tuple:
     """
     Returns start and end time of fill with fill number.
 

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -8,7 +8,9 @@ Tools to extract data from ``Timber``. It is a bit heavy on the LHC side at the 
 both of which are only possible from inside the CERN network.
 
 To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the [tech] extra
-dependency (``pip install omc3[tech]``).
+dependency and installing from the ``acc-py`` package index (by specifying ``--index-url
+https://acc-py-repo.cern.ch/repository/vr-py-releases/simple`` and
+``--trusted-host acc-py-repo.cern.ch`` to your ``pip`` installation command).
 """
 import re
 

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -15,19 +15,31 @@ https://acc-py-repo.cern.ch/repository/vr-py-releases/simple`` and
 import re
 
 import numpy as np
-import pytimber
 import tfs
 
 from omc3.tune_analysis import constants as const
 from omc3.utils import logging_tools
 from omc3.utils.time_tools import CERNDatetime
 
+
 TIME_COL = const.get_time_col()
 START_TIME = const.get_tstart_head()
 END_TIME = const.get_tend_head()
 
-
 LOG = logging_tools.get_logger(__name__)
+
+try:
+    import pytimber
+except ImportError:
+    class MockPytimber:
+        """Mock class to raise if pytimber functionality is called when the package is not installed."""
+        def __getattr__(self, *args, **kwargs):
+            LOG.error(
+                "The pytimber package does not seem to be installed but is needed for this function. "
+                "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
+                "technical network and install from the acc-py package index. See module documentation.")
+            raise ImportError("The pytimber package is needed for this operation but can't be found.")
+    pytimber = MockPytimber()
 
 
 def lhc_fill_to_tfs(fill_number, keys=None, names=None) -> tfs.TfsDataFrame:
@@ -83,12 +95,12 @@ def extract_between_times(t_start, t_end, keys=None, names=None) -> tfs.TfsDataF
     return out_df
 
 
-def get_tune_and_coupling_variables(db: pytimber.LoggingDB) -> list:
+def get_tune_and_coupling_variables(db) -> list:
     """
     Returns the tune and coupling variable names.
 
     Args:
-        db: pytimber database.
+        db (pytimber.LoggingDB): pytimber database.
 
     Returns:
         `list` of variable names.
@@ -102,13 +114,13 @@ def get_tune_and_coupling_variables(db: pytimber.LoggingDB) -> list:
     return bbq_vars
 
 
-def get_fill_times(db: pytimber.LoggingDB, fill_number: int) -> tuple:
+def get_fill_times(db, fill_number: int) -> tuple:
     """
     Returns start and end time of fill with fill number.
 
     Args:
-        db: pytimber database.
-        fill_number: fill number.
+        db (pytimber.LoggingDB): pytimber database.
+        fill_number (int): fill number.
 
     Returns:
        `Tuple` of start and end time.

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -20,26 +20,14 @@ import tfs
 from omc3.tune_analysis import constants as const
 from omc3.utils import logging_tools
 from omc3.utils.time_tools import CERNDatetime
-
+from omc3.utils.mock import cern_network_import
 
 TIME_COL = const.get_time_col()
 START_TIME = const.get_tstart_head()
 END_TIME = const.get_tend_head()
 
 LOG = logging_tools.get_logger(__name__)
-
-try:
-    import pytimber
-except ImportError:
-    class MockPytimber:
-        """Mock class to raise if pytimber functionality is called when the package is not installed."""
-        def __getattr__(self, *args, **kwargs):
-            LOG.error(
-                "The pytimber package does not seem to be installed but is needed for this function. "
-                "Install it with the 'tech' dependency of omc3, which requires to be on the CERN "
-                "technical network and install from the acc-py package index. See module documentation.")
-            raise ImportError("The pytimber package is needed for this operation but can't be found.")
-    pytimber = MockPytimber()
+pytimber = cern_network_import("pytimber")
 
 
 def lhc_fill_to_tfs(fill_number, keys=None, names=None) -> tfs.TfsDataFrame:

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -7,7 +7,7 @@ Tools to extract data from ``Timber``. It is a bit heavy on the LHC side at the 
 **Please note**: this module requires the ``pytimber`` package to access ``Timber`` functionality,
 both of which are only possible from inside the CERN network.
 
-To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the [tech] extra
+To install ``pytimber`` along ``omc3``, please do so from inside the CERN network by using the [cern] extra
 dependency and installing from the ``acc-py`` package index (by specifying ``--index-url
 https://acc-py-repo.cern.ch/repository/vr-py-releases/simple`` and
 ``--trusted-host acc-py-repo.cern.ch`` to your ``pip`` installation command).

--- a/omc3/utils/mock.py
+++ b/omc3/utils/mock.py
@@ -14,11 +14,11 @@ Provides mock functionality for packages necessitating the ``CERN GPN`` and only
 import importlib
 
 
-class TechicalNetworkMockPackage:
+class CERNNetworkMockPackage:
     """
     Mock class to raise an error if the desired package functionality is called when the package is not
     actually installed. Designed for packages installable only from inside the CERN network,
-    that are declared as ``tech`` extras.
+    that are declared as ``cern`` extra. See module documentation.
     """
     def __init__(self, name: str):
         self.name = name
@@ -26,7 +26,7 @@ class TechicalNetworkMockPackage:
     def __getattr__(self, item):
         raise ImportError(
             f"The '{self.name}' package does not seem to be installed but is needed for this function. "
-            "Install it with the 'tech' extra dependency, which requires to be on the CERN network and "
+            "Install it with the 'cern' extra dependency, which requires to be on the CERN network and to "
             "install from the acc-py package index. Refer to the documentation for more information."
         )
 
@@ -43,4 +43,4 @@ def cern_network_import(package: str):
     try:
         return importlib.import_module(package)
     except ImportError:
-        return TechicalNetworkMockPackage(package)
+        return CERNNetworkMockPackage(package)

--- a/omc3/utils/mock.py
+++ b/omc3/utils/mock.py
@@ -1,0 +1,46 @@
+"""
+Mock
+----
+
+Provides mock functionality for packages necessitating the ``CERN GPN`` and only installable from the
+``acc-py`` package index, such as ``pytimber``, ``pjlsa`` etc.
+
+.. code-block:: python
+
+    from omc3.utils.mock import cern_network_import
+    pytimber = cern_network_import("pytimber")
+    db = pytimber.LoggingDB(source="nxcals")  # will raise if pytimber not installed
+"""
+import importlib
+
+
+class TechicalNetworkMockPackage:
+    """
+    Mock class to raise an error if the desired package functionality is called when the package is not
+    actually installed. Designed for packages installable only from inside the CERN network,
+    that are declared as ``tech`` extras.
+    """
+    def __init__(self, name: str):
+        self.name = name
+
+    def __getattr__(self, item):
+        raise ImportError(
+            f"The '{self.name}' package does not seem to be installed but is needed for this function. "
+            "Install it with the 'tech' extra dependency, which requires to be on the CERN network and "
+            "install from the acc-py package index. Refer to the documentation for more information."
+        )
+
+
+def cern_network_import(package: str):
+    """
+    Convenience function to try and import packages only available (and installable) on the CERN network.
+    If installed, the module is returned, otherwise a mock class is returned, which will raise an
+    insightful ``ImportError`` on attempted use.
+
+    Args:
+        package (str): name of the package to try and import.
+    """
+    try:
+        return importlib.import_module(package)
+    except ImportError:
+        return TechicalNetworkMockPackage(package)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,3 @@ testpaths = tests/unit tests/accuracy
 markers=
         basic: basic tests run for every commit
         extended: test run on PRs
-
-[pycodestyle]
-max-line-length = 100
-exclude = doc/conf.py
-
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ DEPENDENCIES = [
 
 # Extra dependencies
 EXTRA_DEPENDENCIES = {
-    "tech": [
+    "cern": [
         "pytimber>=2.8.0",
     ],
     "test": [

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,14 @@ DEPENDENCIES = [
     "generic-parser>=1.0.6",
     "sdds>=0.1.3",
     "h5py>=2.9.0",
-    "pytimber>=2.8.0",
     "uncertainties>=3.1.4",
 ]
 
 # Extra dependencies
 EXTRA_DEPENDENCIES = {
+    "tech": [
+        "pytimber>=2.8.0",
+    ],
     "test": [
         "pytest>=5.2",
         "pytest-cov>=2.7",

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -1,0 +1,19 @@
+import pytest
+import tfs
+
+from omc3.utils.mock import TechicalNetworkMockPackage, cern_network_import
+
+
+class TestCERNNetworkImport:
+    def test_absent_package_gives_mock_class(self):
+        fake_package = cern_network_import("fake_package")
+        assert isinstance(fake_package, TechicalNetworkMockPackage)
+        assert fake_package.name == "fake_package"
+
+        with pytest.raises(ImportError):
+            fake_package.some_function()
+
+    def test_present_package_works(self):
+        tfspandas = cern_network_import("tfs")
+        df = tfspandas.TfsDataFrame()
+        assert isinstance(df, tfs.TfsDataFrame)

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -1,13 +1,13 @@
 import pytest
 import tfs
 
-from omc3.utils.mock import TechicalNetworkMockPackage, cern_network_import
+from omc3.utils.mock import CERNNetworkMockPackage, cern_network_import
 
 
 class TestCERNNetworkImport:
     def test_absent_package_gives_mock_class(self):
         fake_package = cern_network_import("fake_package")
-        assert isinstance(fake_package, TechicalNetworkMockPackage)
+        assert isinstance(fake_package, CERNNetworkMockPackage)
         assert fake_package.name == "fake_package"
 
         with pytest.raises(ImportError):


### PR DESCRIPTION
This is the implementation PR for https://github.com/pylhc/omc3/issues/272

Checklist:
- [x] Check that CI workflows install fine.
- [x] Document the caveat.
- [x] Failsafe the imports of `pytimber` functionality in `omc3` (currently only in `omc3.tune_analysis.timber_extract.py`, which is only imported  in `omc3.amplitude_detuning_analysis.py`).
- [x] Specify `source="nxcals"` when declaring `db = pytimber.LoggingDB()`, since the change from `CALS` to `NXCALS` has been made.

I took the opportunity to remove unsused parts of `setup.py` and do a little bit of type hinting in `omc3.tune_analysis.timber_extract.py`.

I also named the extra `tech` to stay consistent with the naming adopted in `PyLHC`.