### PR TITLE
Fix cache step in workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,16 +32,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -30,16 +30,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,16 +31,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,16 +31,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
         id: pip-cache
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
-9
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,16 +32,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |
@@ -76,16 +79,19 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      - name: Get pip cache dir  # requires pip >= 20.1
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+9
       - name: Set up cache
         uses: actions/cache@v2
         id: cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
 
       - name: Upgrade pip, setuptools and wheel
         run: |


### PR DESCRIPTION
These changes include `pip`'s out-of-directory cache in the github actions caching step, which will speed up the `Install package` step.

Previous implementation was my bad.