### PR TITLE
Removing Ubuntu 16.04 from CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ It runs on `ubuntu-latest` and our lowest supported version, `Python 3.7`.
 
 Tests are ensured in the `tests` workflow, in two stages.
 The first stage runs our simple tests on all push events (except to `master`), and the second one runs the rest of the testing suite (the `extended` tests).
-Tests runs on a matrix of all available operating systems for all supported Python versions (currently `3.7`, `3.8` and `3.9`).
+Tests runs on a matrix of all available and LTS operating systems for all supported Python versions (currently `3.7`, `3.8` and `3.9`).
 
 ### Test Coverage
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ It runs on `ubuntu-latest` and our lowest supported version, `Python 3.7`.
 
 Tests are ensured in the `tests` workflow, in two stages.
 The first stage runs our simple tests on all push events (except to `master`), and the second one runs the rest of the testing suite (the `extended` tests).
-Tests runs on a matrix of all available and LTS operating systems for all supported Python versions (currently `3.7`, `3.8` and `3.9`).
+Tests run on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.7`, `3.8` and `3.9`).
 
 ### Test Coverage
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.x]  # crons should always run latest python hence 3.x
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
As discussed previously, since Ubuntu 16.04 reached end of LTS we will remove it from CI workflows This will please @JoschD :)

I will create similar PRs on other repos when appropriate.

NB: we will need to update the `master` branch protection rules / requirements before merging.