### PR TITLE
Add element dropping option for the tbt_converter

### DIFF
--- a/omc3/tbt/handler.py
+++ b/omc3/tbt/handler.py
@@ -67,7 +67,11 @@ def get_averaged_data(bpm_names, data, plane, turns):
     return np.nanmean(bpm_data, axis=1)
 
 
-def read_tbt(file_path, datatype="lhc"):
+def read_tbt(file_path, datatype="lhc") -> TbtData:
+    """
+    Calls the appropriate loader for the provided data type and returns a TbtData object of the loaded data.
+    """
+    LOGGER.info(f"Loading turn-by-turn data from '{file_path}'")
     return DATA_READERS[datatype].read_tbt(file_path)
 
 

--- a/omc3/tbt_converter.py
+++ b/omc3/tbt_converter.py
@@ -73,11 +73,16 @@ def converter_entrypoint(opt):
       - **noise_levels** *(float)*: Sigma of added Gaussian noise.
 
         Flags: **--noise_levels**
-        Default: None
+        Default: ``None``
       - **use_average** *(bool)*: If set, returned sdds only contains the average over all particle/bunches.
 
         Flags: **--use_average**
-        Default: False
+        Default: ``False``
+
+      - **drop_elements**: Names of elements to drop from the input file during conversion.
+
+        Flags: **--drop_elements**
+        Default: ``None``
     """
     if opt.realizations < 1:
         raise ValueError("Number of realizations lower than 1.")

--- a/omc3/tbt_converter.py
+++ b/omc3/tbt_converter.py
@@ -5,12 +5,12 @@ TbT Converter
 Top-level script to convert turn-by-turn files from various formats to ``LHC`` binary SDDS files.
 Optionally, it can replicate files with added noise.
 """
-from collections import OrderedDict
+import copy
 from datetime import datetime
 from os.path import basename, join
+from typing import Sequence
 
-from generic_parser.entrypoint_parser import (EntryPointParameters, entrypoint,
-                                              save_options_to_config)
+from generic_parser.entrypoint_parser import EntryPointParameters, entrypoint, save_options_to_config
 
 from omc3 import tbt
 from omc3.definitions import formats
@@ -23,17 +23,27 @@ DEFAULT_CONFIG_FILENAME = "converter_{time:s}.ini"
 
 def converter_params():
     params = EntryPointParameters()
-    params.add_parameter(name="files", required=True, nargs='+', help="TbT files to analyse")
+    params.add_parameter(name="files", required=True, nargs="+", help="TbT files to analyse")
     params.add_parameter(name="outputdir", required=True, help="Output directory.")
-    params.add_parameter(name="tbt_datatype", type=str, default="lhc",
-                         choices=list(tbt.handler.DATA_READERS.keys()),
-                         help="Choose the datatype from which to import. ")
-    params.add_parameter(name="realizations", type=int, default=1,
-                         help="Number of copies with added noise")
-    params.add_parameter(name="noise_levels", nargs='+',
-                         help="Sigma of added Gaussian noise")
-    params.add_parameter(name="use_average", action="store_true",
-                         help="If set, returned sdds only contains the average over all particle/bunches.")
+    params.add_parameter(
+        name="tbt_datatype",
+        type=str,
+        default="lhc",
+        choices=list(tbt.handler.DATA_READERS.keys()),
+        help="Choose the datatype from which to import. ",
+    )
+    params.add_parameter(name="realizations", type=int, default=1, help="Number of copies with added noise")
+    params.add_parameter(name="noise_levels", nargs="+", help="Sigma of added Gaussian noise")
+    params.add_parameter(
+        name="use_average",
+        action="store_true",
+        help="If set, returned sdds only contains the average over all particle/bunches.",
+    )
+    params.add_parameter(
+        name="drop_elements",
+        nargs="+",
+        help="Names of elements to drop from the input file during conversion",
+    )
     return params
 
 
@@ -72,14 +82,18 @@ def converter_entrypoint(opt):
     if opt.realizations < 1:
         raise ValueError("Number of realizations lower than 1.")
     iotools.create_dirs(opt.outputdir)
-    save_options_to_config(join(opt.outputdir, DEFAULT_CONFIG_FILENAME.format(
-        time=datetime.utcnow().strftime(formats.TIME))), OrderedDict(sorted(opt.items())))
+    save_options_to_config(
+        join(opt.outputdir, DEFAULT_CONFIG_FILENAME.format(time=datetime.utcnow().strftime(formats.TIME))),
+        dict(sorted(opt.items())),
+    )
     _read_and_write_files(opt)
 
 
 def _read_and_write_files(opt):
     for input_file in opt.files:
         tbt_data = tbt.read_tbt(input_file, datatype=opt.tbt_datatype)
+        if opt.drop_elements:
+            tbt_data = _drop_elements(tbt_data, opt.drop_elements)
         if opt.use_average:
             tbt_data = tbt.handler.generate_average_tbtdata(tbt_data)
         for i in range(opt.realizations):
@@ -88,8 +102,36 @@ def _read_and_write_files(opt):
                 tbt.write(join(opt.outputdir, f"{_file_name(input_file)}{suffix}"), tbt_data=tbt_data)
             else:
                 for noise_level in opt.noise_levels:
-                    tbt.write(join(opt.outputdir, f"{_file_name(input_file)}_n{noise_level}{suffix}"),
-                              tbt_data=tbt_data, noise=float(noise_level))
+                    tbt.write(
+                        join(opt.outputdir, f"{_file_name(input_file)}_n{noise_level}{suffix}"),
+                        tbt_data=tbt_data,
+                        noise=float(noise_level),
+                    )
+
+
+def _drop_elements(tbt_data: tbt.TbtData, elements_to_drop: Sequence[str]) -> tbt.TbtData:
+    """
+    Drops the provided elements from the matrices in the provided TbtData object.
+    For any element not found in the matrices, a warning is logged and the element is skipped.
+
+    Args:
+        tbt_data (tbt.TbtData): a TbTData object from loading your turn-by-turn data from disk.
+        elements_to_drop (Sequence[str]): list of elements to drop.
+
+    Returns:
+        A copied version of the provided TbtData object with the relevant element dropped from the matrices.
+    """
+    copied_data = copy.deepcopy(tbt_data)
+    LOGGER.info(f"Dropping the following unwanted elements: {', '.join(elements_to_drop)}")
+    for element in elements_to_drop:
+        LOGGER.debug(f"Dropping element '{element}'")
+        try:
+            for entry in copied_data.matrices:
+                for dataframe in entry.values():  # X / Y dfs, BPMs as rows & turn coordinates as columns
+                    dataframe.drop(element, inplace=True)
+        except KeyError:
+            LOGGER.warning(f"Element '{element}' could not be found, skipped")
+    return copied_data
 
 
 def _file_name(filename: str):


### PR DESCRIPTION
This is a workaround for #288 
This PR introduces a `--drop_elements` flag to the `tbt_converter`, which will drop said elements in the `TbtData.matrices` after loading.

The only reasons to have elements mismatch like in #288 would be to either have a wrong model, or to have additionnal elements from simulation tracking (see [this comment](https://github.com/pylhc/omc3/issues/288#issuecomment-870646395)). In the second case, this is a valid solution. In any case, it doesn't hurt to have the option in `tbt_converter`.