### PR TITLE
Pathlib for tbt functionality and tests for --drop_elements

### DIFF
--- a/omc3/tbt/handler.py
+++ b/omc3/tbt/handler.py
@@ -73,7 +73,7 @@ def get_averaged_data(bpm_names, data, plane, turns):
     bpm_data.fill(np.nan)
     for idx, bpm in enumerate(bpm_names):
         for i in range(len(data)):
-            bpm_data[idx, i, : len(data[i][plane].loc[bpm])] = data[i][plane].loc[bpm]
+            bpm_data[idx, i, :len(data[i][plane].loc[bpm])] = data[i][plane].loc[bpm]
 
     return np.nanmean(bpm_data, axis=1)
 

--- a/omc3/tbt/handler.py
+++ b/omc3/tbt/handler.py
@@ -8,7 +8,7 @@ functionality for these objects.
 """
 from datetime import datetime
 from pathlib import Path
-from typing import Tuple, Union
+from typing import TextIO, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -126,17 +126,18 @@ def _add_noise(data: np.ndarray, noise: float) -> np.ndarray:
     return data + noise * np.random.standard_normal(data.shape)
 
 
-def write_lhc_ascii(output_path, tbt_data):
-    LOGGER.info('TbTdata is written in ascii SDDS (LHC) format')
+def write_lhc_ascii(output_path: Union[str, Path], tbt_data: TbtData) -> None:
+    output_path = Path(output_path)
+    LOGGER.info(f"Writing TbTdata in ASCII SDDS (LHC) format at '{output_path.absolute()}'")
 
     for index in range(tbt_data.nbunches):
         suffix = f"_{tbt_data.bunch_ids[index]}" if tbt_data.nbunches > 1 else ""
-        with open(output_path + suffix, "w") as output_file:
+        with output_path.with_suffix(suffix).open("w") as output_file:
             _write_header(tbt_data, index, output_file)
             _write_tbt_data(tbt_data, index, output_file)
 
 
-def _write_header(tbt_data, index, output_file):
+def _write_header(tbt_data: TbtData, index: int, output_file: TextIO) -> None:
     output_file.write("#SDDSASCIIFORMAT v1\n")
     output_file.write(f"#Created: {datetime.now().strftime('%Y-%m-%d at %H:%M:%S')} "
                       f"By: Python SDDS converter\n")
@@ -147,7 +148,7 @@ def _write_header(tbt_data, index, output_file):
     output_file.write(f"#Acquisition date: {tbt_data.date.strftime('%Y-%m-%d at %H:%M:%S')}\n")
 
 
-def _write_tbt_data(tbt_data, bunch_id, output_file):
+def _write_tbt_data(tbt_data: TbtData, bunch_id: int, output_file: TextIO) -> None:
     row_format = "{} {} {}  " + FORMAT_STRING * tbt_data.nturns + "\n"
     for plane in PLANES:
         for bpm_index, bpm_name in enumerate(tbt_data.matrices[bunch_id][plane].index):

--- a/omc3/tbt/reader_esrf.py
+++ b/omc3/tbt/reader_esrf.py
@@ -48,6 +48,7 @@ def load_esrf_mat_file(infile: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray
     if hor.shape != ver.shape:
         raise ValueError("Number of turns, BPMs or measurements in X and Y do not match")
     # TODO change for tfs file got from accelerator class
+    # Need input for someone with ESRF files experience, where exactly should we look for this file?
     bpm_names = json.loads((Path(infile).parent / BPM_NAMES_FILE).read_text())  # weird?
     if hor.shape[1] != len(bpm_names):
         raise ValueError("Number of bpms does not match with accelerator class")

--- a/omc3/tbt/reader_esrf.py
+++ b/omc3/tbt/reader_esrf.py
@@ -48,7 +48,7 @@ def load_esrf_mat_file(infile: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray
     if hor.shape != ver.shape:
         raise ValueError("Number of turns, BPMs or measurements in X and Y do not match")
     # TODO change for tfs file got from accelerator class
-    bpm_names = json.load((Path(__file__).parent / BPM_NAMES_FILE).open("r"))  # weird?
+    bpm_names = json.load((Path(infile).parent / BPM_NAMES_FILE).open("r"))
     if hor.shape[1] != len(bpm_names):
         raise ValueError("Number of bpms does not match with accelerator class")
     tbt_data = _check_esrf_tbt_data(np.transpose(np.array([hor, ver]), axes=[0, 2, 3, 1]))

--- a/omc3/tbt/reader_esrf.py
+++ b/omc3/tbt/reader_esrf.py
@@ -5,7 +5,7 @@ ESRF TbT Data Handler
 Data handling for tbt data from ``ESRF``.
 """
 import json
-# from os.path import abspath, dirname, join
+
 from pathlib import Path
 from typing import Tuple, Union
 
@@ -13,6 +13,8 @@ import numpy as np
 from scipy.io import loadmat
 
 from omc3.tbt import handler
+
+BPM_NAMES_FILE: str = "bpm_names.json"
 
 
 def read_tbt(filepath: Union[str, Path]):
@@ -46,8 +48,7 @@ def load_esrf_mat_file(infile: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray
     if hor.shape != ver.shape:
         raise ValueError("Number of turns, BPMs or measurements in X and Y do not match")
     # TODO change for tfs file got from accelerator class
-    bpm_names = json.load((Path(__file__).parent / "bpm_names.json").open("r"))  # weird?
-    # bpm_names = json.load(open(abspath(join(dirname(__file__), "bpm_names.json")), "r"))  # weird?
+    bpm_names = json.load((Path(__file__).parent / BPM_NAMES_FILE).open("r"))  # weird?
     if hor.shape[1] != len(bpm_names):
         raise ValueError("Number of bpms does not match with accelerator class")
     tbt_data = _check_esrf_tbt_data(np.transpose(np.array([hor, ver]), axes=[0, 2, 3, 1]))

--- a/omc3/tbt/reader_esrf.py
+++ b/omc3/tbt/reader_esrf.py
@@ -5,7 +5,9 @@ ESRF TbT Data Handler
 Data handling for tbt data from ``ESRF``.
 """
 import json
-from os.path import abspath, dirname, join
+# from os.path import abspath, dirname, join
+from pathlib import Path
+from typing import Tuple, Union
 
 import numpy as np
 from scipy.io import loadmat
@@ -13,47 +15,57 @@ from scipy.io import loadmat
 from omc3.tbt import handler
 
 
-def read_tbt(filepath):
+def read_tbt(filepath: Union[str, Path]):
     """
     Reads ESRF ``Matlab`` file.
 
     Args:
-        filepath: path to a file
+        filepath (Union[str, Path]): path to a file
 
     Returns:
         `tbt.TbTData` object.
     """
+    filepath = Path(filepath)
     names, matrix = load_esrf_mat_file(filepath)
     return handler.numpy_to_tbts(names, matrix)
 
 
-def load_esrf_mat_file(infile) -> np.ndarray:
+def load_esrf_mat_file(infile: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray]:
     """
     Reads the ESRF TbT ``Matlab`` file, checks for nans and data duplicities from consecutive kicks.
 
     Args:
-        infile: path to file to be read
+        infile (Union[str, Path]): path to file to be read
 
     Returns:
         A Numpy array of BPM names and a 4D Numpy array [quantity, BPM, particle/bunch No.,
         turn No.] quantities in order [x, y]
-        """
-    esrf_data = loadmat(infile)
+    """
+    esrf_data = loadmat(infile)  # accepts str or pathlib.Path
     hor, ver = esrf_data["allx"], esrf_data["allz"]
     if hor.shape != ver.shape:
         raise ValueError("Number of turns, BPMs or measurements in X and Y do not match")
     # TODO change for tfs file got from accelerator class
-    bpm_names = json.load(open(abspath(join(dirname(__file__), "bpm_names.json")), "r"))
+    bpm_names = json.load((Path(__file__).parent / "bpm_names.json").open("r"))  # weird?
+    # bpm_names = json.load(open(abspath(join(dirname(__file__), "bpm_names.json")), "r"))  # weird?
     if hor.shape[1] != len(bpm_names):
         raise ValueError("Number of bpms does not match with accelerator class")
     tbt_data = _check_esrf_tbt_data(np.transpose(np.array([hor, ver]), axes=[0, 2, 3, 1]))
     return np.array(bpm_names), tbt_data
 
 
-def _check_esrf_tbt_data(tbt_data):
+def _check_esrf_tbt_data(tbt_data: np.ndarray) -> np.ndarray:
     tbt_data[np.isnan(np.sum(tbt_data, axis=3)), :] = 0.0
     # check if contains the same data as in previous kick
-    mask_prev = np.concatenate((np.ones((tbt_data.shape[0], tbt_data.shape[1], 1)),
-                                np.sum(np.abs(np.diff(tbt_data, axis=2)), axis=3)), axis=2) == 0.0
+    mask_prev = (
+        np.concatenate(
+            (
+                np.ones((tbt_data.shape[0], tbt_data.shape[1], 1)),
+                np.sum(np.abs(np.diff(tbt_data, axis=2)), axis=3),
+            ),
+            axis=2,
+        )
+        == 0.0
+    )
     tbt_data[mask_prev, :] = 0.0
     return tbt_data

--- a/omc3/tbt/reader_esrf.py
+++ b/omc3/tbt/reader_esrf.py
@@ -48,7 +48,7 @@ def load_esrf_mat_file(infile: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray
     if hor.shape != ver.shape:
         raise ValueError("Number of turns, BPMs or measurements in X and Y do not match")
     # TODO change for tfs file got from accelerator class
-    bpm_names = json.load((Path(infile).parent / BPM_NAMES_FILE).open("r"))
+    bpm_names = json.loads((Path(infile).parent / BPM_NAMES_FILE).read_text())  # weird?
     if hor.shape[1] != len(bpm_names):
         raise ValueError("Number of bpms does not match with accelerator class")
     tbt_data = _check_esrf_tbt_data(np.transpose(np.array([hor, ver]), axes=[0, 2, 3, 1]))

--- a/omc3/tbt/reader_iota.py
+++ b/omc3/tbt/reader_iota.py
@@ -7,6 +7,8 @@ Takes ``hdf5`` file path containing the TbT data and returns a `TbtData` class t
 processed by ``harpy``.
 """
 from datetime import datetime
+from pathlib import Path
+from typing import Union
 
 import h5py
 import numpy as np
@@ -20,11 +22,13 @@ LOGGER = logging_tools.getLogger(__name__)
 
 VERSIONS = (1, 2)
 
-PLANES_CONV = {1: {'X': 'H', 'Y': 'V'},
-               2: {'X': 'Horizontal', 'Y': 'Vertical'}}
+PLANES_CONV = {
+    1: {"X": "H", "Y": "V"},
+    2: {"X": "Horizontal", "Y": "Vertical"},
+}
 
 
-def read_tbt(file_path):
+def read_tbt(file_path: Union[str, Path]):
     """
     Reads TbTData object from provided file_path.
 
@@ -32,41 +36,46 @@ def read_tbt(file_path):
         file_path: path to a file containing TbtData.
 
     Returns:
-        A `TbtData` object with the loaded data.
+        A ``TbtData`` object with the loaded data.
     """
-    hdf_file = h5py.File(file_path, 'r')
+    hdf_file = h5py.File(file_path, "r")
     bunch_ids = [1]
     date = datetime.now()
 
-    for vers in VERSIONS[::-1]:
+    for version in VERSIONS[::-1]:
         try:
-            bpm_names = FUNCTIONS[vers]['get_bpm_names'](hdf_file)
-            nturns = FUNCTIONS[vers]['get_nturns'](hdf_file, vers)
-            matrices = [{k: pd.DataFrame(index=bpm_names,
-                                         data=FUNCTIONS[vers]['get_tbtdata'](hdf_file, k, vers),
-                                         dtype=float) for k in PLANES}]
-
+            bpm_names = FUNCTIONS[version]["get_bpm_names"](hdf_file)
+            nturns = FUNCTIONS[version]["get_nturns"](hdf_file, version)
+            matrices = [
+                {
+                    plane: pd.DataFrame(
+                        index=bpm_names,
+                        data=FUNCTIONS[version]["get_tbtdata"](hdf_file, plane, version),
+                        dtype=float,
+                    )
+                    for plane in PLANES
+                }
+            ]
             return handler.TbtData(matrices, date, bunch_ids, nturns)
 
         except TypeError:
-            pass
+            LOGGER.error("An unhandled TypeError occured during reading.")
         except KeyError:
-            pass
+            LOGGER.error("An unhandled KeyError occured during reading.")
 
 
 def _get_turn_by_turn_data_v1(hd5, plane, version):
     keys = [key for key in hd5.keys() if (key.endswith(PLANES_CONV[version][plane]))]
     nbpm = len(keys)
-    nturn = FUNCTIONS[version]['get_nturns'](hd5, version)
+    nturn = FUNCTIONS[version]["get_nturns"](hd5, version)
     data = np.zeros((nbpm, nturn))
     for i, key in enumerate(keys):
-        data[i, :] = hd5[key][: nturn]
-
+        data[i, :] = hd5[key][:nturn]
     return data
 
 
 def _get_list_of_bpmnames_v1(hd5):
-    bpms = [f'IBPM{key[4:-1]}' for key in list(hd5.keys()) if check_key_v1(key)]
+    bpms = [f"IBPM{key[4:-1]}" for key in list(hd5.keys()) if check_key_v1(key)]
     return np.unique(bpms)
 
 
@@ -77,11 +86,11 @@ def _get_number_of_turns_v1(hd5, version):
 
 def _get_turn_by_turn_data_v2(hd5, plane, version):
 
-    keys = [key for key in hd5.keys() if not key.startswith('N:')]
-    if keys == []:
-        raise TypeError('Wrong version of converter was used.')
+    keys = [key for key in hd5.keys() if not key.startswith("N:")]
+    if not keys:
+        raise TypeError("Wrong version of converter was used.")
     nbpm = len(keys)
-    nturn = FUNCTIONS[version]['get_nturns'](hd5, version)
+    nturn = FUNCTIONS[version]["get_nturns"](hd5, version)
     data = np.zeros((nbpm, nturn))
     for i, key in enumerate(keys):
         data[i, :] = hd5[key][PLANES_CONV[version][plane]][:nturn]
@@ -90,28 +99,40 @@ def _get_turn_by_turn_data_v2(hd5, plane, version):
 
 
 def _get_list_of_bpmnames_v2(hd5):
-    bpms = [f'IBPM{key}' for key in list(hd5.keys()) if check_key_v2(key)]
-    if bpms == []:
-        raise TypeError('Wrong version of converter was used.')
+    bpms = [f"IBPM{key}" for key in list(hd5.keys()) if check_key_v2(key)]
+    if not bpms:
+        raise TypeError("Wrong version of converter was used.")
     return np.unique(bpms)
 
 
 def _get_number_of_turns_v2(hd5, version):
-    lengths = np.array([(len(hd5[key][PLANES_CONV[version]['X']]), len(hd5[key][PLANES_CONV[version]['Y']])) for key in list(hd5.keys()) if check_key_v2(key)])
+    lengths = np.array(
+        [
+            (len(hd5[key][PLANES_CONV[version]["X"]]), len(hd5[key][PLANES_CONV[version]["Y"]]))
+            for key in list(hd5.keys())
+            if check_key_v2(key)
+        ]
+    )
     return np.min(lengths)
 
 
 def check_key_v2(key):
-    return not (('NL' in key) or key.startswith('N:'))
+    return not (("NL" in key) or key.startswith("N:"))
 
 
 def check_key_v1(key):
-    return ('state' not in key) or key.startswith('N:')
+    return ("state" not in key) or key.startswith("N:")
 
 
-FUNCTIONS = {1: {'get_bpm_names': _get_list_of_bpmnames_v1,
-                 'get_nturns': _get_number_of_turns_v1,
-                 'get_tbtdata': _get_turn_by_turn_data_v1},
-             2: {'get_bpm_names': _get_list_of_bpmnames_v2,
-                 'get_nturns': _get_number_of_turns_v2,
-                 'get_tbtdata': _get_turn_by_turn_data_v2}}
+FUNCTIONS = {
+    1: {
+        "get_bpm_names": _get_list_of_bpmnames_v1,
+        "get_nturns": _get_number_of_turns_v1,
+        "get_tbtdata": _get_turn_by_turn_data_v1,
+    },
+    2: {
+        "get_bpm_names": _get_list_of_bpmnames_v2,
+        "get_nturns": _get_number_of_turns_v2,
+        "get_tbtdata": _get_turn_by_turn_data_v2,
+    },
+}

--- a/omc3/tbt/reader_lhc.py
+++ b/omc3/tbt/reader_lhc.py
@@ -5,6 +5,8 @@ LHC TbT Data Handler
 Data handling for tbt data from the ``LHC``.
 """
 from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -38,15 +40,15 @@ ACQ_STAMP = "acqStamp"
 BPM_NAMES = "bpmNames"
 
 
-def read_tbt(file_path):
+def read_tbt(file_path: Union[str, Path]):
     """
     Reads TbTData object from provided file_path.
 
     Args:
-        file_path: path to a file containing TbtData.
+        file_path (Union[str, Path]): path to a file containing TbtData.
 
     Returns:
-        A `TbtData` object with the loaded data.
+        A ``TbtData`` object with the loaded data.
     """
     if _is_ascii_file(file_path):
         matrices, date = _read_ascii(file_path)
@@ -68,11 +70,11 @@ def read_tbt(file_path):
     return handler.TbtData(matrices, date, bunch_ids, nturns)
 
 
-def _is_ascii_file(file_path) -> bool:
+def _is_ascii_file(file_path: Union[str, Path]) -> bool:
     """
-    Returns ``True`` only if the file looks like a readable tbt ASCII file.
+    Returns ``True`` only if the file looks like a readable tbt ASCII file, else ``False``.
     """
-    with open(file_path, "r") as file_data:
+    with Path(file_path).open("r") as file_data:
         try:
             for line in file_data:
                 if line.strip() == "":
@@ -83,9 +85,9 @@ def _is_ascii_file(file_path) -> bool:
     return False
 
 
-def _read_ascii(file_path):
+def _read_ascii(file_path: Union[str, Path]) -> Tuple[List[Dict[str, pd.DataFrame]], datetime]:
     """Read the ascii file."""
-    with open(file_path, "r") as file_data:
+    with Path(file_path).open("r") as file_data:
         data_lines = file_data.readlines()
 
     bpm_names = {"X": [], "Y": []}
@@ -119,7 +121,7 @@ def _read_ascii(file_path):
 
 # ASCII-File Helper ------------------------------------------------------------
 
-def _parse_samples(line):
+def _parse_samples(line: str) -> Tuple[str, str, np.ndarray]:
     parts = line.split()
     plane_num = parts[0]
     bpm_name = parts[1]
@@ -128,7 +130,7 @@ def _parse_samples(line):
     return plane_num, bpm_name, bpm_samples
 
 
-def _parse_date(line):
+def _parse_date(line: str) -> datetime:
     date_str = line.replace(_ACQ_DATE_PREFIX, "").replace(_ASCII_COMMENT, "").strip()
     try:
         return datetime.strptime(date_str, _ACQ_DATE_FORMAT)

--- a/omc3/tbt/reader_trackone.py
+++ b/omc3/tbt/reader_trackone.py
@@ -2,80 +2,108 @@
 Trackone TbT Data Handler
 -------------------------
 
-Tbt data handling from ``PTC`` trackone.
+Tbt data handling from ``MAD-X`` trackone.
 """
-from collections import OrderedDict
+from pathlib import Path
+from typing import Tuple, Union
 
 import numpy as np
 
 from omc3.tbt import handler
 
 
-def read_tbt(infile):
+def read_tbt(infile: Union[str, Path]):
+    """
+    Reads TbtData object from ``MAD-X`` **trackone** output.
+
+    Args:
+        infile (Union[str, Path]): path to a file containing TbtData.
+
+    Returns:
+        A ``TbtData`` object with the loaded data.
+    """
     nturns, npart = get_trackone_stats(infile)
     names, matrix = get_structure_from_trackone(nturns, npart, infile)
     # matrix[0, 2] contains just (x, y) samples.
     return handler.numpy_to_tbts(names, matrix[[0, 2]])
 
 
-def load_dict(file_name):  # check length?
+def load_dict(file_name: Union[str, Path]):  # check length?
     loaded = np.load(file_name)
     return loaded[loaded.files[0]].item()  # np.ndarray.item()
 
 
-def get_trackone_stats(infile):
+def get_trackone_stats(infile: Union[str, Path]) -> Tuple[int, int]:
+    """
+    Determines the number of particles and turns in the data from the provided ``MAD-X``
+    **trackone** file.
+
+    Args:
+        infile (Union[str, Path]): path to a file containing TbtData.
+
+    Returns:
+        A tuple with the number of turns and particles.
+    """
     stats_string = ""
     nturns, nparticles = 0, 0
     first_seg = True
-    with open(infile, 'r') as f:
-        for l in f:
-            if len(l.strip()) == 0:
+    with Path(infile).open("r") as input_file:
+        for line in input_file:
+            if len(line.strip()) == 0:
                 continue
-            if l.strip()[0] in ['@', '*', '$']:
-                stats_string = stats_string + l
+            if line.strip()[0] in ["@", "*", "$"]:
+                stats_string = stats_string + line
                 continue
-            parts = l.split()
-            if parts[0] == '#segment':
+            parts = line.split()
+            if parts[0] == "#segment":
                 if not first_seg:
                     break
                 nturns = int(parts[2])
                 nparticles = int(parts[3])
                 first_seg = False
-            if parts[0] == '-1':
+            if parts[0] == "-1":
                 nparticles = 1
-            stats_string = stats_string + l
-    with open('stats.txt', "w") as stats_file:
+            stats_string = stats_string + line
+    with open("stats.txt", "w") as stats_file:
         stats_file.write(stats_string)
     return nturns - 1, nparticles
 
 
-def get_structure_from_trackone(nturns=0, npart=0, infile='trackone'):
+def get_structure_from_trackone(
+    nturns: int = 0, npart: int = 0, infile: Union[str, Path] = "trackone"
+) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Reads the **trackone** file produced by ``PTC``.
+    Extracts BPM names and particle coordinates in the **trackone** file produced by ``MAD-X``.
 
     Args:
-        nturns: Number of turns tracked in the **trackone**, i.e. obtained from
+        nturns (int): Number of turns tracked in the **trackone**, i.e. obtained from
             ``get_trackone_stats()``.
-        npart:  Number of particles tracked in the **trackone**, i.e. obtained from
+        npart (int):  Number of particles tracked in the **trackone**, i.e. obtained from
             ``get_trackone_stats()``.
-        infile: path to trackone file to be read.
+        infile (Union[str, Path]): path to trackone file to be read.
 
     Returns:
         A Numpy array of BPM names and a 4D Numpy array [quantity, BPM, particle/bunch No.,
         turn No.] quantities in order [x, px, y, py, t, pt, s, E].
     """
-    bpms = OrderedDict()
-    with open(infile, 'r') as f:
-        for l in f:
-            if len(l.strip()) == 0:
+    bpms = dict()
+    with Path(infile).open("r") as input_file:
+        for line in input_file:
+            if len(line.strip()) == 0:
                 continue
-            if l.strip()[0] in ['@', '*', '$']:
+            if line.strip()[0] in ["@", "*", "$"]:
                 continue
-            parts = l.split()
-            if parts[0] == '#segment':
+            parts = line.split()
+            if parts[0] == "#segment":
                 bpm_name = parts[-1].upper()
-                if (np.all([k not in bpm_name.lower() for k in ['start', 'end']])) and (bpm_name not in bpms.keys()):
+                if (np.all([k not in bpm_name.lower() for k in ["start", "end"]])) and (
+                    bpm_name not in bpms.keys()
+                ):
                     bpms[bpm_name] = np.empty([npart, nturns, 8], dtype=float)
-            elif np.all([k not in bpm_name.lower() for k in ['start', 'end']]):
-                bpms[bpm_name][np.abs(int(float(parts[0]))) - 1, int(float(parts[1])) - 1, :] = np.array(parts[2:])
-    return np.array(list(bpms.keys())), np.transpose(np.array(list(bpms.values())), axes=[3, 0, 1, 2])
+            elif np.all([k not in bpm_name.lower() for k in ["start", "end"]]):
+                bpms[bpm_name][
+                    np.abs(int(float(parts[0]))) - 1, int(float(parts[1])) - 1, :
+                ] = np.array(parts[2:])
+    return np.array(list(bpms.keys())), np.transpose(
+        np.array(list(bpms.values())), axes=[3, 0, 1, 2]
+    )

--- a/omc3/tbt_converter.py
+++ b/omc3/tbt_converter.py
@@ -8,7 +8,8 @@ Optionally, it can replicate files with added noise.
 import copy
 from datetime import datetime
 from os.path import basename, join
-from typing import Sequence
+from pathlib import Path
+from typing import Sequence, Union
 
 from generic_parser.entrypoint_parser import EntryPointParameters, entrypoint, save_options_to_config
 
@@ -88,7 +89,9 @@ def converter_entrypoint(opt):
         raise ValueError("Number of realizations lower than 1.")
     iotools.create_dirs(opt.outputdir)
     save_options_to_config(
-        join(opt.outputdir, DEFAULT_CONFIG_FILENAME.format(time=datetime.utcnow().strftime(formats.TIME))),
+        str(Path(opt.outputdir) / DEFAULT_CONFIG_FILENAME.format(time=datetime.utcnow().strftime(
+            formats.TIME))),
+        # join(opt.outputdir, DEFAULT_CONFIG_FILENAME.format(time=datetime.utcnow().strftime(formats.TIME))),
         dict(sorted(opt.items())),
     )
     _read_and_write_files(opt)
@@ -104,11 +107,11 @@ def _read_and_write_files(opt):
         for i in range(opt.realizations):
             suffix = f"_r{i}" if opt.realizations > 1 else ""
             if opt.noise_levels is None:
-                tbt.write(join(opt.outputdir, f"{_file_name(input_file)}{suffix}"), tbt_data=tbt_data)
+                tbt.write(Path(opt.outputdir) / f"{Path(input_file).stem}{suffix}", tbt_data=tbt_data)
             else:
                 for noise_level in opt.noise_levels:
                     tbt.write(
-                        join(opt.outputdir, f"{_file_name(input_file)}_n{noise_level}{suffix}"),
+                        Path(opt.outputdir) / f"{Path(input_file).stem}_n{noise_level}{suffix}",
                         tbt_data=tbt_data,
                         noise=float(noise_level),
                     )
@@ -126,7 +129,7 @@ def _drop_elements(tbt_data: tbt.TbtData, elements_to_drop: Sequence[str]) -> tb
     Returns:
         A copied version of the provided TbtData object with the relevant element dropped from the matrices.
     """
-    copied_data = copy.deepcopy(tbt_data)
+    copied_data: tbt.TbtData = copy.deepcopy(tbt_data)
     LOGGER.info(f"Dropping the following unwanted elements: {', '.join(elements_to_drop)}")
     for element in elements_to_drop:
         LOGGER.debug(f"Dropping element '{element}'")
@@ -137,10 +140,6 @@ def _drop_elements(tbt_data: tbt.TbtData, elements_to_drop: Sequence[str]) -> tb
         except KeyError:
             LOGGER.warning(f"Element '{element}' could not be found, skipped")
     return copied_data
-
-
-def _file_name(filename: str):
-    return basename(filename)[:-5] if filename.endswith(".sdds") else basename(filename)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_tbt.py
+++ b/tests/unit/test_tbt.py
@@ -1,6 +1,6 @@
-import os
 import tempfile
 from datetime import datetime
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -11,13 +11,13 @@ from omc3.definitions.constants import PLANES
 from omc3.tbt import handler, reader_iota, reader_ptc, reader_trackone
 from omc3.tbt_converter import converter_entrypoint
 
-CURRENT_DIR = os.path.dirname(__file__)
+INPUTS_DIR = Path(__file__).parent.parent / "inputs"
 ASCII_PRECISION = 0.5 / np.power(10, handler.PRINT_PRECISION)
 
 
 @pytest.mark.basic
 def test_converter_one_file(_sdds_file, _test_file):
-    converter_entrypoint(files=[_sdds_file], outputdir=os.path.dirname(_test_file))
+    converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent)
     origin = handler.read_tbt(_sdds_file)
     new = handler.read_tbt(f'{_test_file}.sdds')
     _compare_tbt(origin, new, False)
@@ -27,7 +27,7 @@ def test_converter_one_file(_sdds_file, _test_file):
 def test_converter_one_file_with_noise(_sdds_file, _test_file):
     np.random.seed(2019)
     noiselevel = 0.0005
-    converter_entrypoint(files=[_sdds_file], outputdir=os.path.dirname(_test_file), noise_levels=[noiselevel])
+    converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, noise_levels=[noiselevel])
     origin = handler.read_tbt(_sdds_file)
     new = handler.read_tbt(f'{_test_file}_n{noiselevel}.sdds')
     _compare_tbt(origin, new, True, noiselevel*10)
@@ -36,7 +36,7 @@ def test_converter_one_file_with_noise(_sdds_file, _test_file):
 @pytest.mark.basic
 def test_converter_more_files(_sdds_file, _test_file):
     rep = 2
-    converter_entrypoint(files=[_sdds_file], outputdir=os.path.dirname(_test_file), realizations=rep)
+    converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, realizations=rep)
     origin = handler.read_tbt(_sdds_file)
     for i in range(rep):
         new = handler.read_tbt(f'{_test_file}_r{i}.sdds')
@@ -48,7 +48,7 @@ def test_converter_more_files_with_noise(_sdds_file, _test_file):
     np.random.seed(2019)
     rep = 2
     noiselevel = 0.0005
-    converter_entrypoint(files=[_sdds_file], outputdir=os.path.dirname(_test_file), realizations=rep, noise_levels=[noiselevel])
+    converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, realizations=rep, noise_levels=[noiselevel])
     origin = handler.read_tbt(_sdds_file)
     for i in range(rep):
         new = handler.read_tbt(f'{_test_file}_n{noiselevel}_r{i}.sdds')
@@ -199,7 +199,8 @@ def test_tbt_write_read_ascii(_sdds_file, _test_file):
     _compare_tbt(origin, new, True)
 
 
-def _compare_tbt(origin, new, no_binary, max_deviation=ASCII_PRECISION):
+def _compare_tbt(origin: handler.TbtData, new: handler.TbtData, no_binary: bool,
+                 max_deviation=ASCII_PRECISION) -> None:
     assert new.nturns == origin.nturns
     assert new.nbunches == origin.nbunches
     assert new.bunch_ids == origin.bunch_ids
@@ -214,7 +215,7 @@ def _compare_tbt(origin, new, no_binary, max_deviation=ASCII_PRECISION):
                 assert np.all(origin_mat == new_mat)
 
 
-def _original_trackone(track=False):
+def _original_trackone(track: bool = False) -> handler.TbtData:
     names = np.array(["C1.BPM1"])
     matrix = [
         dict(X=pd.DataFrame(index=names, data=[[0.001, -0.0003606, -0.00165823, -0.00266631]]),
@@ -227,19 +228,19 @@ def _original_trackone(track=False):
     return origin
 
 
-def _create_data(nturns, nbpm, function):
+def _create_data(nturns, nbpm, function) -> np.ndarray:
     return np.ones((nbpm, len(nturns))) * function(nturns)
 
 
 @pytest.fixture()
-def _sdds_file():
-    return os.path.join(CURRENT_DIR, os.pardir, "inputs", "test_file.sdds")
+def _sdds_file() -> Path:
+    return INPUTS_DIR / "test_file.sdds"
 
 
 @pytest.fixture()
-def _hdf5_file():
+def _hdf5_file() -> Path:
     with tempfile.TemporaryDirectory() as cwd:
-        with h5py.File(os.path.join(cwd, f'test_file.hdf5'), 'w') as hd5_file:
+        with h5py.File(Path(cwd) / "test_file.hdf5", 'w') as hd5_file:
             hd5_file.create_dataset("N:IBE2RH", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin).flatten())
             hd5_file.create_dataset("N:IBE2RV", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos).flatten())
             hd5_file.create_dataset("N:IBE2RS", data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten())
@@ -248,13 +249,13 @@ def _hdf5_file():
             hd5_file.create_dataset("N:IBA1CV", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos).flatten())
             hd5_file.create_dataset("N:IBA1CS", data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten())
 
-        yield os.path.join(cwd, f'test_file.hdf5')
+        yield Path(cwd) / "test_file.hdf5"
 
 
 @pytest.fixture()
-def _hdf5_file_v2():
+def _hdf5_file_v2() -> Path:
     with tempfile.TemporaryDirectory() as cwd:
-        with h5py.File(os.path.join(cwd, f'test_file_v2.hdf5'), 'w') as hd5_file:
+        with h5py.File(Path(cwd) / "test_file_v2.hdf5", 'w') as hd5_file:
 
             hd5_file.create_group('A1C')
             hd5_file['A1C'].create_dataset("Horizontal", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin).flatten())
@@ -266,25 +267,25 @@ def _hdf5_file_v2():
             hd5_file['E2R'].create_dataset("Vertical", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos).flatten())
             hd5_file['E2R'].create_dataset("Intensity", data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten())
 
-        yield os.path.join(cwd, f'test_file_v2.hdf5')
+        yield Path(cwd) / "test_file_v2.hdf5"
 
 
 @pytest.fixture()
-def _test_file():
+def _test_file() -> Path:
     with tempfile.TemporaryDirectory() as cwd:
-        yield os.path.join(cwd, "test_file")
+        yield Path(cwd) / "test_file"
 
 
 @pytest.fixture()
-def _ptc_file():
-    return os.path.join(CURRENT_DIR, os.pardir, "inputs", "test_trackone")
+def _ptc_file() -> Path:
+    return INPUTS_DIR / "test_trackone"
 
 
 @pytest.fixture()
-def _ptc_file_losses():
-    return os.path.join(CURRENT_DIR, os.pardir, "inputs", "test_trackone_losses")
+def _ptc_file_losses() -> Path:
+    return INPUTS_DIR / "test_trackone_losses"
 
 
 @pytest.fixture()
-def _ptc_file_sci():
-    return os.path.join(CURRENT_DIR, os.pardir, "inputs", "test_trackone_sci")
+def _ptc_file_sci() -> Path:
+    return INPUTS_DIR / "test_trackone_sci"

--- a/tests/unit/test_tbt.py
+++ b/tests/unit/test_tbt.py
@@ -19,7 +19,7 @@ ASCII_PRECISION = 0.5 / np.power(10, handler.PRINT_PRECISION)
 def test_converter_one_file(_sdds_file, _test_file):
     converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent)
     origin = handler.read_tbt(_sdds_file)
-    new = handler.read_tbt(f'{_test_file}.sdds')
+    new = handler.read_tbt(f"{_test_file}.sdds")
     _compare_tbt(origin, new, False)
 
 
@@ -29,8 +29,8 @@ def test_converter_one_file_with_noise(_sdds_file, _test_file):
     noiselevel = 0.0005
     converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, noise_levels=[noiselevel])
     origin = handler.read_tbt(_sdds_file)
-    new = handler.read_tbt(f'{_test_file}_n{noiselevel}.sdds')
-    _compare_tbt(origin, new, True, noiselevel*10)
+    new = handler.read_tbt(f"{_test_file}_n{noiselevel}.sdds")
+    _compare_tbt(origin, new, True, noiselevel * 10)
 
 
 @pytest.mark.basic
@@ -39,7 +39,7 @@ def test_converter_more_files(_sdds_file, _test_file):
     converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, realizations=rep)
     origin = handler.read_tbt(_sdds_file)
     for i in range(rep):
-        new = handler.read_tbt(f'{_test_file}_r{i}.sdds')
+        new = handler.read_tbt(f"{_test_file}_r{i}.sdds")
         _compare_tbt(origin, new, False)
 
 
@@ -48,18 +48,20 @@ def test_converter_more_files_with_noise(_sdds_file, _test_file):
     np.random.seed(2019)
     rep = 2
     noiselevel = 0.0005
-    converter_entrypoint(files=[_sdds_file], outputdir=_test_file.parent, realizations=rep, noise_levels=[noiselevel])
+    converter_entrypoint(
+        files=[_sdds_file], outputdir=_test_file.parent, realizations=rep, noise_levels=[noiselevel]
+    )
     origin = handler.read_tbt(_sdds_file)
     for i in range(rep):
-        new = handler.read_tbt(f'{_test_file}_n{noiselevel}_r{i}.sdds')
-        _compare_tbt(origin, new, True, noiselevel*10)
+        new = handler.read_tbt(f"{_test_file}_n{noiselevel}_r{i}.sdds")
+        _compare_tbt(origin, new, True, noiselevel * 10)
 
 
 @pytest.mark.basic
 def test_tbt_write_read_sdds_binary(_sdds_file, _test_file):
     origin = handler.read_tbt(_sdds_file)
     handler.write_tbt(_test_file, origin)
-    new = handler.read_tbt(f'{_test_file}.sdds')
+    new = handler.read_tbt(f"{_test_file}.sdds")
     _compare_tbt(origin, new, False)
 
 
@@ -68,17 +70,23 @@ def test_tbt_read_hdf5(_hdf5_file):
 
     origin = handler.TbtData(
         matrices=[
-                  {'X': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
+            {
+                "X": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"],
                     data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 2, np.sin),
-                    dtype=float),
-                   'Y': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
+                    dtype=float,
+                ),
+                "Y": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"],
                     data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 2, np.cos),
-                    dtype=float)}],
+                    dtype=float,
+                ),
+            }
+        ],
         date=datetime.now(),
         bunch_ids=[1],
-        nturns=2000)
+        nturns=2000,
+    )
     new = reader_iota.read_tbt(_hdf5_file)
     _compare_tbt(origin, new, False)
 
@@ -88,17 +96,23 @@ def test_tbt_read_hdf5_v2(_hdf5_file_v2):
 
     origin = handler.TbtData(
         matrices=[
-                  {'X': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
+            {
+                "X": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"],
                     data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 2, np.sin),
-                    dtype=float),
-                   'Y': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
+                    dtype=float,
+                ),
+                "Y": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"],
                     data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 2, np.cos),
-                    dtype=float)}],
+                    dtype=float,
+                ),
+            }
+        ],
         date=datetime.now(),
         bunch_ids=[1],
-        nturns=2000)
+        nturns=2000,
+    )
     new = reader_iota.read_tbt(_hdf5_file_v2)
     _compare_tbt(origin, new, False)
 
@@ -106,41 +120,42 @@ def test_tbt_read_hdf5_v2(_hdf5_file_v2):
 @pytest.mark.basic
 def test_compare_average_Tbtdata():
     npart = 10
-    data = {plane: np.concatenate(
-                                  [[_create_data(np.linspace(1, 10, 10, endpoint=False, dtype=int), 2, (lambda x: np.random.randn(len(x))))]
-                                   for _ in range(npart)
-                                   ],
-                                  axis=0)
-            for plane in PLANES}
+    data = {
+        plane: np.concatenate(
+            [[_create_data(np.linspace(1, 10, 10, endpoint=False, dtype=int), 2, (lambda x: np.random.randn(len(x))),)]
+             for _ in range(npart)], axis=0,
+        )
+        for plane in PLANES
+    }
 
     origin = handler.TbtData(
         matrices=[
-                  {'X': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
-                    data=data['X'][i],
-                    dtype=float),
-                   'Y': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
-                    data=data['Y'][i],
-                    dtype=float)}
-                  for i in range(npart)],
+            {
+                "X": pd.DataFrame(index=["IBPMA1C", "IBPME2R"], data=data["X"][i], dtype=float),
+                "Y": pd.DataFrame(index=["IBPMA1C", "IBPME2R"], data=data["Y"][i], dtype=float),
+            }
+            for i in range(npart)
+        ],
         date=datetime.now(),
         bunch_ids=range(npart),
-        nturns=10)
+        nturns=10,
+    )
 
     new = handler.TbtData(
         matrices=[
-                  {'X': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
-                    data=np.mean(data['X'], axis=0),
-                    dtype=float),
-                   'Y': pd.DataFrame(
-                    index=['IBPMA1C', 'IBPME2R'],
-                    data=np.mean(data['Y'], axis=0),
-                    dtype=float)}],
+            {
+                "X": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"], data=np.mean(data["X"], axis=0), dtype=float
+                ),
+                "Y": pd.DataFrame(
+                    index=["IBPMA1C", "IBPME2R"], data=np.mean(data["Y"], axis=0), dtype=float
+                ),
+            }
+        ],
         date=datetime.now(),
         bunch_ids=[1],
-        nturns=10)
+        nturns=10,
+    )
 
     _compare_tbt(handler.generate_average_tbtdata(origin), new, False)
 
@@ -199,8 +214,9 @@ def test_tbt_write_read_ascii(_sdds_file, _test_file):
     _compare_tbt(origin, new, True)
 
 
-def _compare_tbt(origin: handler.TbtData, new: handler.TbtData, no_binary: bool,
-                 max_deviation=ASCII_PRECISION) -> None:
+def _compare_tbt(
+    origin: handler.TbtData, new: handler.TbtData, no_binary: bool, max_deviation=ASCII_PRECISION
+) -> None:
     assert new.nturns == origin.nturns
     assert new.nbunches == origin.nbunches
     assert new.bunch_ids == origin.bunch_ids
@@ -218,12 +234,15 @@ def _compare_tbt(origin: handler.TbtData, new: handler.TbtData, no_binary: bool,
 def _original_trackone(track: bool = False) -> handler.TbtData:
     names = np.array(["C1.BPM1"])
     matrix = [
-        dict(X=pd.DataFrame(index=names, data=[[0.001, -0.0003606, -0.00165823, -0.00266631]]),
-             Y=pd.DataFrame(index=names, data=[[0.001, 0.00070558, -0.00020681, -0.00093807]])),
+        dict(
+            X=pd.DataFrame(index=names, data=[[0.001, -0.0003606, -0.00165823, -0.00266631]]),
+            Y=pd.DataFrame(index=names, data=[[0.001, 0.00070558, -0.00020681, -0.00093807]]),
+        ),
         dict(
             X=pd.DataFrame(index=names, data=[[0.0011, -0.00039666, -0.00182406, -0.00293294]]),
-            Y=pd.DataFrame(index=names,
-                           data=[[0.0011, 0.00077614, -0.00022749, -0.00103188]]))]
+            Y=pd.DataFrame(index=names, data=[[0.0011, 0.00077614, -0.00022749, -0.00103188]]),
+        ),
+    ]
     origin = handler.TbtData(matrix, None, [0, 1] if track else [1, 2], 4)
     return origin
 
@@ -255,17 +274,43 @@ def _hdf5_file() -> Path:
 @pytest.fixture()
 def _hdf5_file_v2() -> Path:
     with tempfile.TemporaryDirectory() as cwd:
-        with h5py.File(Path(cwd) / "test_file_v2.hdf5", 'w') as hd5_file:
+        with h5py.File(Path(cwd) / "test_file_v2.hdf5", "w") as hd5_file:
 
-            hd5_file.create_group('A1C')
-            hd5_file['A1C'].create_dataset("Horizontal", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin).flatten())
-            hd5_file['A1C'].create_dataset("Vertical", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos).flatten())
-            hd5_file['A1C'].create_dataset("Intensity", data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten())
+            hd5_file.create_group("A1C")
+            hd5_file["A1C"].create_dataset(
+                "Horizontal",
+                data=_create_data(
+                    np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin
+                ).flatten(),
+            )
+            hd5_file["A1C"].create_dataset(
+                "Vertical",
+                data=_create_data(
+                    np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos
+                ).flatten(),
+            )
+            hd5_file["A1C"].create_dataset(
+                "Intensity",
+                data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten(),
+            )
 
-            hd5_file.create_group('E2R')
-            hd5_file['E2R'].create_dataset("Horizontal", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin).flatten())
-            hd5_file['E2R'].create_dataset("Vertical", data=_create_data(np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos).flatten())
-            hd5_file['E2R'].create_dataset("Intensity", data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten())
+            hd5_file.create_group("E2R")
+            hd5_file["E2R"].create_dataset(
+                "Horizontal",
+                data=_create_data(
+                    np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.sin
+                ).flatten(),
+            )
+            hd5_file["E2R"].create_dataset(
+                "Vertical",
+                data=_create_data(
+                    np.linspace(-np.pi, np.pi, 2000, endpoint=False), 1, np.cos
+                ).flatten(),
+            )
+            hd5_file["E2R"].create_dataset(
+                "Intensity",
+                data=_create_data(np.linspace(0, 20, 2000, endpoint=False), 1, np.exp).flatten(),
+            )
 
         yield Path(cwd) / "test_file_v2.hdf5"
 


### PR DESCRIPTION
This PR is complementary to #290.

- It adds tests for the `--drop_element` flag, asserting elements are properly dropped and that a warning is properly logged if elements are not found.

- It makes the conversion to `pathlib` for all `tbt`-related functionality: `tbt_converter` and all members of `tbt` now also accept `pathlib.Path` objects.
