### PR TITLE
Model Creator Fix

### DIFF
--- a/omc3/madx_wrapper.py
+++ b/omc3/madx_wrapper.py
@@ -111,7 +111,7 @@ def _run(full_madx_script, log_file=None, output_file=None, madx_path=MADX_PATH,
     """Starts the ``MAD-X`` process."""
     with _madx_input_wrapper(full_madx_script, output_file) as madx_jobfile:
         process = subprocess.Popen(
-            [str(madx_path), str(madx_jobfile)],
+            [str(madx_path), str(madx_jobfile.absolute())],
             shell=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/omc3/madx_wrapper.py
+++ b/omc3/madx_wrapper.py
@@ -111,7 +111,7 @@ def _run(full_madx_script, log_file=None, output_file=None, madx_path=MADX_PATH,
     """Starts the ``MAD-X`` process."""
     with _madx_input_wrapper(full_madx_script, output_file) as madx_jobfile:
         process = subprocess.Popen(
-            [str(madx_path), str(madx_jobfile.absolute())],
+            [str(Path(madx_path).absolute()), str(Path(madx_jobfile).absolute())],
             shell=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -6,86 +6,97 @@ This module provides the template for all model creators.
 """
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Sequence
+from typing import List, Sequence, Union
 
 from omc3.model.accelerators.accelerator import Accelerator, AccExcitationMode
-from omc3.model.constants import TWISS_AC_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT, TWISS_ADT_DAT
+from omc3.model.constants import TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT
 
 
 class ModelCreator(ABC):
-
+    """
+    Abstract class for the implementation of a model creator. All mandatory methods and convenience
+    functions are defined here.
+    """
     @classmethod
     @abstractmethod
     def get_correction_check_script(cls, accel: Accelerator, corr_file: str, chrom: bool) -> str:
-        """ Returns the madx-script used to verify global corrections.
-        This script should create twissfiles for before (``twiss_no.dat``) and after (``twiss_corr.dat``)
-        correction.
+        """
+        Returns the ``MAD-X`` script used to verify global corrections. This script should create twiss
+        files for before (``twiss_no.dat``) and after (``twiss_corr.dat``) correction.
 
         Args:
-            accel (Accelerator): Accelerator Instance
-            corr_file (str): File containing the corrections (madx-readable)
-            chrom (bool): Flag for chromatic corrections deltapm and deltapp
+            accel (Accelerator): Accelerator Instance used for the model creation.
+            corr_file (str): File containing the corrections (madx-readable).
+            chrom (bool): Flag for chromatic corrections deltapm and deltapp.
 
         Returns:
-            madx-script used to verify global corrections
+            The string of the ``MAD-X`` script used to verify global corrections.
         """
         pass
 
     @classmethod
     @abstractmethod
     def get_madx_script(cls, accel: Accelerator) -> str:
-        """ Returns the madx-script used to create the model (directory).
+        """
+        Returns the ``MAD-X`` script used to create the model (directory).
 
         Args:
-            accel (Accelerator): Accelerator Instance
+            accel (Accelerator): Accelerator Instance used for the model creation.
 
         Returns:
-            madx-script used to used to create the model
+            The string of the ``MAD-X`` script used to used to create the model.
         """
         pass
 
     @classmethod
     @abstractmethod
-    def prepare_run(cls, accel: Accelerator):
-        """ Prepares the model-creation-madx-run.
-        I.e. checks that the directories are created, macros and other files are
-        in place.
-        Should also check that all necessary data for model creation is
-        available in the accelerator instance.
-        Called by the ``model_creator.create_accel_and_instance``
+    def prepare_run(cls, accel: Accelerator) -> None:
+        """
+        Prepares the model creation ``MAD-X`` run. It should check that the appropriate directories
+        are created, and that macros and other files are in place.
+        Should also check that all necessary data for model creation is available in the accelerator
+        instance. Called by the ``model_creator.create_accel_and_instance``
 
         Args:
-            accel (Accelerator): Accelerator Instance
-
+            accel (Accelerator): Accelerator Instance used for the model creation.
         """
         pass
 
     @classmethod
-    def check_run_output(cls, accel: Accelerator):
-        """ Checks that the model-creation-madx-run was successful.
-        I.e. checks that the directories are created, macros and other files are
-        in place. Checks accelerator instance.
-        Called by the ``model_creator.create_instance_and_model``
+    def check_run_output(cls, accel: Accelerator) -> None:
+        """
+        Checks that the model creation ``MAD-X`` run was successful. It should check that the
+        appropriate directories are created, and that macros and other files are in place.
+        Checks the accelerator instance. Called by the ``model_creator.create_instance_and_model``
 
         Args:
-            accel (Accelerator): Accelerator Instance
-
+            accel (Accelerator): Accelerator Instance used for the model creation.
         """
         # These are the default files for most model creators for now.
-        to_check = [TWISS_DAT, TWISS_ELEMENTS_DAT]
+        files_to_check: List[str] = [TWISS_DAT, TWISS_ELEMENTS_DAT]
         if accel.excitation == AccExcitationMode.ACD:
-            to_check += [TWISS_AC_DAT]
+            files_to_check += [TWISS_AC_DAT]
         elif accel.excitation == AccExcitationMode.ADT:
-            to_check += [TWISS_ADT_DAT]
-        cls._check_files_exist(accel.model_dir, to_check)
+            files_to_check += [TWISS_ADT_DAT]
+        cls._check_files_exist(accel.model_dir, files_to_check)
 
     @staticmethod
-    def _check_files_exist(dir_: Path, files: Sequence[str]):
-        """ Convenience function to loop over files and raise an IOError if they
-        do not exist. """
-        for out_file in files:
-            file_path = dir_ / out_file
-            if not file_path.exists():
-                raise IOError(f"Model Creation Failed. "
-                              f"The file '{file_path}' was not created.")
+    def _check_files_exist(dir_: Union[Path, str], files: Sequence[str]) -> None:
+        """
+        Convenience function to loop over files supposed to be in a locatioin and raise an error if
+        one or more of these files does not exist.
 
+        Args:
+            dir_ (Union[Path, str]): Path object or string of the absolute path of the directory in
+                which to check for the files.
+            files (Sequence[str]): the names of files to check the presence of in the directory.
+
+        Raises:
+            Raises an ``FileNotFoundError``
+        """
+        for out_file in files:
+            file_path = Path(dir_) / out_file
+            if not file_path.exists():
+                raise FileNotFoundError(
+                    f"Model Creation Failed. The file '{file_path.absolute()}' was not created."
+                )

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -65,7 +65,7 @@ class ModelCreator(ABC):
         """ Checks that the model-creation-madx-run was successful.
         I.e. checks that the directories are created, macros and other files are
         in place. Checks accelerator instance.
-        Called by the ``model_creator.create_accel_and_instance``
+        Called by the ``model_creator.create_instance_and_model``
 
         Args:
             accel (Accelerator): Accelerator Instance

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -1,0 +1,91 @@
+"""
+Abstract Model Creator Class
+----------------------------
+
+This module provides the template for all model creators.
+"""
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Sequence
+
+from omc3.model.accelerators.accelerator import Accelerator, AccExcitationMode
+from omc3.model.constants import TWISS_AC_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT, TWISS_ADT_DAT
+
+
+class ModelCreator(ABC):
+
+    @classmethod
+    @abstractmethod
+    def get_correction_check_script(cls, accel: Accelerator, corr_file: str, chrom: bool) -> str:
+        """ Returns the madx-script used to verify global corrections.
+        This script should create twissfiles for before (``twiss_no.dat``) and after (``twiss_corr.dat``)
+        correction.
+
+        Args:
+            accel (Accelerator): Accelerator Instance
+            corr_file (str): File containing the corrections (madx-readable)
+            chrom (bool): Flag for chromatic corrections deltapm and deltapp
+
+        Returns:
+            madx-script used to verify global corrections
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_madx_script(cls, accel: Accelerator) -> str:
+        """ Returns the madx-script used to create the model (directory).
+
+        Args:
+            accel (Accelerator): Accelerator Instance
+
+        Returns:
+            madx-script used to used to create the model
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def prepare_run(cls, accel: Accelerator):
+        """ Prepares the model-creation-madx-run.
+        I.e. checks that the directories are created, macros and other files are
+        in place.
+        Should also check that all necessary data for model creation is
+        available in the accelerator instance.
+        Called by the ``model_creator.create_accel_and_instance``
+
+        Args:
+            accel (Accelerator): Accelerator Instance
+
+        """
+        pass
+
+    @classmethod
+    def check_run_output(cls, accel: Accelerator):
+        """ Checks that the model-creation-madx-run was successful.
+        I.e. checks that the directories are created, macros and other files are
+        in place. Checks accelerator instance.
+        Called by the ``model_creator.create_accel_and_instance``
+
+        Args:
+            accel (Accelerator): Accelerator Instance
+
+        """
+        # These are the default files for most model creators for now.
+        to_check = [TWISS_DAT, TWISS_ELEMENTS_DAT]
+        if accel.excitation == AccExcitationMode.ACD:
+            to_check += [TWISS_AC_DAT]
+        elif accel.excitation == AccExcitationMode.ADT:
+            to_check += [TWISS_ADT_DAT]
+        cls._check_files_exist(accel.model_dir, to_check)
+
+    @staticmethod
+    def _check_files_exist(dir_: Path, files: Sequence[str]):
+        """ Convenience function to loop over files and raise an IOError if they
+        do not exist. """
+        for out_file in files:
+            file_path = dir_ / out_file
+            if not file_path.exists():
+                raise IOError(f"Model Creation Failed. "
+                              f"The file '{file_path}' was not created.")
+

--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import tfs
 
-from omc3.model.accelerators.accelerator import AccExcitationMode, AcceleratorDefinitionError, Accelerator
+from omc3.model.accelerators.accelerator import AccExcitationMode, AcceleratorDefinitionError
 from omc3.model.accelerators.lhc import Lhc
 from omc3.model.constants import (B2_ERRORS_TFS, B2_SETTINGS_MADX,
                                   ERROR_DEFFS_TXT, GENERAL_MACROS,

--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -7,27 +7,34 @@ This module provides convenience functions for model creation of the ``LHC``.
 import logging
 import shutil
 from pathlib import Path
+from typing import List
 
 import numpy as np
 import pandas as pd
 import tfs
-
-from omc3.model.accelerators.accelerator import AccExcitationMode, AcceleratorDefinitionError
+from omc3.model.accelerators.accelerator import AcceleratorDefinitionError, AccExcitationMode
 from omc3.model.accelerators.lhc import Lhc
-from omc3.model.constants import (B2_ERRORS_TFS, B2_SETTINGS_MADX,
-                                  ERROR_DEFFS_TXT, GENERAL_MACROS,
-                                  LHC_MACROS, MACROS_DIR,
-                                  TWISS_AC_DAT, TWISS_ADT_DAT,
-                                  TWISS_BEST_KNOWLEDGE_DAT, TWISS_DAT,
-                                  TWISS_ELEMENTS_BEST_KNOWLEDGE_DAT,
-                                  TWISS_ELEMENTS_DAT)
+from omc3.model.constants import (
+    B2_ERRORS_TFS,
+    B2_SETTINGS_MADX,
+    ERROR_DEFFS_TXT,
+    GENERAL_MACROS,
+    LHC_MACROS,
+    MACROS_DIR,
+    TWISS_AC_DAT,
+    TWISS_ADT_DAT,
+    TWISS_BEST_KNOWLEDGE_DAT,
+    TWISS_DAT,
+    TWISS_ELEMENTS_BEST_KNOWLEDGE_DAT,
+    TWISS_ELEMENTS_DAT,
+)
 from omc3.model.model_creators.abstract_model_creator import ModelCreator
 from omc3.utils import iotools
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _b2_columns():
+def _b2_columns() -> List[str]:
     cols_outer = [f"{KP}{num}{S}L" for KP in ("K", "P") for num in range(21) for S in ("", "S")]
     cols_middle = ["DX", "DY", "DS", "DPHI", "DTHETA", "DPSI", "MREX", "MREY", "MREDX", "MREDY",
                    "AREX", "AREY", "MSCALX", "MSCALY", "RFM_FREQ", "RFM_HARMON", "RFM_LAG"]
@@ -35,19 +42,18 @@ def _b2_columns():
 
 
 class LhcModelCreator(ModelCreator):
-
     @classmethod
     def get_madx_script(cls, accel: Lhc) -> str:  # nominal
         use_acd = "1" if (accel.excitation == AccExcitationMode.ACD) else "0"
         use_adt = "1" if (accel.excitation == AccExcitationMode.ADT) else "0"
         madx_script = accel.get_base_madx_script()
-        madx_script +=(
+        madx_script += (
             f"exec, do_twiss_monitors(LHCB{accel.beam}, '{accel.model_dir / TWISS_DAT}', {accel.dpp});\n"
             f"exec, do_twiss_elements(LHCB{accel.beam}, '{accel.model_dir / TWISS_ELEMENTS_DAT}', {accel.dpp});\n"
         )
         if accel.excitation != AccExcitationMode.FREE or accel.drv_tunes is not None:
             # allow user to modify script and enable excitation, if driven tunes are given
-            madx_script +=(
+            madx_script += (
                 f"use_acd={use_acd};\nuse_adt={use_adt};\n"
                 f"if(use_acd == 1){{\n"
                 f"exec, twiss_ac_dipole({accel.nat_tunes[0]}, {accel.nat_tunes[1]}, {accel.drv_tunes[0]}, {accel.drv_tunes[1]}, {accel.beam}, '{accel.model_dir / TWISS_AC_DAT}', {accel.dpp});\n"
@@ -58,58 +64,73 @@ class LhcModelCreator(ModelCreator):
         return madx_script
 
     @classmethod
-    def get_correction_check_script(cls, accel: Lhc, corr_file: str = "changeparameters_couple.madx", chrom: bool = False) -> str:
+    def get_correction_check_script(
+        cls, accel: Lhc, corr_file: str = "changeparameters_couple.madx", chrom: bool = False
+    ) -> str:
         madx_script = accel.get_base_madx_script()
         madx_script += (
             f"exec, do_twiss_monitors_and_ips(LHCB{accel.beam}, '{accel.model_dir / 'twiss_no.dat'!s}', 0.0);\n"
             f"call, file = '{corr_file}';\n"
-            f"exec, do_twiss_monitors_and_ips(LHCB{accel.beam}, '{accel.model_dir / 'twiss_cor.dat'!s}', 0.0);\n")
+            f"exec, do_twiss_monitors_and_ips(LHCB{accel.beam}, '{accel.model_dir / 'twiss_cor.dat'!s}', 0.0);\n"
+        )
         if chrom:
-            madx_script +=(
+            madx_script += (
                 f"exec, do_twiss_monitors_and_ips(LHCB{accel.beam}, '{accel.model_dir / 'twiss_cor_dpm.dat'}', %DELTAPM);\n"
                 f"exec, do_twiss_monitors_and_ips(LHCB{accel.beam}, '{accel.model_dir / 'twiss_cor_dpp.dat'}', %DELTAPP);\n"
             )
         return madx_script
 
     @classmethod
-    def prepare_run(cls, accel: Lhc):
+    def prepare_run(cls, accel: Lhc) -> None:
         cls.check_accelerator_instance(accel)
+        LOGGER.debug("Preparing model creation structure")
         macros_path = accel.model_dir / MACROS_DIR
         iotools.create_dirs(macros_path)
+
+        LOGGER.debug("Copying macros to model directory")
         lib_path = Path(__file__).parent.parent / "madx_macros"
         shutil.copy(lib_path / GENERAL_MACROS, macros_path / GENERAL_MACROS)
         shutil.copy(lib_path / LHC_MACROS, macros_path / LHC_MACROS)
+
         if accel.energy is not None:
+            LOGGER.debug("Copying B2 error files for given energy in model directory")
             core = f"{int(accel.energy * 1000):04d}"
             error_dir_path = accel.get_lhc_error_dir()
             shutil.copy(error_dir_path / f"{core}GeV.tfs", accel.model_dir / ERROR_DEFFS_TXT)
-            shutil.copy(error_dir_path / "b2_errors_settings" / f"beam{accel.beam}_{core}GeV.madx",
-                        accel.model_dir / B2_SETTINGS_MADX)
+            shutil.copy(
+                error_dir_path / "b2_errors_settings" / f"beam{accel.beam}_{core}GeV.madx",
+                accel.model_dir / B2_SETTINGS_MADX,
+            )
             b2_table = tfs.read(error_dir_path / f"b2_errors_beam{accel.beam}.tfs", index="NAME")
-            gen_df = pd.DataFrame(data=np.zeros((b2_table.index.size, len(_b2_columns()))),
-                                  index=b2_table.index, columns=_b2_columns())
+            gen_df = pd.DataFrame(
+                data=np.zeros((b2_table.index.size, len(_b2_columns()))),
+                index=b2_table.index,
+                columns=_b2_columns(),
+            )
             gen_df["K1L"] = b2_table.loc[:, f"K1L_{core}"].to_numpy()
-            tfs.write(accel.model_dir / B2_ERRORS_TFS, gen_df,
-                      headers_dict={"NAME": "EFIELD", "TYPE": "EFIELD"}, save_index="NAME")
+            tfs.write(
+                accel.model_dir / B2_ERRORS_TFS,
+                gen_df,
+                headers_dict={"NAME": "EFIELD", "TYPE": "EFIELD"},
+                save_index="NAME",
+            )
 
     @staticmethod
-    def check_accelerator_instance(accel: Lhc):
+    def check_accelerator_instance(accel: Lhc) -> None:
         accel.verify_object()  # should have been done anyway, but cannot hurt (jdilly)
 
         # Creator specific checks
         if accel.model_dir is None:
             raise AcceleratorDefinitionError(
-                "The accelerator definition is incomplete: "
-                "Model directory (the output directory) is not given."
+                "The accelerator definition is incomplete: model directory (outputdir option) was not given."
             )
 
         if accel.modifiers is None or not len(accel.modifiers):
             raise AcceleratorDefinitionError(
-                "The accelerator definition is incomplete: "
-                "No modifiers could be found."
+                "The accelerator definition is incomplete: no modifiers could be found."
             )
 
-        # hint, if modifiers are given as absolute paths: `path / abs_path` returns `abs_path`  (jdilly)
+        # hint: if modifiers are given as absolute paths: `path / abs_path` returns `abs_path`  (jdilly)
         inexistent_modifiers = [m for m in accel.modifiers if not (accel.model_dir / m).exists()]
         if len(inexistent_modifiers):
             raise AcceleratorDefinitionError(
@@ -119,11 +140,11 @@ class LhcModelCreator(ModelCreator):
 
 
 class LhcBestKnowledgeCreator(LhcModelCreator):
-    EXTRACTED_MQTS_FILENAME = 'extracted_mqts.str'
-    CORRECTIONS_FILENAME = 'corrections.madx'
+    EXTRACTED_MQTS_FILENAME: str = "extracted_mqts.str"
+    CORRECTIONS_FILENAME: str = "corrections.madx"
 
     @classmethod
-    def get_madx_script(cls, accel: Lhc):
+    def get_madx_script(cls, accel: Lhc) -> str:
         if accel.excitation is not AccExcitationMode.FREE:
             raise AcceleratorDefinitionError("Don't set ACD or ADT for best knowledge model.")
         if accel.energy is None:
@@ -142,13 +163,12 @@ class LhcBestKnowledgeCreator(LhcModelCreator):
         return madx_script
 
     @classmethod
-    def check_run_output(cls, accel: Lhc):
-        to_check = [TWISS_BEST_KNOWLEDGE_DAT, TWISS_ELEMENTS_BEST_KNOWLEDGE_DAT]
-        cls._check_files_exist(accel.model_dir, to_check)
+    def check_run_output(cls, accel: Lhc) -> None:
+        files_to_check = [TWISS_BEST_KNOWLEDGE_DAT, TWISS_ELEMENTS_BEST_KNOWLEDGE_DAT]
+        cls._check_files_exist(accel.model_dir, files_to_check)
 
 
 class LhcCouplingCreator(LhcModelCreator):
-
     @classmethod
-    def get_madx_script(cls, accel: Lhc):
+    def get_madx_script(cls, accel: Lhc) -> str:
         return cls.get_correction_check_script(accel)

--- a/omc3/model/model_creators/ps_model_creator.py
+++ b/omc3/model/model_creators/ps_model_creator.py
@@ -16,7 +16,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PsModelCreator(ModelCreator):
-
     @classmethod
     def get_madx_script(cls, accel: Ps) -> str:
         madx_script = accel.get_base_madx_script()
@@ -34,13 +33,6 @@ class PsModelCreator(ModelCreator):
         raise NotImplemented("Correction check is not implemented for the Ps model creator yet. ")
 
     @classmethod
-    def prepare_run(cls, accel: Ps):
+    def prepare_run(cls, accel: Ps) -> None:
         # get path of file from PS model directory (without year at the end)
-        shutil.copy(
-            accel.get_file("error_deff.txt"),
-            accel.model_dir / ERROR_DEFFS_TXT
-        )
-
-
-
-
+        shutil.copy(accel.get_file("error_deff.txt"), accel.model_dir / ERROR_DEFFS_TXT)

--- a/omc3/model/model_creators/ps_model_creator.py
+++ b/omc3/model/model_creators/ps_model_creator.py
@@ -5,18 +5,17 @@ PS Model Creator
 This module provides convenience functions for model creation of the ``PS``.
 """
 import logging
-import os
 import shutil
-from pathlib import Path
 
 from omc3.model.accelerators.accelerator import AccExcitationMode
 from omc3.model.accelerators.ps import Ps
 from omc3.model.constants import ERROR_DEFFS_TXT
+from omc3.model.model_creators.abstract_model_creator import ModelCreator
 
 LOGGER = logging.getLogger(__name__)
 
 
-class PsModelCreator(object):
+class PsModelCreator(ModelCreator):
 
     @classmethod
     def get_madx_script(cls, accel: Ps) -> str:
@@ -30,22 +29,9 @@ class PsModelCreator(object):
         madx_script += madx_template % replace_dict
         return madx_script
 
-    # TODO: Remove when Response Creation implemented (just here for reference) jdilly, 2021
-    # @classmethod
-    # def _prepare_fullresponse(cls, instance, output_path):
-    #     iterate_template = instance.get_file("template.iterate.madx").read_text()
-    #     replace_dict = {
-    #         "FILES_DIR": str(instance.get_dir()),
-    #         "OPTICS_PATH": instance.modifiers,
-    #         "PATH": output_path,
-    #         "KINETICENERGY": instance.energy,
-    #         "NAT_TUNE_X": instance.nat_tunes[0],
-    #         "NAT_TUNE_Y": instance.nat_tunes[1],
-    #         "DRV_TUNE_X": "",
-    #         "DRV_TUNE_Y": "",
-    #     }
-    #     output_file = output_path / JOB_ITERATE_MADX
-    #     output_file.write_text(iterate_template % replace_dict)
+    @classmethod
+    def get_correction_check_script(cls, accel: Ps, corr_file: str, chrom: bool) -> str:
+        raise NotImplemented("Correction check is not implemented for the Ps model creator yet. ")
 
     @classmethod
     def prepare_run(cls, accel: Ps):
@@ -54,6 +40,7 @@ class PsModelCreator(object):
             accel.get_file("error_deff.txt"),
             accel.model_dir / ERROR_DEFFS_TXT
         )
+
 
 
 

--- a/omc3/model/model_creators/psbooster_model_creator.py
+++ b/omc3/model/model_creators/psbooster_model_creator.py
@@ -9,10 +9,10 @@ import shutil
 from omc3.model.accelerators.accelerator import AccExcitationMode
 from omc3.model.accelerators.psbooster import Psbooster
 from omc3.model.constants import ERROR_DEFFS_TXT
-from pathlib import Path
+from omc3.model.model_creators.abstract_model_creator import ModelCreator
 
 
-class PsboosterModelCreator(object):
+class PsboosterModelCreator(ModelCreator):
 
     @classmethod
     def get_madx_script(cls, accel: Psbooster) -> str:
@@ -26,6 +26,10 @@ class PsboosterModelCreator(object):
         madx_template = accel.get_file("twiss.mask").read_text()
         madx_script += madx_template % replace_dict
         return madx_script
+
+    @classmethod
+    def get_correction_check_script(cls, accel: Psbooster, corr_file: str, chrom: bool) -> str:
+        raise NotImplemented("Correction check is not implemented for the PsBooster model creator yet. ")
 
     @classmethod
     def prepare_run(cls, accel: Psbooster):

--- a/omc3/model/model_creators/psbooster_model_creator.py
+++ b/omc3/model/model_creators/psbooster_model_creator.py
@@ -13,7 +13,6 @@ from omc3.model.model_creators.abstract_model_creator import ModelCreator
 
 
 class PsboosterModelCreator(ModelCreator):
-
     @classmethod
     def get_madx_script(cls, accel: Psbooster) -> str:
         madx_script = accel.get_base_madx_script()
@@ -29,11 +28,12 @@ class PsboosterModelCreator(ModelCreator):
 
     @classmethod
     def get_correction_check_script(cls, accel: Psbooster, corr_file: str, chrom: bool) -> str:
-        raise NotImplemented("Correction check is not implemented for the PsBooster model creator yet. ")
+        raise NotImplemented(
+            "Correction check is not implemented for the PsBooster model creator yet. "
+        )
 
     @classmethod
     def prepare_run(cls, accel: Psbooster):
         shutil.copy(
-            accel.get_file(f"error_deff_ring{accel.ring}.txt"),
-            accel.model_dir / ERROR_DEFFS_TXT
+            accel.get_file(f"error_deff_ring{accel.ring}.txt"), accel.model_dir / ERROR_DEFFS_TXT
         )

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -139,8 +139,9 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
                log_file=opt.logfile,
                cwd=opt.outputdir)
 
-    # Return accelerator instance
+    # Check output and return accelerator instance
     accel_inst.model_dir = opt.outputdir
+    creator.check_run_output(accel_inst)
     return accel_inst
 
 

--- a/omc3/plotting/utils/colors.py
+++ b/omc3/plotting/utils/colors.py
@@ -60,7 +60,7 @@ def change_color_brightness(color, amount=0.5):
         c = colorsys.rgb_to_hls(*mc.ColorConverter().to_rgb(c))  # matplotlib 1.5
     except AttributeError:
         c = colorsys.rgb_to_hls(*mc.to_rgb(c))  # matplotlib > 2
-    return colorsys.hls_to_rgb(c[0], 1-amount * (1-c[1]), c[2])
+    return colorsys.hls_to_rgb(c[0], max(0, min(1, amount * c[1])), c[2])
 
 
 def change_ebar_alpha_for_line(ebar, alpha):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,18 @@ def model_inj_beam2(request, tmp_path_factory):
     return tmp_model(tmp_path_factory, beam=2, id_='inj')
 
 
+@pytest.fixture(scope="module")
+def model_25cm_beam1(request, tmp_path_factory):
+    """ Fixture for 25cm beam 1 model"""
+    return tmp_model(tmp_path_factory, beam=1, id_='25cm')
+
+
+@pytest.fixture(scope="module")
+def model_25cm_beam2(request, tmp_path_factory):
+    """ Fixture for 25cm beam 2 model"""
+    return tmp_model(tmp_path_factory, beam=2, id_='25cm')
+
+
 def tmp_model(factory, beam: int, id_: str):
     """Creates a temporary model directory based on the input/models/model_inj_beam#
     but with the addition of a macros/ directory containing the macros from
@@ -88,4 +100,5 @@ def tmp_model(factory, beam: int, id_: str):
         year="2018",
         accel="lhc",
         energy=0.45 if id_ == 'inj' else 6.5,
+        driven_excitation=None if id_ == 'inj' else 'acd'
     )

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -170,9 +170,11 @@ def test_lhc_creation_modifier_nonexistent(tmp_path):
 @pytest.mark.basic
 def test_lhc_creation_relative_modeldir_path(request, tmp_path):
     os.chdir(tmp_path)  # switch cwd to tmp_path
-    model_dir = Path('test_model')
-    model_dir.mkdir()
-    shutil.copy(COMP_MODEL / "opticsfile.24_ctpps2", model_dir / "opticsfile.24_ctpps2")
+    model_dir_relpath = Path('test_model')
+    model_dir_relpath.mkdir()
+
+    optics_file_relpath = Path("opticsfile.24_ctpps2")
+    shutil.copy(COMP_MODEL / optics_file_relpath, model_dir_relpath / optics_file_relpath)
 
     accel_opt = dict(
         accel="lhc",
@@ -182,20 +184,20 @@ def test_lhc_creation_relative_modeldir_path(request, tmp_path):
         nat_tunes=[0.31, 0.32],
         dpp=0.0,
         energy=6.5,
-        modifiers=[Path("opticsfile.24_ctpps2")],
+        modifiers=[optics_file_relpath],
     )
 
     # in case this test fails, create_instance_and_model seems to run,
     # but does not create twiss-files ...
     accel = create_instance_and_model(
-        outputdir=model_dir,
+        outputdir=model_dir_relpath,
         type="nominal",
         logfile=tmp_path / "madx_log.txt",
         **accel_opt
     )
 
     # ... which is then caught here:
-    check_accel_from_dir_vs_options(model_dir, accel_opt, accel,
+    check_accel_from_dir_vs_options(model_dir_relpath, accel_opt, accel,
                                     required_keys=['beam', 'year'])
 
     os.chdir(request.config.invocation_dir)  # return to original cwd

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -229,7 +229,7 @@ def test_lhc_creation_nominal_driven_check_output(model_25cm_beam1):
 # Helper -----------------------------------------------------------------------
 
 def check_accel_from_dir_vs_options(model_dir, accel_options, accel_from_opt, required_keys):
-    # ceation of model from dir tests, that all files are in place
+    # creation via model_from_dir tests that all files are in place:
     accel_from_dir = get_accelerator(
         accel=accel_options['accel'],
         model_dir=model_dir,

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -1,18 +1,18 @@
-import shutil
 import os
+import shutil
 from pathlib import Path
 
 import pytest
-
 from omc3.model.accelerators.accelerator import AcceleratorDefinitionError, AccExcitationMode
+from omc3.model.constants import TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT
 from omc3.model.manager import get_accelerator
 from omc3.model.model_creators.lhc_model_creator import LhcBestKnowledgeCreator, LhcModelCreator
 from omc3.model_creator import create_instance_and_model
-from omc3.model.constants import TWISS_AC_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT, TWISS_ADT_DAT
 
 INPUTS = Path(__file__).parent.parent / "inputs"
 COMP_MODEL = INPUTS / "models" / "25cm_beam1"
-PS_MODEL = Path(__file__).parent.parent.parent / "omc3" / "model" / "accelerators" / "ps" / "2018" / "strength"
+CODEBASE_PATH = Path(__file__).parent.parent.parent / "omc3"
+PS_MODEL = CODEBASE_PATH / "model" / "accelerators" / "ps" / "2018" / "strength"
 
 
 @pytest.mark.basic
@@ -23,17 +23,14 @@ def test_booster_creation_nominal(tmp_path):
         nat_tunes=[4.21, 4.27],
         drv_tunes=[0.205, 0.274],
         driven_excitation="acd",
-        dpp=0.0, energy=0.16,
+        dpp=0.0,
+        energy=0.16,
         modifiers=None,
     )
     accel = create_instance_and_model(
-        type="nominal",
-        outputdir=tmp_path,
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        type="nominal", outputdir=tmp_path, logfile=tmp_path / "madx_log.txt", **accel_opt
     )
-    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel,
-                                    required_keys=['ring'])
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["ring"])
 
 
 @pytest.mark.basic
@@ -43,17 +40,14 @@ def test_ps_creation_nominal(tmp_path):
         nat_tunes=[6.32, 6.29],
         drv_tunes=[0.325, 0.284],
         driven_excitation="acd",
-        dpp=0.0, energy=1.4,
+        dpp=0.0,
+        energy=1.4,
         modifiers=[PS_MODEL / "elements.str", PS_MODEL / "PS_LE_LHC_low_chroma.str"],
     )
     accel = create_instance_and_model(
-        type="nominal",
-        outputdir=tmp_path,
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        type="nominal", outputdir=tmp_path, logfile=tmp_path / "madx_log.txt", **accel_opt
     )
-    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel,
-                                    required_keys=[])
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=[])
 
 
 @pytest.mark.basic
@@ -71,13 +65,9 @@ def test_lhc_creation_nominal_driven(tmp_path):
         modifiers=[COMP_MODEL / "opticsfile.24_ctpps2"],
     )
     accel = create_instance_and_model(
-        outputdir=tmp_path,
-        type="nominal",
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        outputdir=tmp_path, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
-    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel,
-                                    required_keys=['beam', 'year'])
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["beam", "year"])
 
 
 @pytest.mark.basic
@@ -92,13 +82,9 @@ def test_lhc_creation_nominal_free(tmp_path):
         modifiers=[COMP_MODEL / "opticsfile.24_ctpps2"],
     )
     accel = create_instance_and_model(
-        outputdir=tmp_path,
-        type="nominal",
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        outputdir=tmp_path, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
-    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel,
-                                    required_keys=['beam', 'year'])
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["beam", "year"])
 
 
 @pytest.mark.basic
@@ -116,10 +102,7 @@ def test_lhc_creation_best_knowledge(tmp_path):
         modifiers=[COMP_MODEL / "opticsfile.24_ctpps2"],
     )
     accel = create_instance_and_model(
-        outputdir=tmp_path,
-        type="best_knowledge",
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        outputdir=tmp_path, type="best_knowledge", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
 
 
@@ -136,14 +119,11 @@ def test_lhc_creation_relative_modifier_path(tmp_path):
         modifiers=[Path("opticsfile.24_ctpps2")],
     )
     shutil.copy(COMP_MODEL / "opticsfile.24_ctpps2", tmp_path / "opticsfile.24_ctpps2")
+
     accel = create_instance_and_model(
-        outputdir=tmp_path,
-        type="nominal",
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        outputdir=tmp_path, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
-    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel,
-                                    required_keys=['beam', 'year'])
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["beam", "year"])
 
 
 @pytest.mark.basic
@@ -158,21 +138,18 @@ def test_lhc_creation_modifier_nonexistent(tmp_path):
         energy=6.5,
         modifiers=[COMP_MODEL / "opticsfile.non_existent"],
     )
-    with pytest.raises(AcceleratorDefinitionError) as e:
+    with pytest.raises(AcceleratorDefinitionError) as creation_error:
         create_instance_and_model(
-            outputdir=tmp_path,
-            type="nominal",
-            logfile=tmp_path / "madx_log.txt",
-            **accel_opt
+            outputdir=tmp_path, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
         )
-    assert "opticsfile.non_existent" in str(e.value)
+    assert "opticsfile.non_existent" in str(creation_error.value)
 
 
-@pytest.mark.extended
+@pytest.mark.basic
 @pytest.mark.timeout(60)  # madx might get stuck (seen on macos)
 def test_lhc_creation_relative_modeldir_path(request, tmp_path):
     os.chdir(tmp_path)  # switch cwd to tmp_path
-    model_dir_relpath = Path('test_model')
+    model_dir_relpath = Path("test_model")
     model_dir_relpath.mkdir()
 
     optics_file_relpath = Path("opticsfile.24_ctpps2")
@@ -189,23 +166,19 @@ def test_lhc_creation_relative_modeldir_path(request, tmp_path):
         modifiers=[optics_file_relpath],
     )
 
-    # in case this test fails, create_instance_and_model seems to run,
-    # but does not create twiss-files ...
+    # sometimes create_instance_and_model seems to run but does not create twiss-files ...
     accel = create_instance_and_model(
-        outputdir=model_dir_relpath,
-        type="nominal",
-        logfile=tmp_path / "madx_log.txt",
-        **accel_opt
+        outputdir=model_dir_relpath, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
 
     # ... which is then caught here:
-    check_accel_from_dir_vs_options(model_dir_relpath, accel_opt, accel,
-                                    required_keys=['beam', 'year'])
-
+    check_accel_from_dir_vs_options(
+        model_dir_relpath, accel_opt, accel, required_keys=["beam", "year"]
+    )
     os.chdir(request.config.invocation_dir)  # return to original cwd
 
 
-@pytest.mark.extended
+@pytest.mark.basic
 def test_lhc_creation_nominal_driven_check_output(model_25cm_beam1):
     accel = get_accelerator(**model_25cm_beam1)
     LhcModelCreator.check_run_output(accel)
@@ -218,10 +191,10 @@ def test_lhc_creation_nominal_driven_check_output(model_25cm_beam1):
         else:
             shutil.move(file_path, file_path_moved)
 
-        # Run test:
-        with pytest.raises(IOError) as e:
+        # Run test
+        with pytest.raises(FileNotFoundError) as creation_error:
             LhcModelCreator.check_run_output(accel)
-        assert str(dat_file) in str(e.value)
+        assert str(dat_file) in str(creation_error.value)
 
         if file_path_moved.exists():
             shutil.move(file_path_moved, file_path)
@@ -229,12 +202,13 @@ def test_lhc_creation_nominal_driven_check_output(model_25cm_beam1):
 
 # Helper -----------------------------------------------------------------------
 
+
 def check_accel_from_dir_vs_options(model_dir, accel_options, accel_from_opt, required_keys):
     # creation via model_from_dir tests that all files are in place:
     accel_from_dir = get_accelerator(
-        accel=accel_options['accel'],
+        accel=accel_options["accel"],
         model_dir=model_dir,
-        **{k: accel_options[k] for k in required_keys}
+        **{k: accel_options[k] for k in required_keys},
     )
 
     _check_arrays(accel_from_opt.nat_tunes, accel_from_dir.nat_tunes, eps=1e-4, tunes=True)
@@ -261,7 +235,6 @@ def _check_arrays(a_array, b_array, eps=None, tunes=False):
         if eps is None:
             assert a == b
         elif tunes:
-            assert abs((a%1) - (b%1)) <= eps
+            assert abs((a % 1) - (b % 1)) <= eps
         else:
             assert abs(a - b) <= eps
-

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -169,6 +169,7 @@ def test_lhc_creation_modifier_nonexistent(tmp_path):
 
 
 @pytest.mark.extended
+@pytest.mark.timeout(60)  # madx might get stuck (seen on macos)
 def test_lhc_creation_relative_modeldir_path(request, tmp_path):
     os.chdir(tmp_path)  # switch cwd to tmp_path
     model_dir_relpath = Path('test_model')


### PR DESCRIPTION
This is a fix for #302 

In `madx_wrapper`, using absolute paths to call the jobfile and `MAD-X` executable ensures the file is found regardless of having `cwd`-ed into the `outputdir`.