### PR TITLE
Fix PS and PSBooster Driven Tunes

### DIFF
--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -100,10 +100,10 @@ class Ps(Accelerator):
         if best_knowledge:
             raise NotImplementedError(f"Best knowledge model not implemented for accelerator {self.NAME}")
 
-        use_acd = str(int(self.excitation == AccExcitationMode.ACD)),
+        use_acd = self.excitation == AccExcitationMode.ACD
         replace_dict = {
             "FILES_DIR": str(self.get_dir()),
-            "USE_ACD": use_acd,
+            "USE_ACD": str(int(use_acd)),
             "NAT_TUNE_X": self.nat_tunes[0],
             "NAT_TUNE_Y": self.nat_tunes[1],
             "KINETICENERGY": self.energy,

--- a/omc3/model/accelerators/psbooster.py
+++ b/omc3/model/accelerators/psbooster.py
@@ -125,10 +125,10 @@ class Psbooster(Accelerator):
         if best_knowledge:
             raise NotImplementedError(f"Best knowledge model not implemented for accelerator {self.NAME}")
 
-        use_acd = str(int(self.excitation == AccExcitationMode.ACD)),
+        use_acd = self.excitation == AccExcitationMode.ACD
         replace_dict = {
             "FILES_DIR": str(self.get_dir()),
-            "USE_ACD": use_acd,
+            "USE_ACD": str(int(use_acd)),
             "RING": self.ring,
             "NAT_TUNE_X": self.nat_tunes[0],
             "NAT_TUNE_Y": self.nat_tunes[1],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with README.open("r") as docs:
 
 # Dependencies for the package itself
 DEPENDENCIES = [
-    "matplotlib>=3.2.0",
+    "matplotlib>=3.2.0,<3.4.3",  # temporary limitations, try run test!
     "Pillow>=6.2.2",  # not our dependency but older versions crash with mpl
     "numpy>=1.19.0",
     "pandas>=1.0",

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -16,7 +16,7 @@ PS_MODEL = CODEBASE_PATH / "model" / "accelerators" / "ps" / "2018" / "strength"
 
 
 @pytest.mark.basic
-def test_booster_creation_nominal(tmp_path):
+def test_booster_creation_nominal_driven(tmp_path):
     accel_opt = dict(
         accel="psbooster",
         ring=1,
@@ -32,9 +32,24 @@ def test_booster_creation_nominal(tmp_path):
     )
     check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["ring"])
 
-
 @pytest.mark.basic
-def test_ps_creation_nominal(tmp_path):
+def test_booster_creation_nominal_free(tmp_path):
+    accel_opt = dict(
+        accel="psbooster",
+        ring=1,
+        nat_tunes=[4.21, 4.27],
+        dpp=0.0,
+        energy=0.16,
+        modifiers=None,
+    )
+    accel = create_instance_and_model(
+        type="nominal", outputdir=tmp_path, logfile=tmp_path / "madx_log.txt", **accel_opt
+    )
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["ring"])
+
+        
+@pytest.mark.basic
+def test_ps_creation_nominal_driven(tmp_path):
     accel_opt = dict(
         accel="ps",
         nat_tunes=[6.32, 6.29],
@@ -49,7 +64,22 @@ def test_ps_creation_nominal(tmp_path):
     )
     check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=[])
 
+    
+@pytest.mark.basic
+def test_ps_creation_nominal_free(tmp_path):
+    accel_opt = dict(
+        accel="ps",
+        nat_tunes=[6.32, 6.29],
+        dpp=0.0,
+        energy=1.4,
+        modifiers=[PS_MODEL / "elements.str", PS_MODEL / "PS_LE_LHC_low_chroma.str"],
+    )
+    accel = create_instance_and_model(
+        type="nominal", outputdir=tmp_path, logfile=tmp_path / "madx_log.txt", **accel_opt
+    )
+    check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=[]) 
 
+    
 @pytest.mark.basic
 def test_lhc_creation_nominal_driven(tmp_path):
     accel_opt = dict(


### PR DESCRIPTION
A wrongly implemented fix for #284 for the PS and PSBooster prohibited creating models without excitation for these machines.
