### PR TITLE
Update ps.py

### DIFF
--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -79,7 +79,7 @@ class Ps(Accelerator):
         params.add_parameter(
             name="year",
             type=int,
-            required=True,
+            default=2021,
             choices=(2018, 2021),
             help="Year of the optics.",
         )


### PR DESCRIPTION
Temporary fix to use 2021 as default PS year (should be fixed with the fetcher later).
This is basically a fix for the GUI, as it does not submit a year when running optics analysis.
It does not make sense to adapt it to that yet though, because of the rewrite we need to do after the fetcher is implemented.