### PR TITLE
To enable model creation for 2022 if no afs is available.

### DIFF
--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -87,7 +87,7 @@ class LhcModelCreator(ModelCreator):
     def prepare_run(cls, accel: Lhc) -> None:
         if accel.year in ["2018", "2022"]:  # these years should be handled by the fetcher
             symlink_dst = Path(accel.model_dir)/LHC_REPOSITORY_NAME
-            if symlink_dst.exists() is False:
+            if not symlink_dst.exists():
                 LOGGER.debug(f"Symlink destination: {symlink_dst}")
                 symlink_dst.absolute().symlink_to((ACCELERATOR_MODEL_REPOSITORY/f"{accel.year}"))
 

--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -87,10 +87,10 @@ class LhcModelCreator(ModelCreator):
     def prepare_run(cls, accel: Lhc) -> None:
         if accel.year in ["2018", "2022"]:  # these years should be handled by the fetcher
             symlink_dst = Path(accel.model_dir)/LHC_REPOSITORY_NAME
-            LOGGER.debug(f"Symlink destination: {symlink_dst}")
-            if symlink_dst.is_symlink():
-                symlink_dst.unlink()
-            symlink_dst.absolute().symlink_to((ACCELERATOR_MODEL_REPOSITORY/f"{accel.year}"))
+            if symlink_dst.exists() is False:
+                LOGGER.debug(f"Symlink destination: {symlink_dst}")
+                symlink_dst.absolute().symlink_to((ACCELERATOR_MODEL_REPOSITORY/f"{accel.year}"))
+
         cls.check_accelerator_instance(accel)
         LOGGER.debug("Preparing model creation structure")
         macros_path = accel.model_dir / MACROS_DIR


### PR DESCRIPTION
Before it was trying to unlink if it was there but now it skips the linking if the folder is already there. This enables the creation of model if you have manually copied or checked out the repository. 