### PR TITLE
Fix Amplitude error for RDT when using one file

### DIFF
--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -185,7 +185,7 @@ def _fit_rdt_amplitudes(invariants, line_amp, plane, rdt):
     for i, bpm_rdt_data in enumerate(line_amp):
         popt, pcov = curve_fit(fitting, kick_data, bpm_rdt_data, p0=guess[i])
         amps[i] = popt[0]
-        err_amps[i] = np.sqrt(pcov)[0] if np.sqrt(pcov)[0] != np.Inf else 0. # if single file is used, the error is reported as Inf, which is then overwritten with 0
+        err_amps[i] = np.sqrt(pcov)[0] if np.isfinite(np.sqrt(pcov)[0]) else 0. # if single file is used, the error is reported as Inf, which is then overwritten with 0
     return amps, err_amps
 
 

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -184,7 +184,8 @@ def _fit_rdt_amplitudes(invariants, line_amp, plane, rdt):
 
     for i, bpm_rdt_data in enumerate(line_amp):
         popt, pcov = curve_fit(fitting, kick_data, bpm_rdt_data, p0=guess[i])
-        amps[i], err_amps[i] = popt[0], np.sqrt(pcov)[0]
+        amps[i] = popt[0]
+        err_amps[i] = np.sqrt(pcov)[0] if np.sqrt(pcov)[0] != np.Inf else 0. # if single file is used, the error is reported as Inf, which is then overwritten with 0
     return amps, err_amps
 
 


### PR DESCRIPTION
Before, when using a single file, the error on the RDT amplitude would be inf.
Now, if the fitting returns an infinite errors, it is replaced with 0..