### PR TITLE
Bug/355/kmod manifest default error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### 2022-01-10
+
+- Fixed:
+  - Sequences for K-Modulation are now included in PyPi package
+  - Bug fixed where default errors in K-Modulation would not have been taken into account
 #### 2021-07-14 
 _by jdilly_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed:
   - Sequences for K-Modulation are now included in PyPi package
   - Bug fixed where default errors in K-Modulation would not have been taken into account
+  
 #### 2021-07-14 
 _by jdilly_
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include omc3/bin/madx*
 graft omc3/model/accelerators 
 graft omc3/model/madx_macros 
+graft omc3/kmod/sequences 
 graft omc3/plotting/styles

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/run_kmod.py
+++ b/omc3/run_kmod.py
@@ -301,7 +301,7 @@ def convert_betastar_and_waist(bs):
 
 def check_default_error(options, error):
     if options[error] is None:
-        options[error] = DEFAULTS_IP[error] if options.ip is not None else DEFAULTS_CIRCUITS[error]
+        options[error] = DEFAULTS_IP[error] if options.interaction_point is not None else DEFAULTS_CIRCUITS[error]
     return options
 
 

--- a/tests/accuracy/test_kmod.py
+++ b/tests/accuracy/test_kmod.py
@@ -321,6 +321,23 @@ def test_kmod_outputdir_default(tmp_path, _kmod_inputs_path):
     assert (tmp_path / "MQM.7L4.B2-MQY.6L4.B2").exists()
 
 
+@pytest.mark.extended
+def test_kmod_error_default(tmp_path, _kmod_inputs_path):
+    """
+    Test that default errors work.
+    """
+    [shutil.copy(kmod_input, tmp_path) for kmod_input in _kmod_inputs_path.glob("*L4B2*")]
+    analyse_kmod(
+        betastar_and_waist=[200.0, -100.0],
+        working_directory=tmp_path,
+        beam=2,
+        simulation=False,
+        no_sig_digits=True,
+        no_plots=False,
+        circuits=["RQ7.L4B2", "RQ6.L4B2"],
+    )
+
+
 @pytest.fixture()
 def _kmod_inputs_path() -> Path:
     return Path(__file__).parent.parent / "inputs" / "kmod"


### PR DESCRIPTION
Fixes #355 and #356 

Sequences path is now added in MANIFEST.in.
Wrong dict key in default errors was fixed and a test was added.