### PR TITLE
remove S intersection while merging in coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### 2022-04-25
+
+- Fixed:
+  - Only perform index merging on the `NAME` column during coupling calculation. This solves an (at the moment) un-understood issue where some BPMs would have different `S` values in different files.
+
 #### 2022-04-12
 
 - Fixed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -371,13 +371,13 @@ def _joined_frames(input_files: dict) -> tfs.TfsDataFrame:
         merged_transverse_lins_df = pd.merge(
             left=linx,
             right=liny,
-            on=[NAME, S],
+            on=[NAME],
             how="inner",
             sort=False,
         )
         joined_dfs.append(merged_transverse_lins_df)
 
-    partial_merge = partial(pd.merge, how="inner", on=[NAME, S], sort=False)
+    partial_merge = partial(pd.merge, how="inner", on=[NAME], sort=False)
     reduced = reduce(partial_merge, joined_dfs).set_index(NAME)
     reduced = reduced.rename(
         columns={f"{PHASE_ADV}X_X_0": f"{PHASE_ADV}X", f"{PHASE_ADV}Y_Y_0": f"{PHASE_ADV}Y"}
@@ -398,7 +398,7 @@ def rename_col(plane: str, index: int) -> Callable:
     """
 
     def fn(column):
-        if column in [NAME, S]:
+        if column == NAME:
             return column
         return f"{column}_{plane}_{index}"
 


### PR DESCRIPTION
the merge (`pandas.merge` command, not this git merge) performed intersection of `NAME` **and** `S`, removing many BPMs where horizontal and vertical `S` wasn't the same.

fix: remove the intersection along `S`