### PR TITLE
Peak to peak script

### DIFF
--- a/omc3/harpy/constants.py
+++ b/omc3/harpy/constants.py
@@ -28,3 +28,27 @@ COL_NATMU = "NATMU"
 COL_FREQ = "FREQ"
 COL_PHASE = "PHASE"
 COL_ERR = "ERR"
+
+# Defocussing Monitors ---------------------------------------------------------
+LIST_1 = ["BPM.20L3.B", "BPM.18L3.B",
+          "BPM.21R3.B", "BPM.19R3.B",
+          "BPM.20L7.B", "BPM.18L7.B",
+          "BPM.21R7.B", "BPM.19R7.B",
+          "BPM.20R2.B", "BPM.18R2.B",
+          "BPM.21L4.B", "BPM.19L4.B",
+          "BPM.20R6.B", "BPM.18R6.B",
+          "BPM.21L8.B", "BPM.19L8.B",]
+
+LIST_2 = ["BPM.21L3.B", "BPM.19L3.B",
+          "BPM.20R3.B", "BPM.18R3.B",
+          "BPM.21L7.B", "BPM.19L7.B",
+          "BPM.20R7.B", "BPM.18R7.B",
+          "BPM.21R2.B", "BPM.19R2.B",
+          "BPM.20L4.B", "BPM.18L4.B",
+          "BPM.21R6.B", "BPM.19R6.B",
+          "BPM.20L8.B", "BPM.18L8.B",]
+
+DEFOCUSSING_MONITORS = {
+    1: {"X": LIST_1, "Y": LIST_2},
+    2: {"X": LIST_2, "Y": LIST_1}
+}

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -47,27 +47,37 @@ Provides the plotting function for amplitude detuning analysis
 
 - **y_lim** *(float)*: Tune limits in units of tune scale (y-axis).
 """
+from dataclasses import dataclass
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
+from typing import Dict, Sequence
 
 import numpy as np
-from generic_parser import entrypoint, EntryPointParameters
+from generic_parser import entrypoint, EntryPointParameters, DotDict
 from generic_parser.entry_datatypes import DictAsString
 from generic_parser.entrypoint_parser import save_options_to_config
-from matplotlib import colors as mcolors
+from matplotlib import colors as mcolors, MatplotlibDeprecationWarning
 from matplotlib import pyplot as plt
+from matplotlib import rcParams
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+from numpy.typing import ArrayLike
+from scipy import odr
 from tfs.tools import significant_digits
 
 from omc3.definitions import formats
 from omc3.definitions.constants import UNIT_IN_METERS, PLANES
 from omc3.plotting.utils import colors as pcolors, annotations as pannot, style as pstyle
 from omc3.tune_analysis import constants as const, kick_file_modifiers as kick_mod, fitting_tools
+from omc3.tune_analysis.kick_file_modifiers import AmpDetData, FakeOdrOutput
 from omc3.utils import logging_tools
+from omc3.utils.contexts import suppress_warnings
 
 LOG = logging_tools.get_logger(__name__)
 
 NFIT = 100  # Points for the fitting function
+X, Y = PLANES
 
 MANUAL_STYLE_DEFAULT = {
     u'figure.figsize': [9.5, 4],
@@ -92,7 +102,7 @@ def get_params():
         plane=dict(
             help="Plane of the kicks.",
             required=True,
-            choices=PLANES,
+            choices=list(PLANES) + [''.join(PLANES), '3D'],
             type=str,
         ),
         detuning_order=dict(
@@ -153,50 +163,15 @@ def main(opt):
     _save_options(opt)
     _check_opt(opt)
 
-    kick_plane = opt.plane
     figs = {}
 
     _set_plotstyle(opt.manual_style)
-    limits = opt.get_subdict(['x_lim', 'y_lim'])
 
     for tune_plane in PLANES:
-        for corrected in [False, True]:
-            corr_label = "_corrected" if corrected else ""
-            acd_corr = 1
-            if opt.correct_acd and (kick_plane == tune_plane):
-                acd_corr = 0.5
-
-            fig = plt.figure()
-            ax = fig.add_subplot(111)
-
-            for idx, (kick, label) in enumerate(zip(opt.kicks, opt.labels)):
-                kick_df = kick_mod.read_timed_dataframe(kick) if isinstance(kick, str) else kick
-                try:
-                    data_df = kick_mod.get_ampdet_data(kick_df, kick_plane, tune_plane, corrected=corrected)
-                except KeyError:
-                    continue  # should only happen when there is no 'corrected' columns
-
-                odr_fit = kick_mod.get_odr_data(kick_df, kick_plane, tune_plane,
-                                                order=opt.detuning_order, corrected=corrected)
-                data_df, odr_fit = _correct_and_scale(data_df, odr_fit,
-                                                   opt.action_unit, opt.action_plot_unit,
-                                                   10**opt.tune_scale, acd_corr)
-
-                _plot_detuning(ax, data=data_df, label=label, limits=limits,
-                               odr_fit=odr_fit,
-                               color=pcolors.get_mpl_color(idx),
-                               action_unit=opt.action_plot_unit, tune_scale=10**opt.tune_scale)
-
-            ax_labels = const.get_paired_lables(tune_plane, kick_plane, opt.tune_scale)
-            id_str = f"dQ{tune_plane.upper():s}d2J{kick_plane.upper():s}{corr_label:s}"
-            pannot.set_name(id_str, fig)
-            _format_axes(ax, labels=ax_labels, limits=limits)
-
-            if opt.output:
-                output = Path(opt.output)
-                fig.savefig(f'{output.with_suffix("")}_{id_str}{output.suffix}')
-
-            figs[id_str] = fig
+        if opt.plane == "3D":
+            figs.update(_plot_3d(tune_plane, opt))
+        else:
+            figs.update(_plot_2d(tune_plane, opt))
 
     if opt.show:
         plt.show()
@@ -207,31 +182,90 @@ def main(opt):
 # Plotting --------------------------------------------------------------
 
 
-def _get_scaled_odr_label(odr_fit, order, action_unit, tune_scale, magnitude_exponent=3):
-    scale = (tune_scale * (10 ** -magnitude_exponent)) / (UNIT_IN_METERS[action_unit] ** order)
-    str_val, str_std = _get_scaled_labels(odr_fit.beta[order], odr_fit.sd_beta[order], scale)
-    str_mag = ''
-    if magnitude_exponent != 0:
-        str_mag = f'$\cdot$ 10$^{{{magnitude_exponent}}}$'
-    return f'({str_val} $\pm$ {str_std}) {str_mag} m$^{{-{order}}}$'
+# 2D Plots ----------------------------
+
+def _plot_2d(tune_plane, opt):
+    """ 2D Plots per kick-plane and with/without BBQ correction. """
+    figs = {}
+    limits = opt.get_subdict(['x_lim', 'y_lim'])
+    tune_scale = 10 ** opt.tune_scale
+
+    for action_plane in opt.plane:
+        do_acd_correction = opt.correct_acd and (action_plane == tune_plane)
+        for corrected in [False, True]:  # with and without BBQ correction
+            corr_label = "_corrected" if corrected else ""
+
+            fig = plt.figure()
+            ax = fig.add_subplot(111)
+            isempty = True
+
+            for idx, (kick_file, label) in enumerate(zip(opt.kicks, opt.labels)):
+                kick_df = kick_mod.read_timed_dataframe(kick_file) if isinstance(kick_file, str) else kick_file
+                try:
+                    data = kick_mod.get_ampdet_data(kick_df, action_plane, tune_plane, corrected=corrected)
+                except KeyError:
+                    continue  # should only happen when there is no 'corrected' columns
+
+                # Read data from kick_df headers ---
+                odr_fit = kick_mod.get_odr_data(kick_df, action_plane, tune_plane,
+                                                order=opt.detuning_order,
+                                                corrected=corrected)
+
+                # Get label for ODR fit ---
+                odr_label = _get_odr_label(odr_fit,
+                                           tune_plane=tune_plane,
+                                           action_plane=action_plane,
+                                           action_unit=opt.action_unit,
+                                           do_acd_correction=do_acd_correction
+                                           )
+
+                # Scale and Plot ---
+                data, odr_fit = _scale_data(
+                    data, odr_fit,
+                    opt.action_unit, opt.action_plot_unit,
+                    tune_scale
+                )
+                _plot_detuning(
+                    ax, data=data, label=label, limits=limits,
+                    odr_fit=odr_fit, odr_label=odr_label,
+                    color=pcolors.get_mpl_color(idx),
+                )
+                isempty = False
+
+            if isempty:
+                plt.close(fig)  # don't show empty figs
+                continue  # don't save/return empty figures
+
+            if do_acd_correction:
+                ax.text(0.0, 1.02, "* corrected for AC-Dipole.",
+                        fontsize="x-small",
+                        ha="left",
+                        va='bottom',
+                        transform=ax.transAxes,
+                        )
+
+            id_str = f"dQ{tune_plane.upper():s}d2J{action_plane.upper():s}{corr_label:s}"
+            pannot.set_name(id_str, fig)
+
+            ax_labels = (
+                const.get_action_label(action_plane, opt.action_plot_unit),
+                const.get_tune_label(tune_plane, opt.tune_scale)
+            )
+            _format_axes(ax, labels=ax_labels, limits=limits)
+
+            if opt.output:
+                output = Path(opt.output)
+                fig.savefig(f'{output.with_suffix("")}_{id_str}{output.suffix}')
+
+            figs[id_str] = fig
+    return figs
 
 
-def _get_odr_label(odr_fit, action_unit, tune_scale):
-    order = len(odr_fit.beta) - 1
-
-    str_list = [None] * order
-    for o in range(order):
-        str_list[o] = _get_scaled_odr_label(odr_fit, o+1, action_unit, tune_scale,
-                                            magnitude_exponent=const.get_detuning_exponent_for_order(o+1))
-    return ", ".join(str_list)
-
-
-def plot_odr(ax, odr_fit, xmax, action_unit, tune_scale, color=None):
+def plot_odr(ax, odr_fit, xmax, label='', color=None):
     """Adds a quadratic odr fit to axes."""
 
     color = 'k' if color is None else color
     odr_fit.beta[0] = 0   # no need to remove offset, as it is removed from data
-    label = _get_odr_label(odr_fit, action_unit, tune_scale)
 
     # get fits
     order = len(odr_fit.beta) - 1
@@ -245,32 +279,29 @@ def plot_odr(ax, odr_fit, xmax, action_unit, tune_scale, color=None):
     else:
         x = np.linspace(0, xmax, NFIT)
 
-    ax.fill_between(x, f_low(x), f_upp(x), facecolor=mcolors.to_rgba(color, .3))
-    ax.plot(x, f(x), marker="", linestyle='--', color=color, label=label)
+    line = ax.plot(x, f(x), marker="", linestyle='--', color=color, label=label)
+    if color is None:
+        color = line[0].get_color()
+    ax.fill_between(x, f_low(x), f_upp(x), facecolor=mcolors.to_rgba(color, .3), zorder=-10)
+    return color
 
 
-# Main Plot ---
-
-
-def _plot_detuning(ax, data, label, action_unit, tune_scale, color=None, limits=None, odr_fit=None):
+def _plot_detuning(ax: Axes, data: AmpDetData, label: str, color=None,
+                   limits: Dict[str, float] = None, odr_fit: odr.Output=None, odr_label: str =""):
     """Plot the detuning and the ODR into axes."""
-    x_lim = _get_default(limits, 'x_lim', [0, max(data['action']+data['action_err'])])
+    x_lim = _get_default(limits, 'x_lim', [0, max(data.action+data.action_err)])
+    offset = 0
 
     # Plot Fit
-    offset = odr_fit.beta[0]
-    plot_odr(ax, odr_fit, xmax=x_lim[1], action_unit=action_unit, tune_scale=tune_scale, color=color)
+    if odr_fit is not None:
+        offset = odr_fit.beta[0]
+        color = plot_odr(ax, odr_fit, xmax=x_lim[1], color=color, label=odr_label)
 
     # Plot Data
-    data['tune'] -= offset
-    ax.errorbar(x=data['action'], xerr=data['action_err'],
-                y=data['tune'], yerr=data['tune_err'],
+    data.tune -= offset
+    ax.errorbar(x=data.action, xerr=data.action_err,
+                y=data.tune, yerr=data.tune_err,
                 label=label, color=color)
-
-
-def _set_plotstyle(manual_style):
-    mstyle = MANUAL_STYLE_DEFAULT
-    mstyle.update(manual_style)
-    pstyle.set_style("standard", mstyle)
 
 
 def _format_axes(ax, limits, labels):
@@ -291,6 +322,291 @@ def _format_axes(ax, limits, labels):
     ax.figure.tight_layout()  # needs two calls for some reason to look great
 
 
+# 3D Plots ----------------------------
+
+def _plot_3d(tune_plane: str, opt: DotDict):
+    """ 3D Plots for both kick-planes, one plot each with/without BBQ correction. """
+    figs = {}
+    limits = opt.get_subdict(['x_lim', 'y_lim'])
+    tune_scale = 10 ** opt.tune_scale
+
+    for corrected in [False, True]:  # with and without BBQ correction
+        corr_label = "_corrected" if corrected else ""
+
+        # hack to draw spines properly, as their style is
+        # determined by lines
+        rc_save = rcParams.copy()
+        rcParams['lines.linestyle'] = "-"
+        rcParams['lines.marker'] = ""
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+        all_odr_labels = [None] * len(opt.kicks)
+
+        # restore rcParams from before the hack
+        with suppress_warnings(MatplotlibDeprecationWarning):
+            rcParams.update(rc_save)
+        isempty = True
+
+        for idx, (kick_file, label) in enumerate(zip(opt.kicks, opt.labels)):
+            kick_df = kick_mod.read_timed_dataframe(kick_file) if isinstance(kick_file, str) else kick_file
+
+            datas, odr_fits, odr_labels = {}, {}, {}
+            for action_plane in PLANES:
+                do_acd_correction = opt.correct_acd and (action_plane == tune_plane)
+                try:
+                    data = kick_mod.get_ampdet_data(kick_df, action_plane, tune_plane, corrected=corrected)
+                except KeyError as e:
+                    LOG.debug(str(e))
+                    continue  # should only happen when there is no 'corrected' columns
+
+                # Read data from kick_df headers ---
+                odr_fit = kick_mod.get_odr_data(kick_df, action_plane, tune_plane,
+                                                order=opt.detuning_order,
+                                                corrected=corrected)
+
+                # Get label for ODR fit ---
+                odr_label = _get_odr_label(odr_fit,
+                                           tune_plane=tune_plane,
+                                           action_plane=action_plane,
+                                           action_unit=opt.action_unit,
+                                           do_acd_correction=do_acd_correction)
+
+                # Scale ---
+                data, odr_fit = _scale_data(
+                    data, odr_fit,
+                    opt.action_unit, opt.action_plot_unit,
+                    tune_scale
+                )
+
+                # Save ---
+                isempty = False
+                odr_fits[action_plane] = odr_fit
+                odr_labels[action_plane] = odr_label
+                datas[action_plane] = data
+
+            if len(datas) < 2:
+                continue
+
+            _plot_detuning_3d(
+                ax, data=datas, label=label, limits=limits,
+                odr_fits=odr_fits,
+                color=pcolors.get_mpl_color(idx),
+            )
+            all_odr_labels[idx] = odr_labels
+
+        if isempty:
+            plt.close(fig)  # don't show empty figs
+            continue  # don't save/return empty figures
+
+        id_str = f"dQ{tune_plane.upper():s}d2JXY_3D{corr_label:s}"
+        pannot.set_name(id_str, fig)
+
+        ax_labels = (
+            const.get_action_label(PLANES[0], opt.action_plot_unit),
+            const.get_action_label(PLANES[1], opt.action_plot_unit),
+            const.get_tune_label(tune_plane, opt.tune_scale)
+        )
+        _format_axes_3d(ax, ax_labels=ax_labels, limits=limits,
+                        acd=opt.correct_acd, odr_labels=all_odr_labels)
+
+        if opt.output:
+            output = Path(opt.output)
+            fig.savefig(f'{output.with_suffix("")}_{id_str}{output.suffix}')
+
+        figs[id_str] = fig
+    return figs
+
+
+def _plot_detuning_3d(ax: Axes, data: Dict[str, AmpDetData], label: str, color=None, limits=None, odr_fits=None):
+    """ Plot the detuning and the ODR into axes."""
+    offset = 0
+    jx, jx_err = data[X].action, data[X].action_err
+    jy, jy_err = data[Y].action, data[Y].action_err
+    tune, tune_err = data[X].tune, data[X].tune_err
+    x_lim = _get_default(limits, 'x_lim', [0, max(jx+jx_err)])
+    y_lim = _get_default(limits, 'x_lim', [0, max(jy+jy_err)])
+
+    # Plot Fit
+    if odr_fits is not None:
+        offset = odr_fits[X].beta[0]
+        color = plot_odr_3d(ax, odr_fits, xymax=[x_lim[1], y_lim[1]], color=color)
+
+    # Plot Data
+    tune -= offset
+
+    # there is no errorbar3D in mpl it seems
+    # so plotting is done manually.
+    # plot points
+    line = ax.plot(jx, jy, tune, label=label, color=color)
+    if color is None:
+        color = line[0].get_color()
+
+    # plot errorbars
+    for idx in np.arange(0, len(tune)):
+        x, dx = jx[idx], jx_err[idx]
+        y, dy = jy[idx], jy_err[idx]
+        z, dz = tune[idx], tune_err[idx]
+
+        ax.plot([x+dx, x-dx], [y, y], [z, z], ls="-", marker="_", color=color)
+        ax.plot([x, x], [y+dy, y-dy], [z, z], ls="-", marker="_", color=color)
+        ax.plot([x, x], [y, y], [z+dz, z-dz], ls="-", marker="_", color=color)
+
+
+@dataclass
+class FitFuncs:
+    fit: callable
+    upper: callable
+    lower: callable
+
+
+def fit_fun_odr_1d(x, y, q0, qdx, qdy):
+    return q0 + qdx * x + qdy * y
+
+
+def plot_odr_3d(ax: Axes, odr_fits: Dict[str, odr.Output], xymax: Sequence[float], color=None):
+    """Plot the odr fit in 3D."""
+
+    color = 'k' if color is None else color
+    odr_fits[X].beta[0] = 0   # no need to remove offset, as it is removed from data
+    odr_fits[Y].beta[0] = 0   # no need to remove offset, as it is removed from data
+
+    # get fits
+    order = len(odr_fits[X].beta) - 1
+    if order > 1:
+        raise NotImplementedError("ODR fit plots for order > 1 are not implemented.")
+    f = partial(fit_fun_odr_1d,
+                q0=odr_fits[X].beta[0],
+                qdx=odr_fits[X].beta[1],
+                qdy=odr_fits[Y].beta[1])
+    f_low = partial(fit_fun_odr_1d,
+                    q0=odr_fits[X].beta[0]-odr_fits[X].sd_beta[0],
+                    qdx=odr_fits[X].beta[1]-odr_fits[X].sd_beta[1],
+                    qdy=odr_fits[Y].beta[1]-odr_fits[Y].sd_beta[1])
+    f_upp = partial(fit_fun_odr_1d,
+                    q0=odr_fits[X].beta[0]+odr_fits[X].sd_beta[0],
+                    qdx=odr_fits[X].beta[1]+odr_fits[X].sd_beta[1],
+                    qdy=odr_fits[Y].beta[1]+odr_fits[Y].sd_beta[1])
+
+    x = np.linspace(0, xymax[0], 6)
+    y = np.linspace(0, xymax[1], 6)
+    xm, ym = np.meshgrid(x, y)
+
+    # line = ax.plot_surface(xm, ym, f(xm, ym), color=color, label=label, alpha=0.3)
+    frame = ax.plot_wireframe(xm, ym, f(xm, ym), color=color, alpha=0.5)
+    if color is None:
+        color = frame[0].get_color()
+
+    # Plot only the lower and upper boundaries
+    # ax.plot_surface(xm, ym, f_low(xm, ym), color=color, alpha=0.3)
+    # ax.plot_surface(xm, ym, f_upp(xm, ym), color=color, alpha=0.3)
+
+    # Plot the full surface
+    x = np.linspace(0, xymax[0], 2)
+    y = np.linspace(0, xymax[1], 2)
+    plot_cube(ax, x, y, f_low, f_upp, color=color, alpha=0.2, rcount=2, ccount=2)
+    return color
+
+
+def plot_cube(ax: Axes, x: ArrayLike, y: ArrayLike, f_low: callable, f_upp: callable, **kwargs):
+    """Plots a cube-like plot with f_low and f_upp as surfaces. """
+    # lower
+    xm, ym = np.meshgrid(x, y)
+    zm = f_low(xm, ym)
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+    # upper
+    zm = f_upp(xm, ym)
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+    # north
+    xm, ym = np.array([x, x]), y[0]*np.ones([2, len(y)])
+    zm = np.array([f_low(x, y[0]), f_upp(x, y[0])])
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+    # south
+    xm, ym = np.array([x, x]), y[-1]*np.ones([2, len(y)])
+    zm = np.array([f_low(x, y[-1]), f_upp(x, y[-1])])
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+    # east
+    xm, ym = x[0]*np.ones([2, len(x)]), np.array([y, y])
+    zm = np.array([f_low(x[0], y), f_upp(x[0], y)])
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+    # west
+    xm, ym = x[-1]*np.ones([2, len(x)]), np.array([y, y])
+    zm = np.array([f_low(x[-1], y), f_upp(x[-1], y)])
+    ax.plot_surface(xm, ym, zm, **kwargs)
+
+
+def _format_axes_3d(
+        ax: Axes, limits: Dict[str, float], ax_labels: Sequence[str],
+        acd: bool, odr_labels: Sequence[Dict[str, str]] = None):
+    # labels
+    ax.set_xlabel(ax_labels[0], labelpad=15)
+    ax.set_ylabel(ax_labels[1], labelpad=15)
+    ax.set_zlabel(ax_labels[2], labelpad=10)
+
+    # limits
+    if limits['x_lim'] is not None:
+        limj = limits['x_lim']
+    else:
+        limj = [0, max([ax.get_xlim()[1], ax.get_ylim()[1]])]
+    ax.set_xlim(limj)
+    ax.set_ylim(limj)
+
+    if limits['y_lim'] is not None:
+        ax.set_zlim(limits['y_lim'])
+
+    # pannot.make_top_legend(ax, ncol=2)
+    if acd:
+        ax.text2D(
+            1.4, 0.02, "* corrected for AC-Dipole.",
+            fontsize="x-small",
+            ha="left",
+            va='bottom',
+            transform=ax.transAxes,
+        )
+    h, l = get_labels_with_odr_labels(ax, odr_labels)
+    ax.legend(h, l, loc='upper left', bbox_to_anchor=(1.2, 1.0), prop={'size': 'small'})
+    ax.view_init(azim=45, elev=18)
+    ax.zaxis._axinfo['juggled'] = (1,2,0)  # move tune axis to the other side
+    ax.figure.tight_layout()  # needs two calls for some reason to look great
+
+
+# Labels -----------------------------------------------------------------------
+
+def _get_odr_label(odr_fit: odr.Output, tune_plane: str, action_plane: str,
+                   action_unit: str, do_acd_correction: bool):
+    order = len(odr_fit.beta) - 1
+    str_list = [None] * order
+    for o in range(order):
+         label = _get_scaled_odr_label(
+            odr_fit,
+            order=o+1,
+            action_unit=action_unit,
+            do_acd_correction=do_acd_correction,
+            magnitude_exponent=const.get_detuning_exponent_for_order(o+1)
+         )
+         order_str = f"^{o+1}" if o else ""
+         str_list[o] = f"$Q{order_str}_{{{tune_plane},{action_plane}}}$: {label}"
+    return ", ".join(str_list)
+
+
+def _get_scaled_odr_label(odr_fit, order, action_unit, do_acd_correction, magnitude_exponent=3):
+    """ Returns the label for the ODR fit after scaling to readable units and accounting for AC-Dipole correction."""
+    acd_scale = 0.5 if do_acd_correction else 1
+    str_acd_scale = "$^*$" if do_acd_correction else ""
+
+    scale = acd_scale * (10 ** -magnitude_exponent) / (UNIT_IN_METERS[action_unit] ** order)
+    str_val, str_std = _get_scaled_labels(odr_fit.beta[order], odr_fit.sd_beta[order], scale)
+    str_mag = ''
+    if magnitude_exponent != 0:
+        str_mag = f'$\cdot$ 10$^{{{magnitude_exponent}}}$'
+    return f'({str_val} $\pm$ {str_std}){str_acd_scale} {str_mag} m$^{{-{order}}}$'
+
+
 def _get_scaled_labels(val, std, scale):
     scaled_vas, scaled_std = val*scale, std*scale
     if abs(scaled_std) > 1 or scaled_std == 0:
@@ -298,7 +614,28 @@ def _get_scaled_labels(val, std, scale):
     return significant_digits(scaled_vas, scaled_std)
 
 
+def get_labels_with_odr_labels(ax, odr_labels):
+    h, l = ax.get_legend_handles_labels()
+    if odr_labels is None:
+        return h, l
+
+    empty = Line2D([0], [0], ls='none', marker='', label='')
+    h_new, l_new = [], []
+    for handle, label, odr in zip(h, l, odr_labels):
+        h_new.append(handle)
+        l_new.append(label)
+        if odr is not None:
+            h_new.append(empty)
+            l_new.append("\n".join(odr.values()))
+    return h_new, l_new
+
+
 # Helper -----------------------------------------------------------------------
+
+def _set_plotstyle(manual_style):
+    mstyle = MANUAL_STYLE_DEFAULT
+    mstyle.update(manual_style)
+    pstyle.set_style("standard", mstyle)
 
 
 def _save_options(opt):
@@ -322,17 +659,17 @@ def _get_default(ddict, key, default):
     return ddict[key]
 
 
-def _correct_and_scale(data, odr_fit, action_unit, action_plot_unit, tune_scale, acd_corr):
-    """Corrects data for AC-Dipole and scales to plot-units (y=tune_scale, x=um)."""
-    # scale action units
+def _scale_data(data: AmpDetData, odr_fit: odr.Output,
+                action_unit: str, action_plot_unit: str, tune_scale: float):
+    """Scale data to plot-units (y=tune_scale, x=um)."""
     x_scale = UNIT_IN_METERS[action_unit] / UNIT_IN_METERS[action_plot_unit]
-    data['action'] *= x_scale
-    data['action_err'] *= x_scale
+    data.action *= x_scale
+    data.action_err *= x_scale
 
-    # correct for ac-diple and tune scaling
-    y_scale = acd_corr / tune_scale
-    data['tune'] *= y_scale
-    data['tune_err'] *= y_scale
+    # correct for tune scaling
+    y_scale = 1. / tune_scale
+    data.tune *= y_scale
+    data.tune_err *= y_scale
 
     # same for odr_fit:
     for idx in range(len(odr_fit.beta)):

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -181,10 +181,9 @@ def main(opt):
 
 # Plotting --------------------------------------------------------------
 
-
 # 2D Plots ----------------------------
 
-def _plot_2d(tune_plane, opt):
+def _plot_2d(tune_plane: str, opt: DotDict):
     """ 2D Plots per kick-plane and with/without BBQ correction. """
     figs = {}
     limits = opt.get_subdict(['x_lim', 'y_lim'])
@@ -261,7 +260,7 @@ def _plot_2d(tune_plane, opt):
     return figs
 
 
-def plot_odr(ax, odr_fit, xmax, label='', color=None):
+def plot_odr(ax: Axes, odr_fit: odr.Output, xmax: float, label: str = '', color=None):
     """Adds a quadratic odr fit to axes."""
 
     color = 'k' if color is None else color
@@ -304,7 +303,7 @@ def _plot_detuning(ax: Axes, data: AmpDetData, label: str, color=None,
                 label=label, color=color)
 
 
-def _format_axes(ax, limits, labels):
+def _format_axes(ax: Axes, limits: Dict[str, Sequence[float]], labels: Sequence[str]):
     # labels
     ax.set_xlabel(labels[0])
     ax.set_ylabel(labels[1])
@@ -579,6 +578,7 @@ def _format_axes_3d(
 
 def _get_odr_label(odr_fit: odr.Output, tune_plane: str, action_plane: str,
                    action_unit: str, do_acd_correction: bool):
+    """ Returns the label for the ODR fit, nicely formatted and scaled. """
     order = len(odr_fit.beta) - 1
     str_list = [None] * order
     for o in range(order):

--- a/omc3/scripts/check_peak_to_peak.py
+++ b/omc3/scripts/check_peak_to_peak.py
@@ -1,0 +1,199 @@
+"""
+Check Peak-to-Peak
+------------------
+
+Performs a quick check on the peak-to-peak of the given
+turn-by-turn files.
+"""
+import numbers
+import re
+from pathlib import Path
+from typing import Union, Sequence, Dict
+
+import numpy as np
+import pandas as pd
+import turn_by_turn as tbt
+from generic_parser import EntryPointParameters, entrypoint
+from turn_by_turn.utils import generate_average_tbtdata
+
+from omc3.definitions.constants import PLANES, UNIT_IN_METERS
+from omc3.harpy.constants import DEFOCUSSING_MONITORS
+from omc3.hole_in_one import HARPY_DEFAULTS
+from omc3.tbt_converter import _file_name_without_sdds
+from omc3.utils.logging_tools import get_logger
+
+LOG = get_logger(__name__)
+
+
+def get_params():
+    params = EntryPointParameters()
+    params.add_parameter(name="files", required=True, nargs='+',
+                         help="Files for analysis")
+    params.add_parameter(name="beam", type=int,
+                         help="LHC beam number.")
+    params.add_parameter(name="tbt_datatype",
+                         default=HARPY_DEFAULTS["tbt_datatype"],
+                         choices=list(tbt.io.DATA_READERS.keys()),
+                         help="Choose the datatype from which to import.")
+    params.add_parameter(name="unit", type=str, default="mm",
+                         choices=list(UNIT_IN_METERS.keys()),
+                         help="Unit in which to log the peak-to-peak values.")
+    params.add_parameter(name="input_unit", type=str, default="mm",
+                         choices=list(UNIT_IN_METERS.keys()),
+                         help="Unit of the tbt input data.")
+    return params
+
+
+@entrypoint(get_params(), strict=True)
+def peak_to_peak(opt):
+    """Main function to log peak-to-peak values from SDDS files.
+
+    *--Required--*
+
+    - **files**:
+
+        Files for analysis
+
+
+    *--Optional--*
+
+    - **beam** *(int)*:
+
+        LHC beam number.
+
+
+    - **input_unit** *(str)*:
+
+        Unit of the tbt input data.
+
+        choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
+
+        default: ``mm``
+
+
+    - **tbt_datatype**:
+
+        Choose the datatype from which to import.
+
+        choices: ``['lhc', 'iota', 'esrf', 'ptc', 'trackone']``
+
+        default: ``lhc``
+
+
+    - **unit** *(str)*:
+
+        Unit in which to log the peak-to-peak values.
+
+        choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
+
+        default: ``mm``
+
+    """
+    for input_file in opt.files:
+        LOG.debug(f"Calculating pk2pk for file: {input_file}")
+        input_file = Path(input_file)
+        name = _file_name_without_sdds(input_file)
+        beam = _get_beam(opt.beam, filename=name)
+        bpms = DEFOCUSSING_MONITORS[beam]
+        tbt_data = tbt.read_tbt(input_file, datatype=opt.tbt_datatype)
+        for bunch, positions in zip(tbt_data.bunch_ids, tbt_data.matrices):
+            LOG.debug(f"Bunch: {bunch}")
+            pk2pk = get_pk2pk(positions, bpms)
+            _log_pk2pk(pk2pk, name, bunch, opt.input_unit, opt.unit)
+
+        if tbt_data.nbunches > 1:
+            tbt_data_av = generate_average_tbtdata(tbt_data)
+            positions = tbt_data_av.matrices[0]
+            pk2pk = get_pk2pk(positions, bpms)
+            _log_pk2pk(pk2pk, name, '(average)', opt.input_unit, opt.unit)
+
+
+def get_pk2pk(data: tbt.TransverseData, bpms: Dict[str, Sequence[str]]) -> Dict[str, float]:
+    """Get the filtered peak-to-peak from the current tbt-data from the given bpms."""
+    pk2pk = {p: None for p in PLANES}
+    for plane in PLANES:
+        positions: pd.DataFrame = getattr(data, plane)
+
+        # Get only the desired BPMs
+        mask = _get_index_mask(positions.index, bpms[plane])
+        if not any(mask):
+            LOG.debug(f"None of the required pk2pk BPMs are present "
+                      f"in plane {plane} of the current tbt data.")
+            continue
+        positions = positions.loc[mask, :]
+
+        # Filter BPMs with exact zeros
+        exact_zeros = get_exact_zero_mask(positions)
+        if all(exact_zeros):
+            LOG.debug(f"Exact zeros found in all BPMs "
+                      f"in plane {plane} of the current tbt data.")
+            continue
+        positions = positions.loc[~exact_zeros, :]
+
+        # Calculate peak-to-peak from remaining
+        pk2pk_per_bpm = positions.max(axis='columns') - positions.min(axis='columns')
+        pk2pk[plane] = pk2pk_per_bpm.mean()
+    return pk2pk
+
+
+def _log_pk2pk(pk2pk: Dict[str, float], name: str = None, other: Union[int, str] = None, input_unit: str = "m", unit: str = "mm"):
+    other_str = other if isinstance(other, str) else ""
+    if isinstance(other, numbers.Integral):
+        other_str = f", Bunch {other: d}"
+
+    unit_scale = UNIT_IN_METERS[input_unit] / UNIT_IN_METERS[unit]
+    pk2pk_str = " ".join(f"   {plane}: {p2p*unit_scale:.4f} {unit}" for plane, p2p in pk2pk.items() if p2p is not None)
+    pk2pk_warn = ", ".join(plane for plane, p2p in pk2pk.items() if p2p is None)
+
+    LOG.info(f"Peak-to-Peak values for {name}{other_str}: {pk2pk_str} ")
+    if pk2pk_warn:
+        LOG.warning(f"No Peak-to-Peak values for {name} {other_str} in planes {pk2pk_warn}")
+
+
+# Utils ------------------------------------------------------------------------
+
+def _get_beam(beam: int, filename: Union[Path, str]) -> int:
+    """Get the beam from either given option or try to get it from the filename."""
+    if beam is None:
+        try:
+            beam = infer_beam_from_filename(filename)
+        except AttributeError:
+            raise NameError(f"No beam option given and could not infer beam from filename {filename}. "
+                            f"Please provide a beam number. ")
+    LOG.debug(f"Assuming Beam {beam}")
+    return beam
+
+
+def _get_index_mask(index: pd.Index, bpms: Sequence[str]) -> Sequence[bool]:
+    """Get the boolean mask for the index/columns of the desired bpms."""
+    mask = np.zeros_like(index, dtype=bool)
+    not_found_bpms = []
+    for bpm in bpms:
+        new_mask = index.str.startswith(bpm)
+        if any(new_mask):
+            mask |= new_mask
+        else:
+            not_found_bpms.append(bpm)
+
+    if len(not_found_bpms):
+        LOG.debug(f"Some BPMs were not found in current tbt data: {not_found_bpms}")
+    return mask
+
+
+def get_exact_zero_mask(positions: pd.DataFrame):
+    """Finds bpms containing exact zeros in the data."""
+    exact_zeros = (positions == 0).any(axis='columns')
+    if any(exact_zeros):
+        LOG.debug(f"Exact zeros found in bpms {positions.columns[exact_zeros]}")
+    return exact_zeros
+
+
+def infer_beam_from_filename(filename: Union[str, Path]) -> int:
+    """Regex to find 'beam\\d' in filename and return the beam."""
+    return int(re.search(r"Beam(\d)", str(filename), flags=re.IGNORECASE).group(1))
+
+
+# Script Mode ------------------------------------------------------------------
+
+if __name__ == '__main__':
+    peak_to_peak()

--- a/omc3/tune_analysis/constants.py
+++ b/omc3/tune_analysis/constants.py
@@ -4,8 +4,10 @@ Constants
 
 Specific constants and helpers to be used in ``tune_analysis``, to help with consistency.
 """
-from typing import Tuple
+from dataclasses import dataclass
+from typing import Tuple, Sequence
 
+import pandas as pd
 from omc3.definitions.constants import PLANE_TO_NUM
 from omc3.optics_measurements.constants import ACTION, ERR, EXT, KICK_NAME, NAT_TUNE, RES, TIME
 
@@ -21,7 +23,9 @@ BBQ: str = "BBQ"
 
 def get_timber_bbq_key(plane: str, beam: int) -> str:
     """ Key to extract bbq from timber. """
-    return f"lhc.bofsu:eigen_freq_{PLANE_TO_NUM[plane] :d}_b{beam:d}".upper()
+    # return f"lhc.bofsu:eigen_freq_{PLANE_TO_NUM[plane]:d}_b{beam:d}".upper()  # pre run 3
+    # return f"BFC.LHC:TuneFBAcq:TUNEB{beam:d}{PLANE_TO_HV[plane]}"  # contains less data
+    return f"LHC.BQBBQ.CONTINUOUS_HS.B{beam:d}:EIGEN_FREQ_{PLANE_TO_NUM[plane]:d}"
 
 
 def get_kick_out_name() -> str:
@@ -30,6 +34,22 @@ def get_kick_out_name() -> str:
 
 def get_bbq_out_name() -> str:
     return f"bbq_ampdet.tfs"
+
+
+@dataclass
+class AmpDetData:
+    tune_plane: str
+    action_plane: str
+    action: pd.Series
+    action_err: pd.Series
+    tune: pd.Series
+    tune_err: pd.Series
+
+
+@dataclass
+class FakeOdrOutput:
+    beta: Sequence[float]
+    sd_beta: Sequence[float]
 
 
 # Kick File Headers ###########################################################
@@ -160,12 +180,19 @@ def get_action_err_col(plane: str) -> str:
 # Plotting #####################################################################
 
 
-def get_paired_lables(tune_plane: str, action_plane: str, tune_scale: int = None) -> Tuple[str, str]:
-    """ Labels for the action/tune plots. """
-    tune_unit = ""
-    if tune_scale:
-        tune_unit = f" \quad [10^{{{tune_scale:d}}}]"
-    return (fr"$2J_{action_plane.lower():s} \quad [\mu m]$", fr"$\Delta Q_{tune_plane.lower():s}{tune_unit}$")
+def get_tune_label(plane: str, scale: int = None) -> str:
+    """ Tune label for the action/tune plots. """
+    unit = ""
+    if scale:
+        unit = f" \quad [10^{{{scale:d}}}]"
+    return fr"$\Delta Q_{plane.lower():s}{unit}$"
+
+
+def get_action_label(plane: str, unit: str) -> str:
+    """ Action label for the action/tune plots. """
+    if unit == "um":
+        unit = r"\mu m"
+    return fr"$2J_{plane.lower():s} \quad [{unit:s}]$"
 
 
 def get_detuning_exponent_for_order(order: int) -> int:

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -86,6 +86,7 @@ def extract_between_times(
 
     # Attempt getting data from NXCALS, which can sometimes need a few retries (yay NXCALS)
     # If Java gives a feign.RetryableException, retry up to MAX_RETRIES times.
+    extract_dict = {}
     for tries in range(MAX_RETRIES + 1):
         try:
             # We use timestamps to avoid any confusion with local time
@@ -99,6 +100,16 @@ def extract_between_times(
             raise IOError("Could not get data from timber!") from e
         else:
             break
+
+    if (not len(extract_dict)  # dict is empty
+            or all(not len(v) for v in extract_dict.values())  # values are empty
+            or all(len(v) == 2 and not len(v[0]) for v in extract_dict.values())  # arrays are empty (size 2 for time/data)
+    ):
+        raise IOError(f"Variables {keys} found but no data extracted in time {t_start.utc_string} - {t_end.utc_string} (UTC).\n"
+                      f"Possible reasons:\n"
+                      f"  - Too small time window.\n"
+                      f"  - Old pytimber version.\n"
+                      f"  - Variable outdated (i.e. no longer logged).")
 
     out_df = tfs.TfsDataFrame()
     for key in keys:

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from io import StringIO
 from logging import NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL  # make them available directly
 
+import numpy as np
 import pandas as pd
 
 DIVIDER = "|"
@@ -208,16 +209,21 @@ class TempStringLogger:
 
 def odr_pprint(printer, odr_out):
     """Logs the odr output results. Adapted from odr_output pretty print."""
-    printer('ODR-Summary:')
-    printer(f'  Beta: {odr_out.beta}')
-    printer(f'  Beta Std Error: {odr_out.sd_beta}')
-    printer(f'  Beta Covariance: {odr_out.cov_beta}')
+    old_opts = np.get_printoptions()
+    np.set_printoptions(precision=2)
+    odr_str = ('\nODR-Summary:\n'
+               f'Beta:\n {odr_out.beta}\n'
+               f'Beta Std Error:\n {odr_out.sd_beta}\n'
+               f'Beta Covariance:\n {odr_out.cov_beta}\n'
+               )
     if hasattr(odr_out, 'info'):
-        printer(f'  Residual Variance: {odr_out.res_var}')
-        printer(f'  Inverse Condition #: {odr_out.inv_condnum}')
-        printer(f'  Reason(s) for Halting:')
+        odr_str += (f'  Residual Variance:\n {odr_out.res_var}\n'
+                    f'  Inverse Condition #:\n {odr_out.inv_condnum}\n'
+                    f'  Reason(s) for Halting:\n')
         for r in odr_out.stopreason:
-            printer(f'    {r}')
+            odr_str += f'    {r}\n'
+    printer(odr_str)
+    np.set_printoptions(**old_opts)
 
 
 def list2str(list_: list) -> str:


### PR DESCRIPTION
After we had some problems yesterday with the pk2pk values in multiturn, I thought that might be helpful.
Strangely, I am not getting exactly the values from the logbook, e.g.

```python
from pathlib import Path

from omc3.scripts.check_peak_to_peak import peak_to_peak
from omc3.utils.logging_tools import get_logger, DEBUG

LOG = get_logger(__name__, level_console=DEBUG)


if __name__ == '__main__':
    base = Path('/user/slops/data/LHC_DATA/OP_DATA/FILL_DATA/7391/BPM')
    files = ['Beam2@BunchTurn@2018_10_30@12_54_03_710.sdds',  'Beam2@BunchTurn@2018_10_30@13_01_28_539.sdds', 'Beam2@BunchTurn@2018_10_30@13_03_01_002.sdds']
    peak_to_peak(files=[base/f for f in files])
```
```
Peak-to-Peak values for Beam2@BunchTurn@2018_10_30@13_01_28_539, Bunch  5:    X: 1.6512 mm    Y: 1.7183 mm
Peak-to-Peak values for Beam2@BunchTurn@2018_10_30@13_01_28_539, Bunch  5:    X: 1.6512 mm    Y: 1.7183 mm
Peak-to-Peak values for Beam2@BunchTurn@2018_10_30@13_01_28_539, Bunch  5:    X: 1.6512 mm    Y: 1.7183 mm
```
```
2018-10-30 12:54:03.710   - 5.0% 5.0% - 0.7265mm 0.7496mm 
2018-10-30 13:01:28.539  - 45.0% 35.0% - 1.635mm 1.6981mm 
2018-10-30 13:03:01.002  - 45.0% 35.0% - 1.6351mm 1.6748mm 
```
https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/3196358

Ideas are welcome! 
I am actually not sure, if such a script is needed in omc3 as it's probably one of those that everyone already has lying around anyway. Thank god I didn't write it from scratch.