### PR TITLE
Plotting style improvements

### DIFF
--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -6,46 +6,92 @@ Provides the plotting function for amplitude detuning analysis
 
 **Arguments:**
 
-*--Required--*
+- **plane** *(str)*:
 
-- **kicks**: Kick files as data frames or tfs files.
+    Plane of the kicks.
 
-- **labels** *(str)*: Labels for the data. Needs to be same length as kicks.
+    choices: ``('X', 'Y')``
 
-- **plane** *(str)*: Plane of the kicks.
-
-  Choices: ``('X', 'Y')``
 
 *--Optional--*
 
-- **action_plot_unit** *(str)*: Unit the action should be plotted in.
+- **action_plot_unit** *(str)*:
 
-  Choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
-  Default: ``um``
-- **action_unit** *(str)*: Unit the action is given in.
+    Unit the action should be plotted in.
 
-  Choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
-  Default: ``m``
-- **correct_acd**: Correct for AC-Dipole kicks.
+    choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
 
-  Action: ``store_true``
-- **detuning_order** *(int)*: Order of the detuning as int. Basically just the order of the applied fit.
+    default: ``um``
 
-  Default: ``1``
-- **manual_style** *(DictAsString)*: Additional plotting style.
 
-  Default: ``{}``
-- **output** *(str)*: Save the amplitude detuning plot here.
+- **action_unit** *(str)*:
 
-- **show**: Show the amplitude detuning plot.
+    Unit the action is given in.
 
-  Action: ``store_true``
-- **tune_scale** *(int)*: Plotting exponent of the tune.
+    choices: ``['km', 'm', 'mm', 'um', 'nm', 'pm', 'fm', 'am']``
 
-  Default: ``-3``
-- **x_lim** *(float)*: Action limits in um (x-axis).
+    default: ``m``
 
-- **y_lim** *(float)*: Tune limits in units of tune scale (y-axis).
+
+- **correct_acd**:
+
+    Correct for AC-Dipole kicks.
+
+    action: ``store_true``
+
+
+- **detuning_order** *(int)*:
+
+    Order of the detuning as int. Basically just the order of the applied
+    fit.
+
+    default: ``1``
+
+
+- **manual_style** *(DictAsString)*:
+
+    Additional style rcParameters which update the set of predefined ones.
+
+    default: ``{}``
+
+
+- **output** *(str)*:
+
+    Save the amplitude detuning plot here. Give filename with extension.
+    An id for the 4 different plots will be added before the suffix.
+
+
+- **plot_styles** *(UnionPathStr)*:
+
+    Plotting styles.
+
+    default: ``['standard', 'amplitude_detuning']``
+
+
+- **show**:
+
+    Show the amplitude detuning plot.
+
+    action: ``store_true``
+
+
+- **tune_scale** *(int)*:
+
+    Plotting exponent of the tune.
+
+    default: ``-3``
+
+
+- **x_lim** *(float)*:
+
+    Action limits in um (x-axis).
+
+
+- **y_lim** *(float)*:
+
+    Tune limits in units of tune scale (y-axis).
+
+
 """
 from collections import OrderedDict
 from functools import partial
@@ -62,10 +108,9 @@ from tfs.tools import significant_digits
 from omc3.definitions import formats
 from omc3.definitions.constants import UNIT_IN_METERS, PLANES
 from omc3.plotting.utils import colors as pcolors, annotations as pannot, style as pstyle
-from omc3.plotting.utils.style import set_style_from_cli_input, PathOrStrOrDictAsString
 from omc3.tune_analysis import constants as const, kick_file_modifiers as kick_mod, fitting_tools
 from omc3.utils import logging_tools
-from omc3.utils.iotools import PathOrStr, UnionPathStr
+from omc3.utils.iotools import UnionPathStr
 
 LOG = logging_tools.get_logger(__name__)
 

--- a/omc3/plotting/plot_bbq.py
+++ b/omc3/plotting/plot_bbq.py
@@ -8,30 +8,67 @@ Provides the plotting function for the extracted and cleaned BBQ data from timbe
 
 *--Required--*
 
-- **input**: BBQ data as data frame or tfs file.
+- **input**:
 
-  Flags: **--in**
+    BBQ data as data frame or tfs file.
+
 
 *--Optional--*
 
-- **interval** *(float)*: x_axis interval that was used in calculations.
+- **interval** *(float)*:
 
-  Flags: **--interval**
-- **kick**: Kick file as data frame or tfs file.
+    x_axis interval that was used in calculations.
 
-- **output** *(str)*: Save figure to this location.
 
-  Flags: **--out**
-- **show**: Show plot.
+- **kick**:
 
-  Action: ``store_true``
-- **two_plots**: Plot two axis into the figure.
+    Kick file as data frame or tfs file.
 
-  Flags: **--two**
-  Action: ``store_true``
-- **x_lim** *(float)*: X-Axis limits. (yyyy-mm-dd HH:mm:ss.mmm)
 
-- **y_lim** *(float)*: Y-Axis limits.
+- **manual_style** *(DictAsString)*:
+
+    Additional style rcParameters which update the set of predefined ones.
+
+    default: ``{}``
+
+
+- **output** *(str)*:
+
+    Save figure to this location.
+
+
+- **plot_styles** *(UnionPathStr)*:
+
+    Which plotting styles to use, either from plotting.styles.*.mplstyles
+    or default mpl.
+
+    default: ``['standard', 'bbq']``
+
+
+- **show**:
+
+    Show plot.
+
+    action: ``store_true``
+
+
+- **two_plots**:
+
+    Plot two axis into the figure.
+
+    action: ``store_true``
+
+
+- **x_lim** *(float)*:
+
+    X-Axis limits. (yyyy-mm-dd HH:mm:ss.mmm)
+
+
+- **y_lim** *(float)*:
+
+    Y-Axis limits.
+    
+
 """
 from collections import OrderedDict
 from contextlib import suppress
@@ -42,7 +79,7 @@ import numpy as np
 from generic_parser import entrypoint, EntryPointParameters
 from generic_parser.entry_datatypes import DictAsString
 from generic_parser.entrypoint_parser import save_options_to_config
-from matplotlib import pyplot as plt, gridspec
+from matplotlib import pyplot as plt
 from matplotlib.ticker import FormatStrFormatter
 from pandas.plotting import register_matplotlib_converters
 
@@ -50,7 +87,6 @@ from omc3 import amplitude_detuning_analysis as ad_ana
 from omc3.definitions import formats
 from omc3.definitions.constants import PLANES
 from omc3.plotting.utils import colors as pcolors, style as pstyle
-from omc3.plotting.utils.style import set_style_from_cli_input, PathOrStrOrDictAsString
 from omc3.tune_analysis import kick_file_modifiers as kick_mod
 from omc3.tune_analysis.constants import (get_mav_window_header, get_used_in_mav_col,
                                           get_bbq_col, get_mav_col)

--- a/omc3/plotting/plot_spectrum.py
+++ b/omc3/plotting/plot_spectrum.py
@@ -122,7 +122,7 @@ one figure is used.
     Which plotting styles to use, either from plotting.styles.*.mplstyles
     or default mpl.
 
-    default: ``['standard']``
+    default: ``['standard', 'spectrum']``
 
 
 - **plot_type**:
@@ -322,7 +322,7 @@ def get_params():
     params.add_parameter(name="plot_styles",
                          type=UnionPathStr,
                          nargs="+",
-                         default=['standard'],
+                         default=['standard', 'spectrum'],
                          help='Which plotting styles to use, either from plotting.styles.*.mplstyles or default mpl.'
                          )
     params.add_parameter(name="manual_style",

--- a/omc3/plotting/plot_spectrum.py
+++ b/omc3/plotting/plot_spectrum.py
@@ -34,76 +34,161 @@ one figure is used.
 
 *--Required--*
 
-- **files**: List of paths to the spectrum files. The files need to be given
-  without their '.lin'/'.amps[xy]','.freqs[xy]' endings. (So usually the path
-  of the TbT-Data file.)
+- **files**:
+
+    List of paths to the spectrum files. The files need to be given
+    without their '.lin'/'.amps[xy]','.freqs[xy]' endings.  (So usually
+    the path of the TbT-Data file.)
 
 
 *--Optional--*
 
-- **amp_limit** *(float)*: All amplitudes <= limit are filtered.
-  This value needs to be at least 0 to filter non-found frequencies.
+- **amp_limit** *(float)*:
 
-  Default: ``0.0``
-- **bpms**: List of BPMs for which spectra will be plotted. If not given all BPMs are used.
+    All amplitudes <= limit are filtered. This value needs to be at least
+    0 to filter non-found frequencies.
 
-- **combine_by**: Choose how to combine the data into figures.
+    default: ``0.0``
 
-  Choices: ``['bpms', 'files']``
-  Default: ``[]``
-- **filetype** *(str)*: Filetype to save plots as (i.e. extension without ".")
 
-  Default: ``pdf``
-- **lines_manual** *(DictAsString)*: List of manual lines to plot. Need to contain arguments for axvline,
-  and may contain the additional key "loc" which is one of ['bottom', 'top', 'line bottom', 'line top']
-  and places the label as text at the given location.
+- **bpms**:
 
-  Default: ``[]``
-- **lines_nattunes** *(tuple)*: List of natural tune lines to plot
+    List of BPMs for which spectra will be plotted. If not given all BPMs
+    are used.
 
-  Default: ``[(1, 0), (0, 1)]``
-- **lines_tunes** *(tuple)*: list of tune lines to plot
 
-  Default: ``[(1, 0), (0, 1)]``
-- **manual_style** *(DictAsString)*: Additional Style parameters which update the set of predefined ones.
+- **combine_by**:
 
-  Default: ``{}``
-- **ncol_legend** *(int)*: Number of bpm legend-columns. If < 1 no legend is shown.
+    Choose how to combine the data into figures.
 
-  Default: ``5``
-- **output_dir** *(str)*: Directory to write results to. If no option is given, plots will not be saved.
+    choices: ``['bpms', 'files']``
 
-- **plot_type**: Choose plot type (Multiple choices possible).
+    default: ``[]``
 
-  Choices: ``['stem', 'waterfall']``
-  Default: ``['stem']``
-- **rescale**: Flag to rescale plots amplitude to max-line = 1
 
-  Action: ``store_true``
-- **show_plots**: Flag to show plots
+- **filetype** *(str)*:
 
-  Action: ``store_true``
-- **waterfall_cmap** *(str)*: Colormap to use for waterfall plot.
+    Filetype to save plots as (i.e. extension without ".")
 
-  Default: ``inferno``
-- **waterfall_common_plane_colors**: Same colorbar scale for both planes in waterfall plots.
+    default: ``pdf``
 
-  Action: ``store_true``
-- **waterfall_line_width**: Line width of the waterfall frequency lines. "auto" fills them up until the next one.
 
-  Default: ``2``
-- **xlim** *(float)*: Limits on the x axis (Tupel)
+- **lines_manual** *(DictAsString)*:
 
-  Default: ``[0, 0.5]``
-- **ylim** *(float)*: Limits on the y axis (Tupel)
+    List of manual lines to plot. Need to contain arguments for axvline,
+    and may contain the additional keys "text" and "loc" which is one of
+    ['bottom', 'top', 'line bottom', 'line top'] and places the text at
+    the given location.
 
-  Default: ``[1e-09, 1.0]``
+    default: ``[]``
+
+
+- **lines_nattunes** *(tuple)*:
+
+    List of natural tune lines to plot
+
+    default: ``[(1, 0), (0, 1)]``
+
+
+- **lines_tunes** *(tuple)*:
+
+    list of tune lines to plot
+
+    default: ``[(1, 0), (0, 1)]``
+
+
+- **manual_style** *(DictAsString)*:
+
+    Additional style rcParameters which update the set of predefined ones.
+
+    default: ``{}``
+
+
+- **ncol_legend** *(int)*:
+
+    Number of bpm legend-columns. If < 1 no legend is shown.
+
+    default: ``5``
+
+
+- **output_dir** *(str)*:
+
+    Directory to write results to. If no option is given, plots will not
+    be saved.
+
+
+- **plot_styles** *(UnionPathStr)*:
+
+    Which plotting styles to use, either from plotting.styles.*.mplstyles
+    or default mpl.
+
+    default: ``['standard']``
+
+
+- **plot_type**:
+
+    Choose plot type (Multiple choices possible).
+
+    choices: ``['stem', 'waterfall']``
+
+    default: ``['stem']``
+
+
+- **rescale**:
+
+    Flag to rescale plots amplitude to max-line = 1
+
+    action: ``store_true``
+
+
+- **show_plots**:
+
+    Flag to show plots
+
+    action: ``store_true``
+
+
+- **waterfall_cmap** *(str)*:
+
+    Colormap to use for waterfall plot.
+
+    default: ``inferno``
+
+
+- **waterfall_common_plane_colors**:
+
+    Same colorbar scale for both planes in waterfall plots.
+
+    action: ``store_true``
+
+
+- **waterfall_line_width**:
+
+    Line width of the waterfall frequency lines. "auto" fills them up
+    until the next one.
+
+    default: ``2``
+
+
+- **xlim** *(float)*:
+
+    Limits on the x axis (Tupel)
+
+    default: ``[0, 0.5]``
+
+
+- **ylim** *(float)*:
+
+    Limits on the y axis (Tupel)
+
+    default: ``[1e-09, 1.0]``
+
+
 """
 import os
 from collections import OrderedDict
 from typing import Tuple
 
-import matplotlib
 from cycler import cycler
 from generic_parser.entry_datatypes import DictAsString
 from generic_parser.entrypoint_parser import (entrypoint, EntryPointParameters,
@@ -118,9 +203,11 @@ from omc3.plotting.spectrum.utils import (NCOL_LEGEND, LIN,
                                           filter_amps, get_bpms, get_stem_id,
                                           get_waterfall_id, get_data_for_bpm,
                                           load_spectrum_data)
-from omc3.plotting.utils.lines import VERTICAL_LINES_TEXT_LOCATIONS
 from omc3.plotting.spectrum.waterfall import create_waterfall_plots
+from omc3.plotting.utils import style as pstyle
+from omc3.plotting.utils.lines import VERTICAL_LINES_TEXT_LOCATIONS
 from omc3.utils import logging_tools
+from omc3.utils.iotools import UnionPathStr
 
 LOG = logging_tools.getLogger(__name__)
 
@@ -146,14 +233,7 @@ DEFAULTS = DotDict(
     filetype='pdf',
     waterfall_line_width=2,
     manual_style={
-        u'figure.figsize': [18, 9],
-        u'axes.labelsize': 15,
         u'axes.prop_cycle': get_reshuffled_tab20c(),
-        u'lines.linestyle': '-',
-        u'lines.marker': 'o',
-        u'lines.markersize': 3,
-        u'markers.fillstyle': u'none',
-        u'figure.subplot.hspace': 0.3,  # space between subplots
     }
 )
 
@@ -239,10 +319,18 @@ def get_params():
                          type=str,
                          default=DEFAULTS.filetype,
                          help='Filetype to save plots as (i.e. extension without ".")')
+    params.add_parameter(name="plot_styles",
+                         type=UnionPathStr,
+                         nargs="+",
+                         default=['standard'],
+                         help='Which plotting styles to use, either from plotting.styles.*.mplstyles or default mpl.'
+                         )
     params.add_parameter(name="manual_style",
                          type=DictAsString,
                          default={},
-                         help='Additional Style parameters which update the set of predefined ones.')
+                         help='Additional style rcParameters which update the set of predefined ones.'
+                         )
+ 
     return params
 
 
@@ -256,7 +344,7 @@ def main(opt):
         _save_options_to_config(opt)
 
     opt = _check_opt(opt)
-    matplotlib.rcParams.update(opt.manual_style)
+    pstyle.set_style(opt.plot_styles, opt.manual_style)
     stem_opt, waterfall_opt, sorting_opt = _sort_opt(opt)
     stem, waterfall = _sort_input_data(sorting_opt)
 
@@ -287,7 +375,7 @@ def _check_opt(opt):
         raise ValueError("The amplitude limit needs to be at least '0' "
                          "to filter for non-found frequencies.")
 
-    style_dict = DEFAULTS['manual_style']
+    style_dict = DEFAULTS.manual_style.copy()
     if opt.manual_style is not None:
         style_dict.update(opt.manual_style)
     opt.manual_style = style_dict

--- a/omc3/plotting/plot_tfs.py
+++ b/omc3/plotting/plot_tfs.py
@@ -616,7 +616,7 @@ def _get_axes_ids(opt):
     """
     Get's all id's first (to know how many axes to use). So the `get_id` is done later for
     actual plotting again.
-    The order matters, as this function detemines the order in which the data is distributed on
+    The order matters, as this function determines the order in which the data is distributed on
     the figure axes (if multiple), which is important if one gives the manual y-labels option.
     Couldn't find a quicker way... (jdilly)
     """

--- a/omc3/plotting/spectrum/stem.py
+++ b/omc3/plotting/spectrum/stem.py
@@ -12,6 +12,7 @@ from omc3.plotting.spectrum.utils import (plot_lines, FigureContainer, get_cycle
                                           get_approx_size_in_axes_coordinates,
                                           PLANES, STEM_LINES_ALPHA, LABEL_Y_SPECTRUM,
                                           LABEL_X, AMPS, FREQS, output_plot)
+from omc3.plotting.utils.annotations import get_fontsize_as_float
 from omc3.utils import logging_tools
 
 LOG = logging_tools.getLogger(__name__)
@@ -91,5 +92,6 @@ def _create_legend(ax, labels, lines, ncol):
 
     # move above line-labels
     nlines = sum([line is not None for line in lines.values()]) + 0.05
-    y_shift = get_approx_size_in_axes_coordinates(leg.axes, label_size=matplotlib.rcParams['axes.labelsize']) * nlines
+    label_size = get_fontsize_as_float(matplotlib.rcParams['axes.labelsize'])
+    y_shift = get_approx_size_in_axes_coordinates(leg.axes, label_size=label_size) * nlines
     leg.axes.legend(handles=handles, bbox_to_anchor=(1. + x_shift, 1. + y_shift), **legend_params)

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -388,10 +388,6 @@ def rescale_amp(amp_data: pd.Series) -> pd.Series:
 
 def output_plot(fig_cont: FigureContainer):
     fig = fig_cont.fig
-
-    fig.tight_layout()
-    fig.tight_layout()  # sometimes better to do twice
-
     if fig_cont.path is not None:
         LOG.info(f"Saving Plot '{fig_cont.path}'")
         fig.savefig(fig_cont.path)

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -20,6 +20,7 @@ from matplotlib.patches import Rectangle
 
 from omc3.definitions.constants import PLANES
 from omc3.harpy.constants import FILE_AMPS_EXT, FILE_FREQS_EXT, FILE_LIN_EXT, COL_NAME
+from omc3.plotting.utils.annotations import get_fontsize_as_float
 from omc3.plotting.utils.lines import VERTICAL_LINES_ALPHA, plot_vertical_line
 from omc3.utils import logging_tools
 
@@ -102,7 +103,7 @@ class FigureCollector:
 
 
 def plot_lines(fig_cont: FigureContainer, lines: DotDict) -> None:
-    label_size = matplotlib.rcParams['axes.labelsize'] * 0.7
+    label_size = get_fontsize_as_float(matplotlib.rcParams['axes.labelsize']) * 0.7
     bottom_qlabel = 1.01
 
     for idx_plane, plane in enumerate(PLANES):

--- a/omc3/plotting/spectrum/waterfall.py
+++ b/omc3/plotting/spectrum/waterfall.py
@@ -11,6 +11,7 @@ from matplotlib import pyplot as plt, colors
 
 from omc3.plotting.spectrum.utils import (plot_lines, PLANES, LABEL_Y_WATERFALL,
                                           LABEL_X, AMPS, FREQS, output_plot)
+from omc3.plotting.utils.annotations import get_fontsize_as_float
 from omc3.utils import logging_tools
 
 LOG = logging_tools.getLogger(__name__)
@@ -89,7 +90,7 @@ def _format_axes(fig_cont, limits, ncol):
             ax.set_yticklabels([])
             ax.set_yticks([])
         else:
-            ax.set_yticklabels(ylabels, fontdict={'fontsize': matplotlib.rcParams[u'axes.labelsize'] * .5})
+            ax.set_yticklabels(ylabels, fontdict={'fontsize': get_fontsize_as_float(matplotlib.rcParams[u'axes.labelsize']) * .5})
             ax.set_yticks(range(len(ylabels)))
         ax.set_xlabel(LABEL_X)
         ax.set_ylabel(LABEL_Y_WATERFALL.format(plane=plane.upper()))

--- a/omc3/plotting/styles/amplitude_detuning.mplstyle
+++ b/omc3/plotting/styles/amplitude_detuning.mplstyle
@@ -1,0 +1,2 @@
+ figure.figsize: 9.5, 4
+ lines.linestyle: None

--- a/omc3/plotting/styles/bbq.mplstyle
+++ b/omc3/plotting/styles/bbq.mplstyle
@@ -1,0 +1,3 @@
+figure.figsize: 12.24, 7.68
+lines.marker: None     # overwritten on a per-plot basis, e.g. ax.plot(..., marker=)
+lines.linestyle: None  # overwritten on a per-plot basis

--- a/omc3/plotting/styles/spectrum.mplstyle
+++ b/omc3/plotting/styles/spectrum.mplstyle
@@ -1,0 +1,4 @@
+figure.figsize: 18, 9
+lines.markersize: 3
+markers.fillstyle: none
+figure.subplot.hspace: 0.3  # space between subplots

--- a/omc3/plotting/styles/standard.mplstyle
+++ b/omc3/plotting/styles/standard.mplstyle
@@ -512,7 +512,7 @@ grid.alpha:     0.6     # transparency, between 0.0 and 1.0 (Default: 1.0)
 ## * LEGEND                                                                  *
 ## ***************************************************************************
 #legend.loc:           best
-#legend.frameon:       True     # if True, draw the legend on a background patch
+legend.frameon:       False     # if True, draw the legend on a background patch (Default: True)
 #legend.framealpha:    0.8      # legend patch transparency
 #legend.facecolor:     inherit  # inherit from axes.facecolor; or color spec
 #legend.edgecolor:     0.8      # background patch boundary color

--- a/omc3/plotting/styles/standard.mplstyle
+++ b/omc3/plotting/styles/standard.mplstyle
@@ -1,92 +1,763 @@
-axes.autolimit_mode: data
-axes.edgecolor: k
-axes.facecolor: w
-axes.grid: True
-axes.grid.axis: both
-axes.grid.which: major
-axes.labelcolor: k
-axes.labelpad: 4.0
-axes.labelsize: medium
-axes.labelweight: normal
-axes.linewidth: 1.5
-axes.titlepad: 6.0
-axes.titlesize: x-large
-axes.titleweight: bold
-figure.edgecolor: w
-figure.facecolor: w
-figure.figsize: 10.24, 7.68
-figure.frameon: True
-figure.titlesize: large
-figure.titleweight: normal
-font.size: 15.0
-font.stretch: normal
-font.weight: normal
-font.family:
-font.serif: Computer Modern Roman
-font.sans-serif: Computer Modern Sans serif
-grid.alpha: .6
-grid.color: b0b0b0
-grid.linestyle: --
-grid.linewidth: 0.6
-legend.edgecolor: 0.8
-legend.facecolor: inherit
-legend.fancybox: True
-legend.fontsize: 16.
-legend.framealpha: 0.8
-legend.frameon: False
-legend.handleheight: 0.7
-legend.handlelength: 2.0
-legend.handletextpad: 0.8
-legend.labelspacing: 0.5
-legend.loc: best
-legend.markerscale: .8
-legend.numpoints: 1
-legend.scatterpoints: 1
-legend.shadow: False
-lines.antialiased: True
-# lines.color: C0
-lines.linestyle: -
-lines.linewidth: 1.5
-lines.marker: o
-lines.markeredgewidth: 1.0
-lines.markersize: 8.0
-lines.solid_capstyle: projecting
-lines.solid_joinstyle: round
-markers.fillstyle: none
-savefig.format : pdf
-text.antialiased: True
-text.color: k
-xtick.alignment: center
-xtick.bottom: True
-xtick.color: k
-xtick.direction: out
-xtick.labelsize: medium
-xtick.major.bottom: True
-xtick.major.pad: 3.5
-xtick.major.size: 3.5
-xtick.major.top: True
-xtick.major.width: 0.8
-xtick.minor.bottom: True
-xtick.minor.pad: 3.4
-xtick.minor.size: 2.0
-xtick.minor.top: True
-xtick.minor.visible: False
-xtick.minor.width: 0.6
-xtick.top: False
-ytick.alignment: center_baseline
-ytick.color: k
-ytick.direction: out
-ytick.labelsize: medium
-ytick.left: True
-ytick.major.left: True
-ytick.major.pad: 3.5
-ytick.major.right: True
-ytick.major.size: 3.5
-ytick.major.width: 0.8
-ytick.minor.left: True
-ytick.minor.pad: 3.4
-ytick.minor.right: True
-ytick.minor.size: 2.0
-ytick.minor.visible: False
-ytick.minor.width: 0.6
+#### MATPLOTLIBRC FORMAT
 
+## Copied from https://matplotlib.org/stable/tutorials/introductory/customizing.html
+##
+## You should find a copy of this file on your system at
+## site-packages/matplotlib/mpl-data/matplotlibrc (relative to your Python
+## installation location).  DO NOT EDIT IT!
+##
+## If you wish to change your default style, copy this file to one of the
+## following locations:
+##     Unix/Linux:
+##         $HOME/.config/matplotlib/matplotlibrc OR
+##         $XDG_CONFIG_HOME/matplotlib/matplotlibrc (if $XDG_CONFIG_HOME is set)
+##     Other platforms:
+##         $HOME/.matplotlib/matplotlibrc
+## and edit that copy.
+##
+## See https://matplotlib.org/users/customizing.html#the-matplotlibrc-file
+## for more details on the paths which are checked for the configuration file.
+##
+## Blank lines, or lines starting with a comment symbol, are ignored, as are
+## trailing comments.  Other lines must have the format:
+##     key: val  # optional comment
+##
+## Formatting: Use PEP8-like style (as enforced in the rest of the codebase).
+## All lines start with an additional '#', so that removing all leading '#'s
+## yields a valid style file.
+##
+## Colors: for the color values below, you can either use
+##     - a Matplotlib color string, such as r, k, or b
+##     - an RGB tuple, such as (1.0, 0.5, 0.0)
+##     - a hex string, such as ff00ff
+##     - a scalar grayscale intensity such as 0.75
+##     - a legal html color name, e.g., red, blue, darkslategray
+##
+## Matplotlib configuration are currently divided into following parts:
+##     - BACKENDS
+##     - LINES
+##     - PATCHES
+##     - HATCHES
+##     - BOXPLOT
+##     - FONT
+##     - TEXT
+##     - LaTeX
+##     - AXES
+##     - DATES
+##     - TICKS
+##     - GRIDS
+##     - LEGEND
+##     - FIGURE
+##     - IMAGES
+##     - CONTOUR PLOTS
+##     - ERRORBAR PLOTS
+##     - HISTOGRAM PLOTS
+##     - SCATTER PLOTS
+##     - AGG RENDERING
+##     - PATHS
+##     - SAVING FIGURES
+##     - INTERACTIVE KEYMAPS
+##     - ANIMATION
+
+##### CONFIGURATION BEGINS HERE
+
+
+## ***************************************************************************
+## * BACKENDS                                                                *
+## ***************************************************************************
+## The default backend.  If you omit this parameter, the first working
+## backend from the following list is used:
+##     MacOSX QtAgg Gtk4Agg Gtk3Agg TkAgg WxAgg Agg
+## Other choices include:
+##     QtCairo GTK4Cairo GTK3Cairo TkCairo WxCairo Cairo
+##     Qt5Agg Qt5Cairo Wx  # deprecated.
+##     PS PDF SVG Template
+## You can also deploy your own backend outside of Matplotlib by referring to
+## the module name (which must be in the PYTHONPATH) as 'module://my_backend'.
+##backend: Agg
+
+## The port to use for the web server in the WebAgg backend.
+#webagg.port: 8988
+
+## The address on which the WebAgg web server should be reachable
+#webagg.address: 127.0.0.1
+
+## If webagg.port is unavailable, a number of other random ports will
+## be tried until one that is available is found.
+#webagg.port_retries: 50
+
+## When True, open the web browser to the plot that is shown
+#webagg.open_in_browser: True
+
+## If you are running pyplot inside a GUI and your backend choice
+## conflicts, we will automatically try to find a compatible one for
+## you if backend_fallback is True
+#backend_fallback: True
+
+#interactive: False
+#toolbar:     toolbar2  # {None, toolbar2, toolmanager}
+#timezone:    UTC       # a pytz timezone string, e.g., US/Central or Europe/Paris
+
+
+## ***************************************************************************
+## * LINES                                                                   *
+## ***************************************************************************
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.lines
+## for more information on line properties.
+#lines.linewidth: 1.5               # line width in points
+#lines.linestyle: -                 # solid line
+#lines.color:     C0                # has no affect on plot(); see axes.prop_cycle
+lines.marker:          o        # the default marker (Default: None)
+#lines.markerfacecolor: auto        # the default marker face color
+#lines.markeredgecolor: auto        # the default marker edge color
+#lines.markeredgewidth: 1.0         # the line width around the marker symbol
+lines.markersize:      8           # marker size, in points (Default: 6)
+#lines.dash_joinstyle:  round       # {miter, round, bevel}
+#lines.dash_capstyle:   butt        # {butt, round, projecting}
+#lines.solid_joinstyle: round       # {miter, round, bevel}
+#lines.solid_capstyle:  projecting  # {butt, round, projecting}
+#lines.antialiased: True            # render lines in antialiased (no jaggies)
+
+## The three standard dash patterns.  These are scaled by the linewidth.
+#lines.dashed_pattern: 3.7, 1.6
+#lines.dashdot_pattern: 6.4, 1.6, 1, 1.6
+#lines.dotted_pattern: 1, 1.65
+#lines.scale_dashes: True
+
+markers.fillstyle: none  # {full, left, right, bottom, top, none} (Default: full)
+
+#pcolor.shading: auto
+#pcolormesh.snap: True  # Whether to snap the mesh to pixel boundaries. This is
+                        # provided solely to allow old test images to remain
+                        # unchanged. Set to False to obtain the previous behavior.
+
+## ***************************************************************************
+## * PATCHES                                                                 *
+## ***************************************************************************
+## Patches are graphical objects that fill 2D space, like polygons or circles.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.patches
+## for more information on patch properties.
+#patch.linewidth:       1      # edge width in points.
+#patch.facecolor:       C0
+#patch.edgecolor:       black  # if forced, or patch is not filled
+#patch.force_edgecolor: False  # True to always use edgecolor
+#patch.antialiased:     True   # render patches in antialiased (no jaggies)
+
+
+## ***************************************************************************
+## * HATCHES                                                                 *
+## ***************************************************************************
+#hatch.color:     black
+#hatch.linewidth: 1.0
+
+
+## ***************************************************************************
+## * BOXPLOT                                                                 *
+## ***************************************************************************
+#boxplot.notch:       False
+#boxplot.vertical:    True
+#boxplot.whiskers:    1.5
+#boxplot.bootstrap:   None
+#boxplot.patchartist: False
+#boxplot.showmeans:   False
+#boxplot.showcaps:    True
+#boxplot.showbox:     True
+#boxplot.showfliers:  True
+#boxplot.meanline:    False
+
+#boxplot.flierprops.color:           black
+#boxplot.flierprops.marker:          o
+#boxplot.flierprops.markerfacecolor: none
+#boxplot.flierprops.markeredgecolor: black
+#boxplot.flierprops.markeredgewidth: 1.0
+#boxplot.flierprops.markersize:      6
+#boxplot.flierprops.linestyle:       none
+#boxplot.flierprops.linewidth:       1.0
+
+#boxplot.boxprops.color:     black
+#boxplot.boxprops.linewidth: 1.0
+#boxplot.boxprops.linestyle: -
+
+#boxplot.whiskerprops.color:     black
+#boxplot.whiskerprops.linewidth: 1.0
+#boxplot.whiskerprops.linestyle: -
+
+#boxplot.capprops.color:     black
+#boxplot.capprops.linewidth: 1.0
+#boxplot.capprops.linestyle: -
+
+#boxplot.medianprops.color:     C1
+#boxplot.medianprops.linewidth: 1.0
+#boxplot.medianprops.linestyle: -
+
+#boxplot.meanprops.color:           C2
+#boxplot.meanprops.marker:          ^
+#boxplot.meanprops.markerfacecolor: C2
+#boxplot.meanprops.markeredgecolor: C2
+#boxplot.meanprops.markersize:       6
+#boxplot.meanprops.linestyle:       --
+#boxplot.meanprops.linewidth:       1.0
+
+
+## ***************************************************************************
+## * FONT                                                                    *
+## ***************************************************************************
+## The font properties used by `text.Text`.
+## See https://matplotlib.org/api/font_manager_api.html for more information
+## on font properties.  The 6 font properties used for font matching are
+## given below with their default values.
+##
+## The font.family property can take either a concrete font name (not supported
+## when rendering text with usetex), or one of the following five generic
+## values:
+##     - 'serif' (e.g., Times),
+##     - 'sans-serif' (e.g., Helvetica),
+##     - 'cursive' (e.g., Zapf-Chancery),
+##     - 'fantasy' (e.g., Western), and
+##     - 'monospace' (e.g., Courier).
+## Each of these values has a corresponding default list of font names
+## (font.serif, etc.); the first available font in the list is used.  Note that
+## for font.serif, font.sans-serif, and font.monospace, the first element of
+## the list (a DejaVu font) will always be used because DejaVu is shipped with
+## Matplotlib and is thus guaranteed to be available; the other entries are
+## left as examples of other possible values.
+##
+## The font.style property has three values: normal (or roman), italic
+## or oblique.  The oblique style will be used for italic, if it is not
+## present.
+##
+## The font.variant property has two values: normal or small-caps.  For
+## TrueType fonts, which are scalable fonts, small-caps is equivalent
+## to using a font size of 'smaller', or about 83%% of the current font
+## size.
+##
+## The font.weight property has effectively 13 values: normal, bold,
+## bolder, lighter, 100, 200, 300, ..., 900.  Normal is the same as
+## 400, and bold is 700.  bolder and lighter are relative values with
+## respect to the current weight.
+##
+## The font.stretch property has 11 values: ultra-condensed,
+## extra-condensed, condensed, semi-condensed, normal, semi-expanded,
+## expanded, extra-expanded, ultra-expanded, wider, and narrower.  This
+## property is not currently implemented.
+##
+## The font.size property is the default font size for text, given in points.
+## 10 pt is the standard value.
+##
+## Note that font.size controls default text sizes.  To configure
+## special text sizes tick labels, axes, labels, title, etc., see the rc
+## settings for axes and ticks.  Special text sizes can be defined
+## relative to font.size, using the following values: xx-small, x-small,
+## small, medium, large, x-large, xx-large, larger, or smaller
+
+#font.family:  sans-serif
+#font.style:   normal
+#font.variant: normal
+#font.weight:  normal
+#font.stretch: normal
+font.size:    15.0    # (Default: 10.0)
+
+#font.serif:      DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
+#font.sans-serif: DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+#font.cursive:    Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
+#font.fantasy:    Chicago, Charcoal, Impact, Western, Humor Sans, xkcd, fantasy
+#font.monospace:  DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+
+
+## ***************************************************************************
+## * TEXT                                                                    *
+## ***************************************************************************
+## The text properties used by `text.Text`.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
+## for more information on text properties
+#text.color: black
+
+## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the
+## following (Proprietary Matplotlib-specific synonyms are given in parentheses,
+## but their use is discouraged):
+## - default: Use the font's native hinter if possible, else FreeType's auto-hinter.
+##            ("either" is a synonym).
+## - no_autohint: Use the font's native hinter if possible, else don't hint.
+##                ("native" is a synonym.)
+## - force_autohint: Use FreeType's auto-hinter.  ("auto" is a synonym.)
+## - no_hinting: Disable hinting.  ("none" is a synonym.)
+#text.hinting: force_autohint
+
+#text.hinting_factor: 8  # Specifies the amount of softness for hinting in the
+                         # horizontal direction.  A value of 1 will hint to full
+                         # pixels.  A value of 2 will hint to half pixels etc.
+#text.kerning_factor: 0  # Specifies the scaling factor for kerning values.  This
+                         # is provided solely to allow old test images to remain
+                         # unchanged.  Set to 6 to obtain previous behavior.
+                         # Values  other than 0 or 6 have no defined meaning.
+#text.antialiased: True  # If True (default), the text will be antialiased.
+                         # This only affects raster outputs.
+
+
+## ***************************************************************************
+## * LaTeX                                                                   *
+## ***************************************************************************
+## For more information on LaTeX properties, see
+## https://matplotlib.org/tutorials/text/usetex.html
+#text.usetex: False  # use latex for all text handling. The following fonts
+                     # are supported through the usual rc parameter settings:
+                     # new century schoolbook, bookman, times, palatino,
+                     # zapf chancery, charter, serif, sans-serif, helvetica,
+                     # avant garde, courier, monospace, computer modern roman,
+                     # computer modern sans serif, computer modern typewriter
+#text.latex.preamble:   # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
+                        # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
+                        # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
+                        # text.latex.preamble is a single line of LaTeX code that
+                        # will be passed on to the LaTeX system. It may contain
+                        # any code that is valid for the LaTeX "preamble", i.e.
+                        # between the "\documentclass" and "\begin{document}"
+                        # statements.
+                        # Note that it has to be put on a single line, which may
+                        # become quite long.
+                        # The following packages are always loaded with usetex,
+                        # so beware of package collisions:
+                        #   geometry, inputenc, type1cm.
+                        # PostScript (PSNFSS) font packages may also be
+                        # loaded, depending on your font settings.
+
+## The following settings allow you to select the fonts in math mode.
+#mathtext.fontset: dejavusans  # Should be 'dejavusans' (default),
+                               # 'dejavuserif', 'cm' (Computer Modern), 'stix',
+                               # 'stixsans' or 'custom' (unsupported, may go
+                               # away in the future)
+## "mathtext.fontset: custom" is defined by the mathtext.bf, .cal, .it, ...
+## settings which map a TeX font name to a fontconfig font pattern.  (These
+## settings are not used for other font sets.)
+#mathtext.bf:  sans:bold
+#mathtext.cal: cursive
+#mathtext.it:  sans:italic
+#mathtext.rm:  sans
+#mathtext.sf:  sans
+#mathtext.tt:  monospace
+#mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
+                        # 'stixsans'] when a symbol can not be found in one of the
+                        # custom math fonts. Select 'None' to not perform fallback
+                        # and replace the missing character by a dummy symbol.
+#mathtext.default: it  # The default font to use for math.
+                       # Can be any of the LaTeX font names, including
+                       # the special name "regular" for the same font
+                       # used in regular text.
+
+
+## ***************************************************************************
+## * AXES                                                                    *
+## ***************************************************************************
+## Following are default face and edge colors, default tick sizes,
+## default font sizes for tick labels, and so on.  See
+## https://matplotlib.org/api/axes_api.html#module-matplotlib.axes
+#axes.facecolor:     white   # axes background color
+#axes.edgecolor:     black   # axes edge color
+axes.linewidth:     1.5     # edge line width  (Default: 0.8)
+axes.grid:          True    # display grid or not  (Default: False)
+#axes.grid.axis:     both    # which axis the grid should apply to
+#axes.grid.which:    major   # grid lines at {major, minor, both} ticks
+#axes.titlelocation: center  # alignment of the title: {left, right, center}
+axes.titlesize:     x-large   # font size of the axes title (Default: large)
+axes.titleweight:   bold  # font weight of title  (Default: normal)
+#axes.titlecolor:    auto    # color of the axes title, auto falls back to
+                             # text.color as default value
+#axes.titley:        None    # position title (axes relative units).  None implies auto
+#axes.titlepad:      6.0     # pad between axes and title in points
+#axes.labelsize:     medium  # font size of the x and y labels
+#axes.labelpad:      4.0     # space between label and axis
+#axes.labelweight:   normal  # weight of the x and y labels
+#axes.labelcolor:    black
+#axes.axisbelow:     line    # draw axis gridlines and ticks:
+                             #     - below patches (True)
+                             #     - above patches but below lines ('line')
+                             #     - above all (False)
+
+#axes.formatter.limits: -5, 6  # use scientific notation if log10
+                               # of the axis range is smaller than the
+                               # first or larger than the second
+#axes.formatter.use_locale: False  # When True, format tick labels
+                                   # according to the user's locale.
+                                   # For example, use ',' as a decimal
+                                   # separator in the fr_FR locale.
+#axes.formatter.use_mathtext: False  # When True, use mathtext for scientific
+                                     # notation.
+#axes.formatter.min_exponent: 0  # minimum exponent to format in scientific notation
+#axes.formatter.useoffset: True  # If True, the tick label formatter
+                                 # will default to labeling ticks relative
+                                 # to an offset when the data range is
+                                 # small compared to the minimum absolute
+                                 # value of the data.
+#axes.formatter.offset_threshold: 4  # When useoffset is True, the offset
+                                     # will be used when it can remove
+                                     # at least this number of significant
+                                     # digits from tick labels.
+
+#axes.spines.left:   True  # display axis spines
+#axes.spines.bottom: True
+#axes.spines.top:    True
+#axes.spines.right:  True
+
+#axes.unicode_minus: True  # use Unicode for the minus symbol rather than hyphen.  See
+                           # https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
+#axes.prop_cycle: cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
+                  # color cycle for plot lines as list of string color specs:
+                  # single letter, long name, or web-style hex
+                  # As opposed to all other parameters in this file, the color
+                  # values must be enclosed in quotes for this parameter,
+                  # e.g. '1f77b4', instead of 1f77b4.
+                  # See also https://matplotlib.org/tutorials/intermediate/color_cycle.html
+                  # for more details on prop_cycle usage.
+#axes.xmargin:   .05  # x margin.  See `axes.Axes.margins`
+#axes.ymargin:   .05  # y margin.  See `axes.Axes.margins`
+#axes.zmargin:   .05  # z margin.  See `axes.Axes.margins`
+#axes.autolimit_mode: data  # If "data", use axes.xmargin and axes.ymargin as is.
+                            # If "round_numbers", after application of margins, axis
+                            # limits are further expanded to the nearest "round" number.
+#polaraxes.grid: True  # display grid on polar axes
+#axes3d.grid:    True  # display grid on 3D axes
+
+
+## ***************************************************************************
+## * AXIS                                                                    *
+## ***************************************************************************
+#xaxis.labellocation: center  # alignment of the xaxis label: {left, right, center}
+#yaxis.labellocation: center  # alignment of the yaxis label: {bottom, top, center}
+
+
+## ***************************************************************************
+## * DATES                                                                   *
+## ***************************************************************************
+## These control the default format strings used in AutoDateFormatter.
+## Any valid format datetime format string can be used (see the python
+## `datetime` for details).  For example, by using:
+##     - '%%x' will use the locale date representation
+##     - '%%X' will use the locale time representation
+##     - '%%c' will use the full locale datetime representation
+## These values map to the scales:
+##     {'year': 365, 'month': 30, 'day': 1, 'hour': 1/24, 'minute': 1 / (24 * 60)}
+
+#date.autoformatter.year:        %Y
+#date.autoformatter.month:       %Y-%m
+#date.autoformatter.day:         %Y-%m-%d
+#date.autoformatter.hour:        %m-%d %H
+#date.autoformatter.minute:      %d %H:%M
+#date.autoformatter.second:      %H:%M:%S
+#date.autoformatter.microsecond: %M:%S.%f
+## The reference date for Matplotlib's internal date representation
+## See https://matplotlib.org/examples/ticks_and_spines/date_precision_and_epochs.py
+#date.epoch: 1970-01-01T00:00:00
+## 'auto', 'concise':
+#date.converter:                  auto
+## For auto converter whether to use interval_multiples:
+#date.interval_multiples:         True
+
+## ***************************************************************************
+## * TICKS                                                                   *
+## ***************************************************************************
+## See https://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
+#xtick.top:           False   # draw ticks on the top side
+#xtick.bottom:        True    # draw ticks on the bottom side
+#xtick.labeltop:      False   # draw label on the top
+#xtick.labelbottom:   True    # draw label on the bottom
+#xtick.major.size:    3.5     # major tick size in points
+#xtick.minor.size:    2       # minor tick size in points
+#xtick.major.width:   0.8     # major tick width in points
+#xtick.minor.width:   0.6     # minor tick width in points
+#xtick.major.pad:     3.5     # distance to major tick label in points
+#xtick.minor.pad:     3.4     # distance to the minor tick label in points
+#xtick.color:         black   # color of the ticks
+#xtick.labelcolor:    inherit # color of the tick labels or inherit from xtick.color
+#xtick.labelsize:     medium  # font size of the tick labels
+#xtick.direction:     out     # direction: {in, out, inout}
+#xtick.minor.visible: False   # visibility of minor ticks on x-axis
+#xtick.major.top:     True    # draw x axis top major ticks
+#xtick.major.bottom:  True    # draw x axis bottom major ticks
+#xtick.minor.top:     True    # draw x axis top minor ticks
+#xtick.minor.bottom:  True    # draw x axis bottom minor ticks
+#xtick.alignment:     center  # alignment of xticks
+
+#ytick.left:          True    # draw ticks on the left side
+#ytick.right:         False   # draw ticks on the right side
+#ytick.labelleft:     True    # draw tick labels on the left side
+#ytick.labelright:    False   # draw tick labels on the right side
+#ytick.major.size:    3.5     # major tick size in points
+#ytick.minor.size:    2       # minor tick size in points
+#ytick.major.width:   0.8     # major tick width in points
+#ytick.minor.width:   0.6     # minor tick width in points
+#ytick.major.pad:     3.5     # distance to major tick label in points
+#ytick.minor.pad:     3.4     # distance to the minor tick label in points
+#ytick.color:         black   # color of the ticks
+#ytick.labelcolor:    inherit # color of the tick labels or inherit from ytick.color
+#ytick.labelsize:     medium  # font size of the tick labels
+#ytick.direction:     out     # direction: {in, out, inout}
+#ytick.minor.visible: False   # visibility of minor ticks on y-axis
+#ytick.major.left:    True    # draw y axis left major ticks
+#ytick.major.right:   True    # draw y axis right major ticks
+#ytick.minor.left:    True    # draw y axis left minor ticks
+#ytick.minor.right:   True    # draw y axis right minor ticks
+#ytick.alignment:     center_baseline  # alignment of yticks
+
+
+## ***************************************************************************
+## * GRIDS                                                                   *
+## ***************************************************************************
+#grid.color:     b0b0b0  # grid color
+grid.linestyle: --       # dashed  (Default: -)
+grid.linewidth: 0.6     # in points (Default: 1.0)
+grid.alpha:     0.6     # transparency, between 0.0 and 1.0 (Default: 1.0)
+
+
+## ***************************************************************************
+## * LEGEND                                                                  *
+## ***************************************************************************
+#legend.loc:           best
+#legend.frameon:       True     # if True, draw the legend on a background patch
+#legend.framealpha:    0.8      # legend patch transparency
+#legend.facecolor:     inherit  # inherit from axes.facecolor; or color spec
+#legend.edgecolor:     0.8      # background patch boundary color
+#legend.fancybox:      True     # if True, use a rounded box for the
+                                # legend background, else a rectangle
+#legend.shadow:        False    # if True, give background a shadow effect
+#legend.numpoints:     1        # the number of marker points in the legend line
+#legend.scatterpoints: 1        # number of scatter points
+#legend.markerscale:   1.0      # the relative size of legend markers vs. original
+#legend.fontsize:      medium
+#legend.labelcolor:    None
+#legend.title_fontsize: None    # None sets to the same as the default axes.
+
+## Dimensions as fraction of font size:
+#legend.borderpad:     0.4  # border whitespace
+#legend.labelspacing:  0.5  # the vertical space between the legend entries
+#legend.handlelength:  2.0  # the length of the legend lines
+#legend.handleheight:  0.7  # the height of the legend handle
+#legend.handletextpad: 0.8  # the space between the legend line and legend text
+#legend.borderaxespad: 0.5  # the border between the axes and legend edge
+#legend.columnspacing: 2.0  # column separation
+
+
+## ***************************************************************************
+## * FIGURE                                                                  *
+## ***************************************************************************
+## See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
+#figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
+#figure.titleweight: normal    # weight of the figure title
+figure.figsize:     10.24, 7.68  # figure size in inches (Default: 6.4, 4.8)
+#figure.dpi:         100       # figure dots per inch
+#figure.facecolor:   white     # figure face color
+#figure.edgecolor:   white     # figure edge color
+#figure.frameon:     True      # enable figure frame
+#figure.max_open_warning: 20   # The maximum number of figures to open through
+                               # the pyplot interface before emitting a warning.
+                               # If less than one this feature is disabled.
+#figure.raise_window : True    # Raise the GUI window to front when show() is called.
+
+## The figure subplot parameters.  All dimensions are a fraction of the figure width and height.
+#figure.subplot.left:   0.125  # the left side of the subplots of the figure
+#figure.subplot.right:  0.9    # the right side of the subplots of the figure
+#figure.subplot.bottom: 0.11   # the bottom of the subplots of the figure
+#figure.subplot.top:    0.88   # the top of the subplots of the figure
+#figure.subplot.wspace: 0.2    # the amount of width reserved for space between subplots,
+                               # expressed as a fraction of the average axis width
+#figure.subplot.hspace: 0.2    # the amount of height reserved for space between subplots,
+                               # expressed as a fraction of the average axis height
+
+## Figure layout
+#figure.autolayout: False  # When True, automatically adjust subplot
+                           # parameters to make the plot fit the figure
+                           # using `tight_layout`
+figure.constrained_layout.use: True  # When True, automatically make plot  (Default: False)
+                                       # elements fit on the figure. (Not
+                                       # compatible with `autolayout`, above).
+#figure.constrained_layout.h_pad:  0.04167  # Padding around axes objects. Float representing
+#figure.constrained_layout.w_pad:  0.04167  # inches. Default is 3/72 inches (3 points)
+#figure.constrained_layout.hspace: 0.02     # Space between subplot groups. Float representing
+#figure.constrained_layout.wspace: 0.02     # a fraction of the subplot widths being separated.
+
+
+## ***************************************************************************
+## * IMAGES                                                                  *
+## ***************************************************************************
+#image.aspect:          equal        # {equal, auto} or a number
+#image.interpolation:   antialiased  # see help(imshow) for options
+#image.cmap:            viridis      # A colormap name, gray etc...
+#image.lut:             256          # the size of the colormap lookup table
+#image.origin:          upper        # {lower, upper}
+#image.resample:        True
+#image.composite_image: True  # When True, all the images on a set of axes are
+                              # combined into a single composite image before
+                              # saving a figure as a vector graphics file,
+                              # such as a PDF.
+
+
+## ***************************************************************************
+## * CONTOUR PLOTS                                                           *
+## ***************************************************************************
+#contour.negative_linestyle: dashed  # string or on-off ink sequence
+#contour.corner_mask:        True    # {True, False, legacy}
+#contour.linewidth:          None    # {float, None} Size of the contour line
+                                     # widths. If set to None, it falls back to
+                                     # `line.linewidth`.
+
+
+## ***************************************************************************
+## * ERRORBAR PLOTS                                                          *
+## ***************************************************************************
+#errorbar.capsize: 0  # length of end cap on error bars in pixels
+
+
+## ***************************************************************************
+## * HISTOGRAM PLOTS                                                         *
+## ***************************************************************************
+#hist.bins: 10  # The default number of histogram bins or 'auto'.
+
+
+## ***************************************************************************
+## * SCATTER PLOTS                                                           *
+## ***************************************************************************
+#scatter.marker: o         # The default marker type for scatter plots.
+#scatter.edgecolors: face  # The default edge colors for scatter plots.
+
+
+## ***************************************************************************
+## * AGG RENDERING                                                           *
+## ***************************************************************************
+## Warning: experimental, 2008/10/10
+#agg.path.chunksize: 0  # 0 to disable; values in the range
+                        # 10000 to 100000 can improve speed slightly
+                        # and prevent an Agg rendering failure
+                        # when plotting very large data sets,
+                        # especially if they are very gappy.
+                        # It may cause minor artifacts, though.
+                        # A value of 20000 is probably a good
+                        # starting point.
+
+
+## ***************************************************************************
+## * PATHS                                                                   *
+## ***************************************************************************
+#path.simplify: True  # When True, simplify paths by removing "invisible"
+                      # points to reduce file size and increase rendering
+                      # speed
+#path.simplify_threshold: 0.111111111111  # The threshold of similarity below
+                                          # which vertices will be removed in
+                                          # the simplification process.
+#path.snap: True  # When True, rectilinear axis-aligned paths will be snapped
+                  # to the nearest pixel when certain criteria are met.
+                  # When False, paths will never be snapped.
+#path.sketch: None  # May be None, or a 3-tuple of the form:
+                    # (scale, length, randomness).
+                    #     - *scale* is the amplitude of the wiggle
+                    #         perpendicular to the line (in pixels).
+                    #     - *length* is the length of the wiggle along the
+                    #         line (in pixels).
+                    #     - *randomness* is the factor by which the length is
+                    #         randomly scaled.
+#path.effects:
+
+
+## ***************************************************************************
+## * SAVING FIGURES                                                          *
+## ***************************************************************************
+## The default savefig parameters can be different from the display parameters
+## e.g., you may want a higher resolution, or to make the figure
+## background white
+#savefig.dpi:       figure      # figure dots per inch or 'figure'
+#savefig.facecolor: auto        # figure face color when saving
+#savefig.edgecolor: auto        # figure edge color when saving
+savefig.format:    pdf         # {png, ps, pdf, svg} (Default: png)
+#savefig.bbox:      standard    # {tight, standard}
+                                # 'tight' is incompatible with pipe-based animation
+                                # backends (e.g. 'ffmpeg') but will work with those
+                                # based on temporary files (e.g. 'ffmpeg_file')
+#savefig.pad_inches:   0.1      # Padding to be used when bbox is set to 'tight'
+#savefig.directory:    ~        # default directory in savefig dialog box,
+                                # leave empty to always use current working directory
+#savefig.transparent: False     # setting that controls whether figures are saved with a
+                                # transparent background by default
+#savefig.orientation: portrait  # Orientation of saved figure
+
+### tk backend params
+#tk.window_focus:   False  # Maintain shell focus for TkAgg
+
+### ps backend params
+#ps.papersize:      letter  # {auto, letter, legal, ledger, A0-A10, B0-B10}
+#ps.useafm:         False   # use of AFM fonts, results in small files
+#ps.usedistiller:   False   # {ghostscript, xpdf, None}
+                            # Experimental: may produce smaller files.
+                            # xpdf intended for production of publication quality files,
+                            # but requires ghostscript, xpdf and ps2eps
+#ps.distiller.res:  6000    # dpi
+#ps.fonttype:       3       # Output Type 3 (Type3) or Type 42 (TrueType)
+
+### PDF backend params
+#pdf.compression:    6  # integer from 0 to 9
+                        # 0 disables compression (good for debugging)
+#pdf.fonttype:       3  # Output Type 3 (Type3) or Type 42 (TrueType)
+#pdf.use14corefonts: False
+#pdf.inheritcolor:   False
+
+### SVG backend params
+#svg.image_inline: True  # Write raster image data directly into the SVG file
+#svg.fonttype: path      # How to handle SVG fonts:
+                         #     path: Embed characters as paths -- supported
+                         #           by most SVG renderers
+                         #     None: Assume fonts are installed on the
+                         #           machine where the SVG will be viewed.
+#svg.hashsalt: None      # If not None, use this string as hash salt instead of uuid4
+
+### pgf parameter
+## See https://matplotlib.org/tutorials/text/pgf.html for more information.
+#pgf.rcfonts: True
+#pgf.preamble:  # See text.latex.preamble for documentation
+#pgf.texsystem: xelatex
+
+### docstring params
+#docstring.hardcopy: False  # set this when you want to generate hardcopy docstring
+
+
+## ***************************************************************************
+## * INTERACTIVE KEYMAPS                                                     *
+## ***************************************************************************
+## Event keys to interact with figures/plots via keyboard.
+## See https://matplotlib.org/users/navigation_toolbar.html for more details on
+## interactive navigation.  Customize these settings according to your needs.
+## Leave the field(s) empty if you don't need a key-map. (i.e., fullscreen : '')
+#keymap.fullscreen: f, ctrl+f   # toggling
+#keymap.home: h, r, home        # home or reset mnemonic
+#keymap.back: left, c, backspace, MouseButton.BACK  # forward / backward keys
+#keymap.forward: right, v, MouseButton.FORWARD      # for quick navigation
+#keymap.pan: p                  # pan mnemonic
+#keymap.zoom: o                 # zoom mnemonic
+#keymap.save: s, ctrl+s         # saving current figure
+#keymap.help: f1                # display help about active tools
+#keymap.quit: ctrl+w, cmd+w, q  # close the current figure
+#keymap.quit_all:               # close all figures
+#keymap.grid: g                 # switching on/off major grids in current axes
+#keymap.grid_minor: G           # switching on/off minor grids in current axes
+#keymap.yscale: l               # toggle scaling of y-axes ('log'/'linear')
+#keymap.xscale: k, L            # toggle scaling of x-axes ('log'/'linear')
+#keymap.copy: ctrl+c, cmd+c     # copy figure to clipboard
+
+
+## ***************************************************************************
+## * ANIMATION                                                               *
+## ***************************************************************************
+#animation.html: none  # How to display the animation as HTML in
+                       # the IPython notebook:
+                       #     - 'html5' uses HTML5 video tag
+                       #     - 'jshtml' creates a JavaScript animation
+#animation.writer:  ffmpeg        # MovieWriter 'backend' to use
+#animation.codec:   h264          # Codec to use for writing movie
+#animation.bitrate: -1            # Controls size/quality trade-off for movie.
+                                  # -1 implies let utility auto-determine
+#animation.frame_format: png      # Controls frame format used by temp files
+#animation.ffmpeg_path:  ffmpeg   # Path to ffmpeg binary. Without full path
+                                  # $PATH is searched
+#animation.ffmpeg_args:           # Additional arguments to pass to ffmpeg
+#animation.convert_path: convert  # Path to ImageMagick's convert binary.
+                                  # On Windows use the full path since convert
+                                  # is also the name of a system tool.
+#animation.convert_args:          # Additional arguments to pass to convert
+#animation.embed_limit:  20.0     # Limit, in MB, of size of base64 encoded
+                                  # animation in HTML (i.e. IPython notebook)/

--- a/omc3/plotting/utils/annotations.py
+++ b/omc3/plotting/utils/annotations.py
@@ -6,6 +6,7 @@ Helper functions to create annotations as well as style labels in plots.
 """
 import re
 from distutils.version import LooseVersion
+from typing import Union
 
 import matplotlib
 import pandas as pd
@@ -343,3 +344,21 @@ def set_sci_magnitude(ax, axis="both", order=0, fformat="%1.1f", offset=True, ma
     ax.ticklabel_format(axis=axis, style="sci", scilimits=(order, order), useMathText=math_text)
 
     return ax
+
+
+def get_fontsize_as_float(font_size: Union[str, float]) -> float:
+    try:
+        scale = {
+            'xx-small': 0.579,
+            'x-small': 0.694,
+            'small': 0.833,
+            'medium': 1.0,
+            'large': 1.200,
+            'x-large': 1.440,
+            'xx-large': 1.728,
+            'larger': 1.2,
+            'smaller': 0.833,
+            None: 1.0}[font_size]
+    except KeyError:
+        return font_size
+    return scale * matplotlib.rcParams['font.size']

--- a/omc3/plotting/utils/annotations.py
+++ b/omc3/plotting/utils/annotations.py
@@ -286,10 +286,6 @@ def make_top_legend(ax, ncol, frame=False, handles=None, labels=None, pad=0.02):
                     bbox_to_anchor=(1.0, 1.0+pad),
                     fancybox=frame, shadow=frame, frameon=frame, ncol=ncol)
 
-    if LooseVersion(matplotlib.__version__) <= LooseVersion("2.2.0"):
-        legend_height = leg.get_window_extent().inverse_transformed(leg.axes.transAxes).height
-        ax.figure.tight_layout(rect=[0, 0, 1, 1+pad-legend_height])
-
     leg.axes.figure.canvas.draw()
     legend_width = leg.get_window_extent().transformed(leg.axes.transAxes.inverted()).width
     if legend_width > 1:
@@ -297,9 +293,6 @@ def make_top_legend(ax, ncol, frame=False, handles=None, labels=None, pad=0.02):
         ax.legend(handles=handles, labels=labels, loc='lower right',
                   bbox_to_anchor=(1.0 + x_shift, 1.0+pad),
                   fancybox=frame, shadow=frame, frameon=frame, ncol=ncol)
-
-    if LooseVersion(matplotlib.__version__) >= LooseVersion("2.2.0"):
-        ax.figure.tight_layout()
 
     return leg
 

--- a/omc3/plotting/utils/style.py
+++ b/omc3/plotting/utils/style.py
@@ -4,10 +4,14 @@ Plotting Utilities: Style
 
 Helper functions to style plots.
 """
+from typing import Dict, Any, Sequence, Union
+
 import matplotlib
+from generic_parser.entry_datatypes import get_instance_faker_meta
 from matplotlib import pyplot as plt
 from pathlib import Path
 
+from omc3.utils.iotools import PathOrStr
 
 REMOVE_ENTRY = "REMOVE ENTRY"  # id to remove entries in manual style
 
@@ -21,7 +25,7 @@ def omc3_styles():
     return {p.with_suffix('').name: p for p in STYLES_DIR.glob('*.mplstyle')}
 
 
-def set_style(styles=('standard',), manual=None):
+def set_style(styles: Sequence[Union[Path, str]] = 'standard', manual: Dict[str, Any] = None):
     """
     Sets the style for all following plots.
 
@@ -30,7 +34,7 @@ def set_style(styles=('standard',), manual=None):
             styles or from the mpl styles
         manual: `Dict` of manual parameters to update. Convention: ``REMOVE_ENTRY`` removes entry.
     """
-    if isinstance(styles, str):
+    if isinstance(styles, PathOrStr):
         styles = (styles,)
 
     local_styles = omc3_styles()

--- a/omc3/plotting/utils/style.py
+++ b/omc3/plotting/utils/style.py
@@ -32,7 +32,8 @@ def set_style(styles: Sequence[Union[Path, str]] = 'standard', manual: Dict[str,
     Args:
         styles: `List` of styles (or single string), either path to style-file, name of style in
             styles or from the mpl styles
-        manual: `Dict` of manual parameters to update. Convention: ``REMOVE_ENTRY`` removes entry.
+        manual: `Dict` of manual parameters to update. Convention: ``REMOVE_ENTRY`` removes entry
+                from given styles, i.e. falls back to mpl default.
     """
     if isinstance(styles, PathOrStr):
         styles = (styles,)

--- a/omc3/plotting/utils/style.py
+++ b/omc3/plotting/utils/style.py
@@ -25,7 +25,8 @@ def omc3_styles():
     return {p.with_suffix('').name: p for p in STYLES_DIR.glob('*.mplstyle')}
 
 
-def set_style(styles: Sequence[Union[Path, str]] = 'standard', manual: Dict[str, Any] = None):
+def set_style(styles: Union[Path, str, Sequence[Union[Path, str]]] = 'standard',
+              manual: Dict[str, Any] = None):
     """
     Sets the style for all following plots.
 

--- a/omc3/utils/iotools.py
+++ b/omc3/utils/iotools.py
@@ -65,6 +65,14 @@ class PathOrStr(metaclass=get_instance_faker_meta(Path, str)):
         return Path(value)
 
 
+class UnionPathStr(metaclass=get_instance_faker_meta(Path, str)):
+    """A class that can be used as Path and string parser input, but does not convert."""
+    def __new__(cls, value):
+        if isinstance(value, str):
+            value = value.strip("\'\"")  # behavior like dict-parser, IMPORTANT FOR EVERY STRING-FAKER
+        return value
+
+
 class PathOrStrOrDataFrame(metaclass=get_instance_faker_meta(TfsDataFrame, Path, str)):
     """A class that behaves like a Path when possible, otherwise like a string."""
     def __new__(cls, value):


### PR DESCRIPTION
removes all tight_layout() calls and tries to handle all plotting styles via rcParams.
Input for all plotting functions should allow for `plot_styles` and `manual_style`, where the former is a list of omc3-styles or paths to your own styles and manual style is a dictionary (which allows for more python shenanigans than .mplstyle files) with additions to the styles.