### PR TITLE
LHC macros call fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OMC3 Changelog
 
+#### 2022-06-21 - v0.4.1 - _jdilly_, _fesoubel_
+
+- Fixed:
+  - LHC ATS macros called for all years after 2018
+  - LHC RunIII macros called for all years after 2022
+  - Getting new BBQ data ended in a key-error.
+  - Better KeyError Message for Exciter-BPM not found.
+
 #### 2022-05-30 - v0.4.0 - _jdilly_
 
 - Added: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 #### 2022-06-21 - v0.4.1 - _jdilly_, _fesoubel_
 
 - Fixed:
-  - LHC ATS macros called for all years after 2018
-  - LHC RunIII macros called for all years after 2022
+  - Fixed macros and knobs usage in model_creator for Run 3 optics
   - Getting new BBQ data ended in a key-error.
   - Better KeyError Message for Exciter-BPM not found.
 

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -334,7 +334,7 @@ class Lhc(Accelerator):
             f"call, file = '{self.model_dir / MACROS_DIR / GENERAL_MACROS}';\n"
             f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS}';\n"
             )
-        if self._uses_run3_macros():  # include the Run 3 macros (fsoubelet, 2022)
+        if self._uses_run3_macros():
             madx_script += (
                 f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS_RUN3}';\n"
             )

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -330,7 +330,7 @@ class Lhc(Accelerator):
             f"call, file = '{self.model_dir / MACROS_DIR / GENERAL_MACROS}';\n"
             f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS}';\n"
             )
-        if int(self.year) >= 2022:  # include the Run 3 macros (fsoubelet, 2022)
+        if self.year.lower().startswith("hllhc") or int(self.year) >= 2022:  # include the Run 3 macros (fsoubelet, 2022)
             madx_script += (
                 f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS_RUN3}';\n"
             )
@@ -365,7 +365,7 @@ class Lhc(Accelerator):
         if high_beta:
             madx_script += "exec, high_beta_matcher();\n"
 
-        if int(self.year) >= 2018:  # starting there we use ATS optics and macros (fsoubelet, 2022)
+        if self.year.lower().startswith("hllhc") or int(self.year) >= 2018:  # starting there we use ATS optics and macros (fsoubelet, 2022)
             madx_script += f"exec, match_tunes_ats({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"
         else:
             madx_script += f"exec, match_tunes{ats_suffix}({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -330,7 +330,7 @@ class Lhc(Accelerator):
             f"call, file = '{self.model_dir / MACROS_DIR / GENERAL_MACROS}';\n"
             f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS}';\n"
             )
-        if self.year == "2022":
+        if int(self.year) >= 2022:  # include the Run 3 macros (fsoubelet, 2022)
             madx_script += (
                 f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS_RUN3}';\n"
             )
@@ -365,7 +365,7 @@ class Lhc(Accelerator):
         if high_beta:
             madx_script += "exec, high_beta_matcher();\n"
 
-        if self.year == "2018":  # to be checked for 2022 (jdilly, 2021)
+        if int(self.year) >= 2018:  # starting there we use ATS optics and macros (fsoubelet, 2022)
             madx_script += f"exec, match_tunes_ats({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"
         else:
             madx_script += f"exec, match_tunes{ats_suffix}({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -315,11 +315,31 @@ class Lhc(Accelerator):
         elif self.beam == 2:
             return [i in index for i in self.model.loc["BPMSW.33R8.B2":].index]
 
+    def _get_madx_script_info_comments(self) -> str:
+        info_comments = (
+            f'title, "LHC Model created by omc3";\n'
+            f"! Model directory: {Path(self.model_dir).absolute()}\n"
+            f"! Natural Tune X         [{self.nat_tunes[0]:10.3f}]\n"
+            f"! Natural Tune Y         [{self.nat_tunes[1]:10.3f}]\n"
+            f"! Best Knowledge:        [{'NO' if self.model_best_knowledge is None else 'OK':>10s}]\n"
+        )
+        if self.excitation == AccExcitationMode.FREE:
+            info_comments += f"! Excitation             [{'NO':>10s}]\n\n"
+            return info_comments
+        else:
+            info_comments += (
+                f"! Excitation             [{'ACD' if self.excitation == AccExcitationMode.ACD else 'ADT':>10s}]\n"
+                f"! > Driven Tune X        [{self.drv_tunes[0]:10.3f}]\n"
+                f"! > Driven Tune Y        [{self.drv_tunes[1]:10.3f}]\n\n"
+            )
+        return info_comments
+
     def get_base_madx_script(self, best_knowledge: bool = False) -> str:
         ats_md = False
         high_beta = False
         madx_script = (
-            # f"option, -echo;\n"
+            f"{self._get_madx_script_info_comments()}"
+            f"! ----- Calling Sequence and Optics -----\n"
             f"call, file = '{self.model_dir / MACROS_DIR / GENERAL_MACROS}';\n"
             f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS}';\n"
             )
@@ -330,7 +350,6 @@ class Lhc(Accelerator):
             )
 
         madx_script += (
-            f'title, "LHC Model created by OMC3";\n'
             f"{self.load_main_seq_madx()}\n"
             f"exec, define_nominal_beams();\n"
         )
@@ -339,6 +358,7 @@ class Lhc(Accelerator):
             for modifier in self.modifiers
         )
         madx_script += (
+            f"\n! ----- Defining Configuration Specifics -----\n"
             f"exec, cycle_sequences();\n"
             f"xing_angles = {'1' if self.xing else '0'};\n"
             f"if(xing_angles==1){{\n"
@@ -352,6 +372,7 @@ class Lhc(Accelerator):
         if best_knowledge:
             # madx_script += f"exec, load_average_error_table({self.energy}, {self.beam});\n"
             madx_script += (
+                f"\n! ----- For Best Knowledge Model -----\n"
                 f"readmytable, file = '{self.model_dir / B2_ERRORS_TFS}', table=errtab;\n"
                 f"seterr, table=errtab;\n"
                 f"call, file = '{self.model_dir / B2_SETTINGS_MADX}';\n"
@@ -359,6 +380,7 @@ class Lhc(Accelerator):
         if high_beta:
             madx_script += "exec, high_beta_matcher();\n"
 
+        madx_script += f"\n! ----- Matching Knobs and Output Files -----\n"
         if self._uses_ats_knobs():
             LOGGER.debug("According to the optics year or the --ats flag being provided, ATS macros and knobs will be used")
             madx_script += f"exec, match_tunes_ats({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -84,12 +84,22 @@ from typing import Dict, Iterator, List, Sequence, Tuple
 
 import tfs
 from generic_parser import EntryPoint
-from omc3.model.accelerators.accelerator import (AccElementTypes, Accelerator,
-                                                 AcceleratorDefinitionError,
-                                                 AccExcitationMode)
-from omc3.model.constants import (B2_ERRORS_TFS, B2_SETTINGS_MADX,
-                                  GENERAL_MACROS, LHC_MACROS, LHC_MACROS_RUN3,
-                                  MACROS_DIR, MODIFIER_TAG)
+
+from omc3.model.accelerators.accelerator import (
+    AccElementTypes,
+    Accelerator,
+    AcceleratorDefinitionError,
+    AccExcitationMode,
+)
+from omc3.model.constants import (
+    B2_ERRORS_TFS,
+    B2_SETTINGS_MADX,
+    GENERAL_MACROS,
+    LHC_MACROS,
+    LHC_MACROS_RUN3,
+    MACROS_DIR,
+    MODIFIER_TAG,
+)
 from omc3.utils import logging_tools
 
 LOGGER = logging_tools.get_logger(__name__)

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -84,22 +84,12 @@ from typing import Dict, Iterator, List, Sequence, Tuple
 
 import tfs
 from generic_parser import EntryPoint
-
-from omc3.model.accelerators.accelerator import (
-    AccElementTypes,
-    Accelerator,
-    AcceleratorDefinitionError,
-    AccExcitationMode,
-)
-from omc3.model.constants import (
-    B2_ERRORS_TFS,
-    B2_SETTINGS_MADX,
-    GENERAL_MACROS,
-    LHC_MACROS,
-    LHC_MACROS_RUN3,
-    MACROS_DIR,
-    MODIFIER_TAG,
-)
+from omc3.model.accelerators.accelerator import (AccElementTypes, Accelerator,
+                                                 AcceleratorDefinitionError,
+                                                 AccExcitationMode)
+from omc3.model.constants import (B2_ERRORS_TFS, B2_SETTINGS_MADX,
+                                  GENERAL_MACROS, LHC_MACROS, LHC_MACROS_RUN3,
+                                  MACROS_DIR, MODIFIER_TAG)
 from omc3.utils import logging_tools
 
 LOGGER = logging_tools.get_logger(__name__)
@@ -334,6 +324,7 @@ class Lhc(Accelerator):
             f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS}';\n"
             )
         if self._uses_run3_macros():
+            LOGGER.debug("According to the optics year, Run 3 versions of the macros will be used")
             madx_script += (
                 f"call, file = '{self.model_dir / MACROS_DIR / LHC_MACROS_RUN3}';\n"
             )
@@ -369,6 +360,7 @@ class Lhc(Accelerator):
             madx_script += "exec, high_beta_matcher();\n"
 
         if self._uses_ats_knobs():
+            LOGGER.debug("According to the optics year or the --ats flag being provided, ATS macros and knobs will be used")
             madx_script += f"exec, match_tunes_ats({self.nat_tunes[0]}, {self.nat_tunes[1]}, {self.beam});\n"
             madx_script += f"exec, coupling_knob_ats({self.beam});\n"
         else:

--- a/omc3/model/madx_macros/lhc.macros.run3.madx
+++ b/omc3/model/madx_macros/lhc.macros.run3.madx
@@ -1,21 +1,41 @@
 /*
 * Macros for runIII of the LHC using the new standard of the _op for the knobs used in operation.
+* If called after lhc.macros.madx these will override the previous definitions.
 */
 
 !requires general.macros.madx
 
 
 /*
+* Performs the matching of the LHC tunes.
+* This is adapted for Run 3 to use the *_op knobs
+* @param nqx: The horizontal tune to match to.
+* @param nqy: The vertical tune to match to.
+* @param beam_number: The beam to use, either 1 or 2.
+*/
+match_tunes(nqx, nqy, beam_number): macro = {
+    exec, find_complete_tunes(nqx, nqy, beam_number);
+    match;
+    vary, name=dQx.bbeam_number_op;
+    vary, name=dQy.bbeam_number_op;
+    constraint, range=#E, mux=total_qx, muy=total_qy;
+    lmdif;
+    endmatch;
+};
+
+
+/*
 * Performs the matching of the LHC tunes, adapted to ATS optics.
+* This is adapted for Run 3 to use the *_sq knobs
 * @param qx: The horizontal tune to match to.
 * @param qy: The vertical tune to match to.
-* @param beam_number: The beam to use either 1 or 2.
+* @param beam_number: The beam to use, either 1 or 2.
 */
 match_tunes_ats(nqx, nqy, beam_number): macro = {
     exec, find_complete_tunes(nqx, nqy, beam_number);
         match;
-        vary, name=dQx_op.bbeam_number_sq;
-        vary, name=dQy_op.bbeam_number_sq;
+        vary, name=dQx.bbeam_number_sq;
+        vary, name=dQy.bbeam_number_sq;
         constraint, range=#E, mux=total_qx, muy=total_qy;
         lmdif;
         endmatch;

--- a/omc3/model/madx_macros/lhc.macros.run3.madx
+++ b/omc3/model/madx_macros/lhc.macros.run3.madx
@@ -1,5 +1,5 @@
 /*
-* Macros for runIII of the LHC using the new standard of the _op for the knobs used in operation.
+* Macros for runIII of the LHC using the new standard _op knobs used in operation.
 * If called after lhc.macros.madx these will override the previous definitions.
 */
 
@@ -8,7 +8,8 @@
 
 /*
 * Performs the matching of the LHC tunes.
-* This is adapted for Run 3 to use the *_op knobs
+* This is adapted for Run 3 to use the *_op knobs and is
+* the default routine to use starting with 2022 optics.
 * @param nqx: The horizontal tune to match to.
 * @param nqy: The vertical tune to match to.
 * @param beam_number: The beam to use, either 1 or 2.
@@ -25,8 +26,10 @@ match_tunes(nqx, nqy, beam_number): macro = {
 
 
 /*
-* Performs the matching of the LHC tunes, adapted to ATS optics.
-* This is adapted for Run 3 to use the *_sq knobs
+* Performs the matching of the LHC tunes using the *_sq knobs.
+* This is not the default routine to use, but it is left available
+* should we choose to use it. If --ats is provided to model_creator
+* then this will be used instead of the one above.
 * @param qx: The horizontal tune to match to.
 * @param qy: The vertical tune to match to.
 * @param beam_number: The beam to use, either 1 or 2.
@@ -43,11 +46,11 @@ match_tunes_ats(nqx, nqy, beam_number): macro = {
 
 /*
 * Coupling knobs convention for Run3
+* beam_number is a parameter here but not used
 */
-coupling_knob_ats(beam_number): macro = {
+coupling_knob(beam_number): macro = {
         Cmrs.b1_op := b1_re_ip7_knob;
         Cmrs.b2_op := b2_re_ip7_knob;
         Cmis.b1_op := b1_im_ip7_knob;
         Cmis.b2_op := b2_im_ip7_knob;  
 };
-

--- a/omc3/model/madx_macros/lhc.macros.run3.madx
+++ b/omc3/model/madx_macros/lhc.macros.run3.madx
@@ -19,7 +19,7 @@ match_tunes(nqx, nqy, beam_number): macro = {
     vary, name=dQx.bbeam_number_op;
     vary, name=dQy.bbeam_number_op;
     constraint, range=#E, mux=total_qx, muy=total_qy;
-    lmdif;
+    lmdif, tolerance=1E-10;
     endmatch;
 };
 
@@ -37,7 +37,7 @@ match_tunes_ats(nqx, nqy, beam_number): macro = {
         vary, name=dQx.bbeam_number_sq;
         vary, name=dQy.bbeam_number_sq;
         constraint, range=#E, mux=total_qx, muy=total_qy;
-        lmdif;
+        lmdif, tolerance=1E-10;
         endmatch;
 };
 

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -124,7 +124,7 @@ def test_lhc_creation_nominal_driven(tmp_path):
 @pytest.mark.basic
 @pytest.mark.parametrize(
     "test_year, uses_ats, uses_run3", 
-    [("2012", False, False), ("2018", True, False), ("2022", True, True), ("hllhc1.3", False, False)]
+    [("2012", False, False), ("2018", True, False), ("2022", False, True), ("hllhc1.3", False, False)]
 )
 def test_lhc_creation_use_ats_and_run3_macros(test_year, uses_ats, uses_run3):
     accel_opt = dict(

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -3,10 +3,13 @@ import shutil
 from pathlib import Path
 
 import pytest
-from omc3.model.accelerators.accelerator import AcceleratorDefinitionError, AccExcitationMode
-from omc3.model.constants import TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT
+from omc3.model.accelerators.accelerator import (AcceleratorDefinitionError,
+                                                 AccExcitationMode)
+from omc3.model.constants import (TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT,
+                                  TWISS_ELEMENTS_DAT)
 from omc3.model.manager import get_accelerator
-from omc3.model.model_creators.lhc_model_creator import LhcBestKnowledgeCreator, LhcModelCreator
+from omc3.model.model_creators.lhc_model_creator import (
+    LhcBestKnowledgeCreator, LhcModelCreator)
 from omc3.model_creator import create_instance_and_model
 
 INPUTS = Path(__file__).parent.parent / "inputs"
@@ -116,6 +119,28 @@ def test_lhc_creation_nominal_driven(tmp_path):
         outputdir=tmp_path, type="nominal", logfile=tmp_path / "madx_log.txt", **accel_opt
     )
     check_accel_from_dir_vs_options(tmp_path, accel_opt, accel, required_keys=["beam", "year"])
+
+
+@pytest.mark.basic
+@pytest.mark.parametrize(
+    "test_year, uses_ats, uses_run3", 
+    [("2012", False, False), ("2018", True, False), ("2022", True, True), ("hllhc1.3", False, False)]
+)
+def test_lhc_creation_use_ats_and_run3_macros(test_year, uses_ats, uses_run3):
+    accel_opt = dict(
+        accel="lhc",
+        year=test_year,
+        beam=1,
+        nat_tunes=[0.28, 0.31],
+        drv_tunes=[0.27, 0.332],
+        driven_excitation="acd",
+        dpp=0.0,
+        energy=6.5,
+        modifiers=[COMP_MODEL / "opticsfile.24_ctpps2"],
+    )
+    accel = get_accelerator(**accel_opt)
+    assert accel._uses_ats_knobs() is uses_ats
+    assert accel._uses_run3_macros() is uses_run3
 
 
 @pytest.mark.basic

--- a/tests/unit/test_model_creator.py
+++ b/tests/unit/test_model_creator.py
@@ -3,13 +3,10 @@ import shutil
 from pathlib import Path
 
 import pytest
-from omc3.model.accelerators.accelerator import (AcceleratorDefinitionError,
-                                                 AccExcitationMode)
-from omc3.model.constants import (TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT,
-                                  TWISS_ELEMENTS_DAT)
+from omc3.model.accelerators.accelerator import AcceleratorDefinitionError, AccExcitationMode
+from omc3.model.constants import TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT
 from omc3.model.manager import get_accelerator
-from omc3.model.model_creators.lhc_model_creator import (
-    LhcBestKnowledgeCreator, LhcModelCreator)
+from omc3.model.model_creators.lhc_model_creator import LhcBestKnowledgeCreator, LhcModelCreator
 from omc3.model_creator import create_instance_and_model
 
 INPUTS = Path(__file__).parent.parent / "inputs"


### PR DESCRIPTION
Currently the LHC model creator will call ats macros (tune matching for instance) only if the year is exactly "2018". Similarly, it calls the run3 macros file only if the year is exactly "2022".

This quick change checks that the year is `>=` to these values (with `int` conversion) and not strictly equal.
It also corrects the run 3 macros to use the proper knobs (`op` or `sq` depending on optics).

I have updated the version number to make this a patch release.