### PR TITLE
Proper use of vectorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### ????-??-?? - v0.4.2 - _fesoubel_
+
+- Fixed:
+  - Some functions in the `kmod` analysis are now properly vectorized.
+
 #### 2022-06-21 - v0.4.1 - _jdilly_, _fesoubel_
 
 - Fixed:

--- a/omc3/kmod/analysis.py
+++ b/omc3/kmod/analysis.py
@@ -146,7 +146,7 @@ def fit_prec(x, beta_av):
     return dQ
 
 
-np.vectorize(fit_prec)
+fit_prec = np.vectorize(fit_prec)
 
 
 def fit_approx(x, beta_av):
@@ -154,7 +154,7 @@ def fit_approx(x, beta_av):
     return dQ
 
 
-np.vectorize(fit_approx)
+fit_approx = np.vectorize(fit_approx)
 
 
 def average_beta_from_Tune(Q, TdQ, l, Dk):


### PR DESCRIPTION
The `np.vectorize` function returns a callable which has to be assigned, and previously was not. This is a simple fix.