### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,13 +28,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,38 +21,21 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Set up env for CodeClimate (push)
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,13 +36,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -29,38 +29,21 @@ jobs:
           #   python-version: 3.10  # jpype1 doesn't build there
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run all tests
         run: python -m pytest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,38 +23,21 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-
       - name: Install package
-        run: pip install '.[doc]'
+        run: python -m pip install '.[doc]'
 
       - name: Build documentation
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,13 +30,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[doc]'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pip'
 
       - name: Upgrade pip, setuptools, wheel, build and twine
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Get full Python version
         id: full-python-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools, wheel, build and twine
-        run: python -m pip install --upgrade pip setuptools wheel build twine
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools, wheel, build and twine
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Build and check build
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-        run: python -m pip install --upgrade pip setuptools wheel build twine
+
+      - name: Upgrade pip, setuptools, wheel, build and twine
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,47 +20,28 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel build twine
 
       - name: Build and check build
         run: |
           python -m build
           twine check dist/*
 
-      - name: Build and publish
+      - name: Publish
         if: ${{ success() }}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python -m build
-          twine check dist/*
           twine upload dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,38 +79,21 @@ jobs:
             python-version: 3.9  # pyTables can't build on that
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run Extended Tests
         run: python -m pytest -m "extended"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,13 +86,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'


### PR DESCRIPTION
Update to the CI workflows making use of the newer versions of certain official worflows.

- Caching and cache management left to the setup-python action
- Properly call pip as module everywhere
- Do not run the build (and build check) twice in the publish repo