### PR TITLE
cleaned logging

### DIFF
--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -266,7 +266,6 @@ def _extract(ldb, knobs_dict: KnobsDict, knob_categories: Sequence[str], time: d
     """
     LOGGER.info(f"---- EXTRACTING KNOBS @ {time} ----")
     knobs = {}
-    knobs_nan_or_inf = []
 
     for category in knob_categories:
         for knob in KNOB_CATEGORIES.get(category, [category]):
@@ -285,21 +284,15 @@ def _extract(ldb, knobs_dict: KnobsDict, knob_categories: Sequence[str], time: d
             timestamps, values = knobvalue[knobkey]
             if len(values) == 0:
                 LOGGER.debug(f"No value for {knob} found")
-                knobs_nan_or_inf.append(knob)
                 continue
 
             value = values[-1]
             if not math.isfinite(value):
                 LOGGER.debug(f"Value for {knob} is not a number or infinite")
-                knobs_nan_or_inf.append(knob)
                 continue
 
             LOGGER.info(f"Knob value for {knob} extracted: {value} (unscaled)")
             knobs[knob].value = value
-
-    if len(knobs_nan_or_inf):
-        LOGGER.info(f"The following knobs didn't return a value (or NaN/Inf):")
-        LOGGER.info(f" {', '.join(knobs_nan_or_inf)}")
 
     return knobs
 

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -2,9 +2,12 @@ r"""
 Knob Extractor
 --------------
 
-Will extract knobs and write them into a file.
-Can also be used to print information about the StateTracker State.
-Fetches data from nxcals through pytimber using the StateTracker fields.
+Entrypoint to extract knobs from ``NXCALS`` at a given time, and eventually write them out to a file.
+This script can also be used to display information about the StateTracker State.
+The data is fetched from ``NXCALS`` through ``pytimber`` using the **StateTracker** fields.
+
+.. note::
+    Please note that access to the GPN is required to use this functionality.
 
 **Arguments:**
 
@@ -61,13 +64,13 @@ Fetches data from nxcals through pytimber using the StateTracker fields.
 
 """
 import argparse
+import logging
 import math
 import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
-import logging
 
 import pandas as pd
 import tfs


### PR DESCRIPTION
This cleans up the logging of knob extractor by suppressing pytimber logs and printing only one statement for missing knob values.