### PR TITLE
Workflows and doc fixes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,7 @@
-# Continous Integration Workflows
+# Continuous Integration Workflows
 
 This package implements different workflows for CI.
-They are organised as follows.
+They are organized as follows.
 
 ### Documentation
 
@@ -12,12 +12,12 @@ It runs on `ubuntu-latest` and one of our supported version, currently `Python 3
 
 Tests are ensured in the `tests` workflow, in two stages.
 The first stage runs our simple tests on all push events (except to `master`), and the second one runs the rest of the testing suite (the `extended` tests).
-Tests run on a matrix of all supported operating systems (ubuntu-20.04, ubuntu-22.04,windows-latest and macos-latest) for all supported Python versions (currently `3.8`, `3.9`, `3.10` and `3.11`).
+Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.11`).
 
 ### Test Coverage
 
-Test coverage is calculated in the `coverage` wokflow, which triggers on pushes to `master` and any push to a `pull request`.
-It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.9`, and reports the coverage results of the test suite to `CodeClimate`.
+Test coverage is calculated in the `coverage` workflow, which triggers on pushes to `master` and any push to a `pull request`.
+It runs on `ubuntu-latest` and `Python 3.9`, and reports the coverage results of the test suite to `CodeClimate`.
 
 ### Regular Testing
 
@@ -26,5 +26,5 @@ It also runs on `Python 3.x` so that newly released Python versions that would b
 
 ### Publishing
 
-Publishing to `PyPI` is done through the `publish` workflow, which triggers anytime a `release` is made of the Github repository.
+Publishing to `PyPI` is done through the `publish` workflow, which triggers anytime a `release` is made of the GitHub repository.
 It builds a `wheel`, checks it, and pushes to `PyPI` if checks are successful.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,10 +30,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.py'
 
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -29,10 +29,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.py'
 
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,10 +32,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.py'
 
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.py'
 
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Upgrade pip, setuptools, wheel, build and twine
         run: python -m pip install --upgrade pip setuptools wheel build twine
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.py'
 
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,38 +22,20 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get full Python version
-        id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
-      - name: Get pip cache dir  # requires pip >= 20.1
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-pip-
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
 
       - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run Basic Tests
         run: python -m pytest -m "not extended and not cern_network"

--- a/doc/entrypoints/analysis.rst
+++ b/doc/entrypoints/analysis.rst
@@ -3,9 +3,15 @@ Analysis
 
 .. automodule:: omc3.hole_in_one
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.amplitude_detuning_analysis
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.run_kmod
     :members:
+    :noindex:
+

--- a/doc/entrypoints/correction.rst
+++ b/doc/entrypoints/correction.rst
@@ -3,9 +3,15 @@ Correction
 
 .. automodule:: omc3.global_correction
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.response_creator
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.check_corrections
     :members:
+    :noindex:
+

--- a/doc/entrypoints/other.rst
+++ b/doc/entrypoints/other.rst
@@ -3,12 +3,20 @@ Other
 
 .. automodule:: omc3.tbt_converter
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.model_creator
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.knob_extractor
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.madx_wrapper
     :members:
+    :noindex:
+

--- a/doc/entrypoints/plotting.rst
+++ b/doc/entrypoints/plotting.rst
@@ -3,18 +3,30 @@ Plotting
 
 .. automodule:: omc3.plotting.plot_optics_measurements
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.plot_tfs
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.plot_spectrum
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.plot_checked_corrections
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.plot_amplitude_detuning
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.plot_bbq
     :members:
+    :noindex:
+

--- a/doc/entrypoints/scripts.rst
+++ b/doc/entrypoints/scripts.rst
@@ -3,19 +3,30 @@ Scripts
 
 .. automodule:: omc3.scripts.betabeatsrc_output_converter
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.scripts.merge_kmod_results
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.scripts.update_nattune_in_linfile
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.scripts.write_madx_macros
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.scripts.fake_measurement_from_model
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.scripts.linfile_clean
     :members:
+    :noindex:
 

--- a/doc/modules/correction.rst
+++ b/doc/modules/correction.rst
@@ -3,35 +3,45 @@ Correction
 
 .. automodule:: omc3.correction.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.filters
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.handler
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.model_appenders
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.model_diff
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.response_madx
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.response_twiss
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.sequence_evaluation
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.correction.response_io
     :members:
+    :noindex:
+

--- a/doc/modules/definitions.rst
+++ b/doc/modules/definitions.rst
@@ -3,8 +3,10 @@ Definitions
 
 .. automodule:: omc3.definitions.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.definitions.formats
     :members:
+    :noindex:
 

--- a/doc/modules/harpy.rst
+++ b/doc/modules/harpy.rst
@@ -3,22 +3,25 @@ Harpy
 
 .. automodule:: omc3.harpy.clean
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.harpy.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.harpy.frequency
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.harpy.handler
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.harpy.kicker
     :members:
-
-
+    :noindex:
 

--- a/doc/modules/kmod.rst
+++ b/doc/modules/kmod.rst
@@ -3,11 +3,15 @@ Kmod
 
 .. automodule:: omc3.kmod.analysis
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.kmod.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.kmod.helper
     :members:
+    :noindex:
+

--- a/doc/modules/model.rst
+++ b/doc/modules/model.rst
@@ -3,55 +3,70 @@ Model
 
 .. automodule:: omc3.model.manager
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.accelerator
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.esrf
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.lhc
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.ps
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.psbooster
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.skekb
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.iota
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.accelerators.petra
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.model_creators.lhc_model_creator
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.model_creators.ps_model_creator
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.model_creators.psbooster_model_creator
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.model.model_creators.segment_creator
     :members:
+    :noindex:
+

--- a/doc/modules/optics_measurements.rst
+++ b/doc/modules/optics_measurements.rst
@@ -3,65 +3,80 @@ Optics Measurements
 
 .. automodule:: omc3.optics_measurements.measure_optics
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.beta_from_amplitude
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.beta_from_phase
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.chromatic
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.crdt
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.data_models
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.dispersion
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.dpp
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.iforest
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.interaction_point
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.kick
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.phase
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.rdt
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.toolbox
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.optics_measurements.tune
     :members:
-
+    :noindex:
 

--- a/doc/modules/plotting.rst
+++ b/doc/modules/plotting.rst
@@ -4,12 +4,14 @@ Plot-Subfunctions
 Optics Measurements Plots
 =========================
 
-
 .. automodule:: omc3.plotting.optics_measurements.constants
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.optics_measurements.utils
     :members:
+    :noindex:
 
 
 Spectrum Plots
@@ -17,14 +19,17 @@ Spectrum Plots
 
 .. automodule:: omc3.plotting.spectrum.stem
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.plotting.spectrum.waterfall
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.plotting.spectrum.utils
     :members:
+    :noindex:
 
 
 Common Plot Functionality
@@ -32,13 +37,20 @@ Common Plot Functionality
 
 .. automodule:: omc3.plotting.utils.annotations
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.utils.colors
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.utils.lines
     :members:
+    :noindex:
+
 
 .. automodule:: omc3.plotting.utils.style
     :members:
+    :noindex:
 

--- a/doc/modules/tune_analysis.rst
+++ b/doc/modules/tune_analysis.rst
@@ -1,23 +1,27 @@
 Tune Analysis
 **************************
 
-
 .. automodule:: omc3.tune_analysis.constants
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.tune_analysis.bbq_tools
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.tune_analysis.fitting_tools
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.tune_analysis.kick_file_modifiers
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.tune_analysis.timber_extract
     :members:
+    :noindex:
 

--- a/doc/modules/utils.rst
+++ b/doc/modules/utils.rst
@@ -1,32 +1,37 @@
 Utils
 **************************
 
-
 .. automodule:: omc3.utils.contexts
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.iotools
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.logging_tools
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.mock
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.outliers
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.stats
     :members:
+    :noindex:
 
 
 .. automodule:: omc3.utils.time_tools
     :members:
-
+    :noindex:
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ EXTRA_DEPENDENCIES = {
     ],
     "doc": [
         "sphinx",
-        "travis-sphinx",
         "sphinx_rtd_theme",
     ],
 }


### PR DESCRIPTION
While looking at the workflows in #416 I realized we were still using the deprecated `set-output` in this repo (which is not needed anymore) and had an inconsistency in the `basic` and `extended` tests steps.

Edit: also fixes the over-indexing in the docs.

No code change in this PR.