### PR TITLE
Fix CO units issue in BBsrc converter

### DIFF
--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/scripts/betabeatsrc_output_converter.py
+++ b/omc3/scripts/betabeatsrc_output_converter.py
@@ -319,9 +319,9 @@ def convert_old_closed_orbit(
 
     dframe = tfs.read(old_file_path)
     dframe = dframe.rename(columns={f"STD{plane}": f"{ERR}{plane}"})
-    # The Closed Orbit is in [mm] in BB.src but in [m] in omc3, so we divide by 1e3
-    dframe[f"{DELTA}{plane}"] = df_diff(dframe, f"{plane}", f"{plane}{MDL}") / 1e3
-    dframe[f"{ERR}{DELTA}{plane}"] = dframe.loc[:, f"{ERR}{plane}"].to_numpy() / 1e3
+    # The Closed Orbit is in [mm] in BB.src but in [m] in omc3, so we multiply by 1e-3
+    dframe[f"{DELTA}{plane}"] = df_diff(dframe, f"{plane}", f"{plane}{MDL}") * 1e-3
+    dframe[f"{ERR}{DELTA}{plane}"] = dframe.loc[:, f"{ERR}{plane}"].to_numpy() * 1e-3
     tfs.write(Path(outputdir) / f"{new_file_name}{plane.lower()}{EXT}", dframe)
 
 

--- a/omc3/scripts/betabeatsrc_output_converter.py
+++ b/omc3/scripts/betabeatsrc_output_converter.py
@@ -319,8 +319,9 @@ def convert_old_closed_orbit(
 
     dframe = tfs.read(old_file_path)
     dframe = dframe.rename(columns={f"STD{plane}": f"{ERR}{plane}"})
-    dframe[f"{DELTA}{plane}"] = df_diff(dframe, f"{plane}", f"{plane}{MDL}")
-    dframe[f"{ERR}{DELTA}{plane}"] = dframe.loc[:, f"{ERR}{plane}"].to_numpy()
+    # The Closed Orbit is in [mm] in BB.src but in [m] in omc3, so we divide by 1e3
+    dframe[f"{DELTA}{plane}"] = df_diff(dframe, f"{plane}", f"{plane}{MDL}") / 1e3
+    dframe[f"{ERR}{DELTA}{plane}"] = dframe.loc[:, f"{ERR}{plane}"].to_numpy() / 1e3
     tfs.write(Path(outputdir) / f"{new_file_name}{plane.lower()}{EXT}", dframe)
 
 


### PR DESCRIPTION
Closes #435.

Fix is simply to divide by 1e3 when doing the conversion to go from the `mm` of BBsrc to the `m` of omc3.