### PR TITLE
Use modifiers for knobs madx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - removed `corrections.madx` from `lhc` best-knowledge model
     - zip up log-output files in `response_madx.py`
     - keep 0th output file in `response_madx.py` for reference of the model setup
+    - Sequence and modifiers use the acc-models symlink in madx-jobs where applicable.
 
 #### 2024-06-05 - v0.14.1 - _jdilly_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     - removed hard-coded `knobs.madx` from `lhc`
     - removed `corrections.madx` from `lhc` best-knowledge model
     - zip up log-output files in `response_madx.py`
-    - keep 0th output file in `response_madx.py` for reference
+    - keep 0th output file in `response_madx.py` for reference of the model setup
 
 #### 2024-06-05 - v0.14.1 - _jdilly_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OMC3 Changelog
 
+#### 2024-07-08 - v0.15.0 - _jdilly_
+
+- PINNING NUMPY TO < 2.0.0
+
+- Changed:
+  - Model creation:
+    - removed hard-coded `knobs.madx` from `lhc`
+    - removed `corrections.madx` from `lhc` best-knowledge model
+    - zip up log-output files in `response_madx.py`
+    - keep 0th output file in `response_madx.py` for reference
+
 #### 2024-06-05 - v0.14.1 - _jdilly_
 
 - Fixed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.14.1"
+__version__ = "0.15.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/correction/response_madx.py
+++ b/omc3/correction/response_madx.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Dict, Sequence, Tuple, List
 
 import numpy as np
+import zipfile
 import pandas as pd
 import tfs
 from optics_functions.coupling import coupling_via_cmatrix
@@ -140,8 +141,8 @@ def _clean_up(temp_dir: Path, num_proc: int) -> None:
         full_log += log_path.read_text()
         log_path.unlink()
         job_path.unlink()
-    full_log_path = temp_dir / "response_madx_full.log"
-    full_log_path.write_text(full_log)
+    full_log_name = "response_madx_full.log"
+    zipfile.ZipFile(temp_dir / f"{full_log_name}.zip", mode="w").writestr(full_log_name, full_log)
 
 
 def _load_madx_results(

--- a/omc3/correction/response_madx.py
+++ b/omc3/correction/response_madx.py
@@ -140,9 +140,16 @@ def _clean_up(temp_dir: Path, num_proc: int) -> None:
         log_path = job_path.with_name(f"{job_path.name}.log")
         full_log += log_path.read_text()
         log_path.unlink()
-        job_path.unlink()
+        if index:  # keep 0th for reference
+            job_path.unlink()
+    
+    # write compressed full log file
     full_log_name = "response_madx_full.log"
-    zipfile.ZipFile(temp_dir / f"{full_log_name}.zip", mode="w").writestr(full_log_name, full_log)
+    zipfile.ZipFile(
+        temp_dir / f"{full_log_name}.zip", 
+        mode="w", 
+        compression=zipfile.ZIP_DEFLATED
+    ).writestr(full_log_name, full_log)
 
 
 def _load_madx_results(

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -459,16 +459,16 @@ def _write_knobsfile(output: Union[Path, str], collected_knobs: tfs.TfsDataFrame
 def _get_knobs_def_file(user_defined: Optional[Union[Path, str]] = None) -> Path:
     """ Check which knobs-definition file is appropriate to take. """
     if user_defined is not None:
-        LOGGER.info(f"Using user defined knobs defition file: '{user_defined}")
+        LOGGER.info(f"Using user knobs-definition file: '{user_defined}")
         return Path(user_defined)
 
     if KNOBS_FILE_ACC_MODELS.is_file():
-        LOGGER.info(f"Using model folder's knobs.txt as definition file: '{KNOBS_FILE_ACC_MODELS}")
+        LOGGER.info(f"Using given acc-models folder's knobs.txt as knobsdefinition file: '{KNOBS_FILE_ACC_MODELS}")
         return KNOBS_FILE_ACC_MODELS
 
     if KNOBS_FILE_AFS.is_file():
         # if all fails, fall back to lhc acc-models
-        LOGGER.info(f"Using afs-fallback knobs.txt as definition file: '{KNOBS_FILE_AFS}'")
+        LOGGER.info(f"Using afs-fallback acc-models folder's knobs.txt as knobs-definition file: '{KNOBS_FILE_AFS}'")
         return KNOBS_FILE_AFS
 
     raise FileNotFoundError("None of the knobs-definition files are available.")

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -33,8 +33,6 @@ The data is fetched from ``NXCALS`` through ``pytimber`` using the **StateTracke
     Specify user-defined output path. This should probably be
     `model_dir/knobs.madx`
 
-    default: ``knobs.madx``
-
 
 - **state**:
 
@@ -461,16 +459,16 @@ def _write_knobsfile(output: Union[Path, str], collected_knobs: tfs.TfsDataFrame
 def _get_knobs_def_file(user_defined: Optional[Union[Path, str]] = None) -> Path:
     """ Check which knobs-definition file is appropriate to take. """
     if user_defined is not None:
-        LOGGER.info(f"Using user defined knobs.txt: '{user_defined}")
+        LOGGER.info(f"Using user defined knobs defition file: '{user_defined}")
         return Path(user_defined)
 
     if KNOBS_FILE_ACC_MODELS.is_file():
-        LOGGER.info(f"Using model folder's knobs.txt: '{KNOBS_FILE_ACC_MODELS}")
+        LOGGER.info(f"Using model folder's knobs.txt as definition file: '{KNOBS_FILE_ACC_MODELS}")
         return KNOBS_FILE_ACC_MODELS
 
     if KNOBS_FILE_AFS.is_file():
         # if all fails, fall back to lhc acc-models
-        LOGGER.info(f"Using fallback knobs.txt: '{KNOBS_FILE_AFS}'")
+        LOGGER.info(f"Using afs-fallback knobs.txt as definition file: '{KNOBS_FILE_AFS}'")
         return KNOBS_FILE_AFS
 
     raise FileNotFoundError("None of the knobs-definition files are available.")

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -423,7 +423,6 @@ class Lhc(Accelerator):
         madx_script += "option, -echo;  ! suppress output from base sequence loading to keep the log small\n"
         madx_script += self.load_main_seq_madx()
         madx_script += "\noption, echo;  ! re-enable output to see the optics settings\n"
-        madx_script += "\n\n"
         
         madx_script += "\n! ---- Call optics and other modifiers ----\n"
 

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -422,10 +422,10 @@ class Lhc(Accelerator):
         madx_script += "\n! ----- Calling Sequence -----\n"
         madx_script += "option, -echo;  ! suppress output from base sequence loading to keep the log small\n"
         madx_script += self.load_main_seq_madx()
+        madx_script += "\noption, echo;  ! re-enable output to see the optics settings\n"
         madx_script += "\n\n"
         
         madx_script += "\n! ---- Call optics and other modifiers ----\n"
-        madx_script += "option, echo;  ! re-enable output to see the optics settings\n"
 
         if self.modifiers is not None:
             madx_script += "".join(
@@ -450,7 +450,6 @@ class Lhc(Accelerator):
             "\n! ----- Finalize Sequence -----\n"
             "exec, cycle_sequences();\n"
             f"use, sequence = LHCB{self.beam};\n"
-            f"option, echo;\n"
         )
 
         if best_knowledge:
@@ -466,7 +465,7 @@ class Lhc(Accelerator):
             madx_script += "exec, high_beta_matcher();\n"
 
         madx_script += f"\n! ----- Matching Knobs and Output Files -----\n"
-        
+
         # in the best knowledge case, all knobs are loaded from actual knowledge
         if not best_knowledge:
             if self._uses_ats_knobs():

--- a/omc3/model/constants.py
+++ b/omc3/model/constants.py
@@ -38,6 +38,6 @@ B2_ERRORS_TFS = "b2_errors.tfs"
 PLANE_TO_HV = dict(X="H", Y="V")
 
 AFS_ACCELERATOR_MODEL_REPOSITORY = Path("/afs/cern.ch/eng/acc-models")
-MODIFIER_SUBDIR = "operation/optics"
+OPTICS_SUBDIR = "operation/optics"
 
 AFS_B2_ERRORS_ROOT = Path("/afs/cern.ch/eng/sl/lintrack/error_tables/")

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -10,51 +10,10 @@ from typing import List, Sequence, Union
 
 from omc3.model.accelerators.accelerator import Accelerator, AccExcitationMode
 from omc3.model.constants import TWISS_AC_DAT, TWISS_ADT_DAT, TWISS_DAT, TWISS_ELEMENTS_DAT
+from omc3.utils import iotools, logging_tools
 
 
-def always_true(_: Path) -> bool:
-    return True
-
-
-def check_folder_choices(parent: Path, msg: str,
-                          selection: str,
-                          list_choices: bool = False,
-                          predicate=always_true) -> Path:
-    """
-    A helper function that scans a selected folder for children, which will then be displayed as possible choices
-    
-    Args:
-        parent (Path): The folder to scan
-        msg (str): The message to display, on failure
-        selection (str): The current selection
-        list_choices (bool): Whether to just list the choices. In that case `None` is returned, instead
-        of an error
-        predicate (callable): A function that takes a path and returns True if the path results in
-        a valid choice
-
-    Examples:
-        Let's say we expect a choice for a sequence file in the folder `model_root`.
-
-        ```
-        check_folder_choices(model_root, "Expected sequence file", predicate=lambda p: p.suffix == ".seq")
-        ```
-
-        Or we want all subfolder of `scenarios`
-
-        ```
-        check_folder_choices(scenarios, "Expected scenario folder", predicate=lambda p: p.is_dir())
-        ```
-    """
-    choices = [d.name for d in parent.iterdir() if predicate(d)]
-
-    if selection is not None and selection in choices:
-        return parent / selection
-
-    if list_choices:
-        for choice in choices:
-            print(choice)
-        return None
-    raise AttributeError(f"{msg}.\nSelected: '{selection}'.\nChoices: [{', '.join(choices)}]")
+LOGGER = logging_tools.get_logger(__file__)
 
 
 class ModelCreator(ABC):
@@ -63,23 +22,22 @@ class ModelCreator(ABC):
     functions are defined here.
     """
 
-
     @classmethod
     @abstractmethod
-    def get_options(cls, accel_inst: Accelerator, options) -> bool:
+    def check_options(cls, accel_inst: Accelerator, options) -> bool:
         """
-        Parses additional commandline options (if any). To be overridden by subclasses.
-        If there are options that ask for some output print, and no valid model to be created, return False.
+        Parses additional commandline options (if any) and checks if they are valid.
+        If there are options missing, return False. 
+        This function is different from the normal parsing of options, as it allows the 
+        model creator to print possible choices for the user.        
 
         Args:
-            options: The remaining options (e.g. if called by model_creater, those not yet consumed by
-                                            the model creator)
+            options: The remaining options (i.e. those not yet consumed by the model creator)
 
         Returns: True if enough options are given to provide a valid model
 
         """
         return True
-
 
     @classmethod
     @abstractmethod
@@ -164,3 +122,91 @@ class ModelCreator(ABC):
                 raise FileNotFoundError(
                     f"Model Creation Failed. The file '{file_path.absolute()}' was not created."
                 )
+
+    @staticmethod
+    def prepare_symlink(accel: Accelerator):
+        """Prepare the acc-models-symlink.
+        Create symlink if it does not yet exist or points the wrong way.
+        Use the symlink from here on instead of the acc-model-path, also in the modifiers.
+
+        This functions can be used by all model creators supporting the acc-models creation.
+
+        Args:
+            accel (Accelerator): Accelerator instance 
+        """
+        if accel.acc_model_path is None:
+            return
+
+        target = accel.acc_model_path
+        link = Path(accel.model_dir) / accel.REPOSITORY
+
+        if link.is_symlink() or link.exists():
+            # something is here
+            if not link.resolve().samefile(target.resolve()):
+                # and it's not pointing at the right target
+                LOGGER.warning(
+                    f"{accel.REPOSITORY} already exists in model dir {accel.model_dir}. "
+                    f"It will be reset to {target}."
+                )
+                link.unlink()
+                link.absolute().symlink_to(target)
+            # else: link already points to the right target -> leave as is
+
+        else:
+            # no symlink so we create one
+            link.absolute().symlink_to(target)
+        
+        # use the link from now on as model path and for modifiers
+        accel.acc_model_path = link.absolute()
+        if accel.modifiers is not None:
+            accel.modifiers = [
+                iotools.replace_in_path(m.absolute(), target.absolute(), link.absolute()) 
+                for m in accel.modifiers
+            ]
+
+
+def check_folder_choices(parent: Path, msg: str,
+                         selection: str,
+                         list_choices: bool = False,
+                         predicate=iotools.always_true) -> Path:
+    """
+    A helper function that scans a selected folder for children, which will then be displayed as possible choices.
+    This funciton allows the model-creator to get only the file/folder names, check
+    in the desired folder if the choice is present and return the full path to the selected folder.
+    
+    Args:
+        parent (Path): The folder to scan.
+        msg (str): The message to display, on failure.
+        selection (str): The current selection.
+        list_choices (bool): Whether to just list the choices. 
+                             In that case `None` is returned, instead of an error
+        predicate (callable): A function that takes a path and returns True.
+                              if the path results in a valid choice.
+    
+    Returns:
+       Path: Full path of the selected choice in `parent`.
+
+    Examples:
+        Let's say we expect a choice for a sequence file in the folder `model_root`.
+
+        ```
+        check_folder_choices(model_root, "Expected sequence file", predicate=lambda p: p.suffix == ".seq")
+        ```
+
+        Or we want all subfolder of `scenarios`
+
+        ```
+        check_folder_choices(scenarios, "Expected scenario folder", predicate=lambda p: p.is_dir())
+        ```
+    """
+    choices = [d.name for d in parent.iterdir() if predicate(d)]
+
+    if selection is not None and selection in choices:
+        return parent / selection
+
+    if list_choices:
+        for choice in choices:
+            print(choice)
+        return None
+    raise AttributeError(f"{msg}.\nSelected: '{selection}'.\nChoices: [{', '.join(choices)}]")
+

--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -5,7 +5,6 @@ LHC Model Creator
 This module provides convenience functions for model creation of the ``LHC``.
 """
 import logging
-import pathlib
 import shutil
 from pathlib import Path
 from typing import List
@@ -31,11 +30,11 @@ from omc3.model.constants import (
     TWISS_ELEMENTS_DAT,
     PATHFETCHER, AFSFETCHER,  # GITFETCHER, LSAFETCHER,
     AFS_ACCELERATOR_MODEL_REPOSITORY,
-    MODIFIER_SUBDIR,
+    OPTICS_SUBDIR,
     AFS_B2_ERRORS_ROOT,
 )
 from omc3.model.model_creators.abstract_model_creator import ModelCreator, check_folder_choices
-from omc3.utils import iotools
+from omc3.utils.iotools import get_check_suffix_func, create_dirs
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,29 +51,42 @@ class LhcModelCreator(ModelCreator):
     acc_model_name = "lhc"
 
     @classmethod
-    def get_options(cls, accel_inst, opt) -> bool:
+    def check_options(cls, accel: Lhc, opt) -> bool:
+        """ Use the fetcher to list choices if requested. """
+        
+        # Set the fetcher paths ---
         if opt.fetch == PATHFETCHER:
-            accel_inst.acc_model_path = Path(opt.path)
+            accel.acc_model_path = Path(opt.path)
+
         elif opt.fetch == AFSFETCHER:
-            accel_inst.acc_model_path = check_folder_choices(AFS_ACCELERATOR_MODEL_REPOSITORY / cls.acc_model_name,
-                                                             "No optics tag (flag --year) given",
-                                                             accel_inst.year,
-                                                             opt.list_choices,
-                                                             lambda path: path.is_dir())
+            # list 'year' choices ---
+            accel.acc_model_path = check_folder_choices(
+                AFS_ACCELERATOR_MODEL_REPOSITORY / cls.acc_model_name,
+                msg="No optics tag (flag --year) given",
+                selection=accel.year,
+                list_choices=opt.list_choices,
+                predicate=Path.is_dir
+            )
         else:
-            raise AttributeError(f"{accel_inst.NAME} model creation requires one of the following fetchers: "
-                                 f"[{PATHFETCHER}, {AFSFETCHER}]. "
-                                 "Please provide one with the flag `--fetch afs` "
-                                 "or `--fetch path --path PATH`.")
-        if accel_inst.acc_model_path is None:
+            raise AttributeError(
+                f"{accel.NAME} model creation requires one of the following fetchers: "
+                f"[{PATHFETCHER}, {AFSFETCHER}]. "
+                "Please provide one with the flag `--fetch afs` "
+                "or `--fetch path --path PATH`."
+            )
+
+        if accel.acc_model_path is None:
             return False
 
+        # list optics choices ---
         if opt.list_choices:
-            check_folder_choices(accel_inst.acc_model_path / MODIFIER_SUBDIR,
-                                 "No modifier given",
-                                 None,
-                                 True,
-                                 lambda path: path.suffix == ".madx")
+            check_folder_choices(
+                accel.acc_model_path / OPTICS_SUBDIR,
+                msg="No modifier given",
+                selection=None,  # TODO: could check if user made valid choice
+                list_choices=opt.list_choices,
+                predicate=get_check_suffix_func(".madx")
+            )
             return False
 
         return True
@@ -120,17 +132,13 @@ class LhcModelCreator(ModelCreator):
     @classmethod
     def prepare_run(cls, accel: Lhc) -> None:
         LOGGER.info("preparing run ...")
-        if accel.acc_model_path is not None:
-            link = Path(accel.model_dir)/accel.REPOSITORY
-            target = accel.acc_model_path
-            if not link.exists():
-                link.absolute().symlink_to(target)
-
+        cls.prepare_symlink(accel)
         cls.check_accelerator_instance(accel)
+        
         LOGGER.debug("Preparing model creation structure")
         macros_path = accel.model_dir / MACROS_DIR
         LOGGER.info("creating macros dirs")
-        iotools.create_dirs(macros_path)
+        create_dirs(macros_path)
 
         LOGGER.debug("Copying macros to model directory")
         lib_path = Path(__file__).parent.parent / "madx_macros"
@@ -197,11 +205,12 @@ class LhcModelCreator(ModelCreator):
             )
 
 
+
 class LhcBestKnowledgeCreator(LhcModelCreator):
     EXTRACTED_MQTS_FILENAME: str = "extracted_mqts.str"
 
     @classmethod
-    def get_options(cls, accel_inst, opt) -> bool:
+    def check_options(cls, accel_inst, opt) -> bool:
 
         if accel_inst.list_b2_errors:
             errors_dir = AFS_B2_ERRORS_ROOT / f"Beam{accel_inst.beam}"
@@ -210,7 +219,7 @@ class LhcBestKnowledgeCreator(LhcModelCreator):
                     print(d.stem)
             return False
 
-        return super().get_options(accel_inst, opt)
+        return super().check_options(accel_inst, opt)
 
     @classmethod
     def get_madx_script(cls, accel: Lhc) -> str:

--- a/omc3/model/model_creators/lhc_model_creator.py
+++ b/omc3/model/model_creators/lhc_model_creator.py
@@ -199,7 +199,6 @@ class LhcModelCreator(ModelCreator):
 
 class LhcBestKnowledgeCreator(LhcModelCreator):
     EXTRACTED_MQTS_FILENAME: str = "extracted_mqts.str"
-    CORRECTIONS_FILENAME: str = "corrections.madx"
 
     @classmethod
     def get_options(cls, accel_inst, opt) -> bool:
@@ -219,11 +218,7 @@ class LhcBestKnowledgeCreator(LhcModelCreator):
             raise AcceleratorDefinitionError(
                 "Don't set ACD or ADT for best knowledge model.")
 
-        corrections_file = accel.model_dir / \
-            cls.CORRECTIONS_FILENAME  # existence is tested in madx
-
         madx_script = accel.get_base_madx_script(best_knowledge=True)
-        madx_script += f"call, file = '{corrections_file}';\n"
 
         mqts_file = accel.model_dir / cls.EXTRACTED_MQTS_FILENAME
         if mqts_file.exists():

--- a/omc3/model/model_creators/ps_base_model_creator.py
+++ b/omc3/model/model_creators/ps_base_model_creator.py
@@ -7,12 +7,9 @@ from omc3.model.constants import (AFS_ACCELERATOR_MODEL_REPOSITORY, AFSFETCHER,
                                   PATHFETCHER)
 from omc3.model.model_creators.abstract_model_creator import ModelCreator, check_folder_choices
 from omc3.utils import logging_tools
+from omc3.utils.iotools import get_check_suffix_func
 
 LOGGER = logging_tools.get_logger(__name__)
-
-
-def is_str_file(path: Path) -> bool:
-    return path.suffix == ".str"
 
 
 class PsBaseModelCreator(ModelCreator):
@@ -26,60 +23,74 @@ class PsBaseModelCreator(ModelCreator):
         )
 
     @classmethod
-    def get_options(cls, accel_inst, opt) -> bool:
+    def check_options(cls, accel_inst, opt) -> bool:
         if opt.fetch == PATHFETCHER:
             accel_inst.acc_model_path = Path(opt.path)
+
         elif opt.fetch == AFSFETCHER:
-            accel_inst.acc_model_path = check_folder_choices(AFS_ACCELERATOR_MODEL_REPOSITORY / cls.acc_model_name,
-                                                              "No optics tag (flag --year) given",
-                                                              accel_inst.year,
-                                                              opt.list_choices)
+            accel_inst.acc_model_path = check_folder_choices(
+                AFS_ACCELERATOR_MODEL_REPOSITORY / cls.acc_model_name,
+                msg="No optics tag (flag --year) given",
+                selection=accel_inst.year,
+                list_choices=opt.list_choices
+            )
         else:
-            raise AttributeError(f"{accel_inst.NAME} model creation requires one of the following fetchers: "
-                                 f"[{PATHFETCHER}, {AFSFETCHER}]. "
-                                 "Please provide one with the flag `--fetch afs` "
-                                 "or `--fetch path --path PATH`.")
+            raise AttributeError(
+                f"{accel_inst.NAME} model creation requires one of the following fetchers: "
+                f"[{PATHFETCHER}, {AFSFETCHER}]. "
+                "Please provide one with the flag `--fetch afs` "
+                "or `--fetch path --path PATH`."
+            )
+
         if accel_inst.acc_model_path is None:
             return False
 
-        scenario_path = check_folder_choices(accel_inst.acc_model_path / "scenarios",
-                                              "No scenario (flag --scenario) selected",
-                                              accel_inst.scenario,
-                                              opt.list_choices)
+        scenario_path = check_folder_choices(
+            accel_inst.acc_model_path / "scenarios",
+            msg="No scenario (flag --scenario) selected",
+            selection=accel_inst.scenario,
+            list_choices=opt.list_choices
+        )
         if scenario_path is None:
             return False
 
-        cycle_point_path = check_folder_choices(scenario_path,
-                                                 "No cycle_point (flag --cycle_point) selected",
-                                                 accel_inst.cycle_point,
-                                                 opt.list_choices)
+        cycle_point_path = check_folder_choices(
+            scenario_path,
+            msg="No cycle_point (flag --cycle_point) selected",
+            selection=accel_inst.cycle_point,
+            list_choices=opt.list_choices
+        )
         if cycle_point_path is None:
             return False
 
-        str_file = check_folder_choices(cycle_point_path,
-                                         "No strength file (flag --str_file) selected",
-                                         accel_inst.str_file,
-                                         opt.list_choices,
-                                         is_str_file
-                                         )
+        str_file = check_folder_choices(
+            cycle_point_path,
+            msg="No strength file (flag --str_file) selected",
+            selection=accel_inst.str_file,
+            list_choices=opt.list_choices,
+            predicate=get_check_suffix_func(".str")
+        )
         if str_file is None:
             return False
 
 
         accel_inst.str_file = str_file
         possible_beam_files = list(cycle_point_path.glob("*.beam"))
+
         # if now `.beam` file is found, try any madx job file, maybe we get lucky there
-        if len(possible_beam_files) == 0:
+        if not len(possible_beam_files):
             possible_beam_files = list(cycle_point_path.glob("*.*job"))
+        
+            if not len(possible_beam_files):
+                raise AcceleratorDefinitionError(f"no beam file found in {cycle_point_path}")
 
         if len(possible_beam_files) > 1:
-            LOGGER.error("more than one beam file found in %s. Taking first one: %s",
-                         cycle_point_path,
-                         possible_beam_files[0])
-        if len(possible_beam_files) == 0:
-            raise AcceleratorDefinitionError(f"no beam file found in {cycle_point_path}")
+            LOGGER.error(f"More than one beam file found in {cycle_point_path}. "
+                         f"Taking first one: {possible_beam_files[0]}")
+
         accel_inst.beam_file = possible_beam_files[0]
-        if accel_inst.beam_file and opt.list_choices:
+
+        if opt.list_choices:
             with open(accel_inst.beam_file) as beamf:
                 print(beamf.read())
             return False

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -20,7 +20,7 @@ from omc3.model.model_creators.lhc_model_creator import (  # noqa
 from omc3.model.model_creators.ps_model_creator import PsModelCreator
 from omc3.model.model_creators.psbooster_model_creator import BoosterModelCreator
 from omc3.model.model_creators.segment_creator import SegmentCreator
-from omc3.utils.iotools import create_dirs, PathOrStr
+from omc3.utils.iotools import create_dirs, PathOrStr, save_config
 from omc3.utils import logging_tools
 from omc3.utils.parsertools import print_help, require_param
 from generic_parser.tools import silence
@@ -151,6 +151,7 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
         print_help(_get_params())
         return None
 
+    
     # proceed to the creator
     accel_inst = manager.get_accelerator(accel_opt)
     require_param("type", _get_params(), opt)
@@ -185,6 +186,10 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
                output_file=opt.outputdir / JOB_MODEL_MADX_MASK.format(opt.type),
                log_file=opt.logfile,
                cwd=opt.outputdir)
+    
+    # Save config at the end, to not being written out for each time the choices are listed
+    save_config(Path(opt.outputdir), opt=opt, unknown_opt=accel_opt, script=__file__)
+    
     # Return accelerator instance
     accel_inst.model_dir = opt.outputdir
     return accel_inst

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -5,13 +5,14 @@ Model Creator
 Entrypoint to run the model creator for LHC, PSBooster and PS models.
 """
 from pathlib import Path
+from typing import Union
 
 from generic_parser import EntryPointParameters, entrypoint
 
 from omc3.madx_wrapper import run_string
 from omc3.model import manager
 from omc3.model.accelerators.accelerator import Accelerator
-from omc3.model.constants import JOB_MODEL_MADX_MASK, PATHFETCHER, AFSFETCHER, GITFETCHER, LSAFETCHER, MODIFIER_SUBDIR
+from omc3.model.constants import JOB_MODEL_MADX_MASK, PATHFETCHER, AFSFETCHER, GITFETCHER, LSAFETCHER, OPTICS_SUBDIR
 from omc3.model.model_creators.lhc_model_creator import (  # noqa
     LhcBestKnowledgeCreator,
     LhcCouplingCreator,
@@ -162,7 +163,7 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
 
     # now that the creator is initialised, we can ask for modifiers that are actually present
     # using the fetcher we chose
-    if not creator.get_options(accel_inst, opt):
+    if not creator.check_options(accel_inst, opt):
         return None
 
     accel_inst.verify_object()
@@ -171,14 +172,14 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
     # Prepare model-dir output directory
     accel_inst.model_dir = Path(opt.outputdir).absolute()
 
+    # adjust modifier paths, to allow giving only filenames in default directories (e.g. optics)
+    if accel_inst.modifiers is not None:
+        accel_inst.modifiers = [_find_modifier(m, accel_inst) for m in accel_inst.modifiers]
+
     # Prepare paths
     create_dirs(opt.outputdir)
     creator.prepare_run(accel_inst)
     
-    # adjust modifier paths,
-    if accel_inst.modifiers is not None:
-        accel_inst.modifiers = [_find_modifier(m, accel_inst) for m in accel_inst.modifiers]
-
     madx_script = creator.get_madx_script(accel_inst)
     # Run madx to create model
     run_string(madx_script,
@@ -194,23 +195,23 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
     return accel_inst
 
 
-def _find_modifier(modifier, accel_inst: Accelerator):
+def _find_modifier(modifier: Path, accel_inst: Accelerator):
     # first case: if modifier exists as is, take it
     if modifier.exists():
         return modifier
 
     # second case: try if it is already in the output dir
-    modifier_path = accel_inst.model_dir / modifier
-    if modifier_path.exists():
-        return modifier_path.absolute()
+    model_dir_path: Path = accel_inst.model_dir / modifier
+    if model_dir_path.exists():
+        return model_dir_path.absolute()
 
     # and last case, try to find it in the acc-models rep
     if accel_inst.acc_model_path is not None:
-        modifier_path = accel_inst.acc_model_path / MODIFIER_SUBDIR / modifier
-        if modifier_path.exists():
-            return modifier_path.absolute()
+        optics_path: Path = accel_inst.acc_model_path / OPTICS_SUBDIR / modifier
+        if optics_path.exists():
+            return optics_path.absolute()
 
-    raise FileNotFoundError(f"couldn't find modifier {modifier}. Tried in {accel_inst.model_dir} and {accel_inst.acc_model_path}/{MODIFIER_SUBDIR}")
+    raise FileNotFoundError(f"couldn't find modifier {modifier}. Tried in {accel_inst.model_dir} and {accel_inst.acc_model_path}/{OPTICS_SUBDIR}")
 
 
 if __name__ == "__main__":

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -171,13 +171,13 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
     # Prepare model-dir output directory
     accel_inst.model_dir = Path(opt.outputdir).absolute()
 
-    # adjust modifier paths,
-    if accel_inst.modifiers is not None:
-        accel_inst.modifiers = [_find_modifier(m, accel_inst) for m in accel_inst.modifiers]
-
     # Prepare paths
     create_dirs(opt.outputdir)
     creator.prepare_run(accel_inst)
+    
+    # adjust modifier paths,
+    if accel_inst.modifiers is not None:
+        accel_inst.modifiers = [_find_modifier(m, accel_inst) for m in accel_inst.modifiers]
 
     madx_script = creator.get_madx_script(accel_inst)
     # Run madx to create model

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -177,7 +177,6 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator:
 
     # Prepare paths
     create_dirs(opt.outputdir)
-    (Path(opt.outputdir) / "knobs.madx").touch()  # create empty knobs.madx for madx job
     creator.prepare_run(accel_inst)
 
     madx_script = creator.get_madx_script(accel_inst)

--- a/omc3/response_creator.py
+++ b/omc3/response_creator.py
@@ -57,6 +57,7 @@ to use. Check :ref:`modules/model:Model` to see which ones are needed.
 
 
 """
+from pathlib import Path
 from typing import Dict
 
 import pandas as pd
@@ -68,7 +69,7 @@ from omc3.correction.response_io import write_fullresponse
 from omc3.global_correction import CORRECTION_DEFAULTS, OPTICS_PARAMS_CHOICES
 from omc3.model import manager
 from omc3.utils import logging_tools
-from omc3.utils.iotools import PathOrStr
+from omc3.utils.iotools import PathOrStr, save_config
 
 LOG = logging_tools.get_logger(__name__)
 
@@ -114,6 +115,9 @@ def create_response_entrypoint(opt: DotDict, other_opt) -> Dict[str, pd.DataFram
     The response matrices can be either created by response_madx or TwissResponse.
     """
     LOG.info("Creating response.")
+    if opt.outfile_path is not None:
+        save_config(Path(opt.outfile_path).parent, opt=opt, unknown_opt=other_opt, script=__file__)
+
     accel_inst = manager.get_accelerator(other_opt)
 
     if opt.creator == "madx":

--- a/omc3/utils/iotools.py
+++ b/omc3/utils/iotools.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Callable, Union
 
 from generic_parser.entry_datatypes import get_instance_faker_meta, get_multi_class
 from generic_parser.entrypoint_parser import save_options_to_config
@@ -167,6 +167,21 @@ def convert_paths_in_dict_to_strings(dict_: dict) -> dict:
     return dict_
 
 
+def replace_in_path(path: Path, old: Union[Path, str], new: Union[Path, str]) -> Path:
+    """ Replace a part of a path with a new path. 
+    Useful for example to replace the original path with a path to a symlink or vice versa.
+
+    Args:
+        path (Path): Path object to replace the subpath in 
+        old (Union[Path, str]): Subpath to be replaced
+        new (Union[Path, str]): Subpath to replace with
+
+    Returns:
+        Path: New Path object with the replacement in.
+    """
+    return Path(str(path).replace(str(old), str(new)))
+
+
 def remove_none_dict_entries(dict_: dict) -> dict:
     """
     Removes ``None`` entries from dict. This can be used as a workaround to
@@ -216,3 +231,17 @@ def save_config(output_dir: Path, opt: dict, script: str,
         dict(sorted(opt.items())),
         unknown=unknown_opt
     )
+
+
+def always_true(*args, **kwargs) -> bool:
+    """ A function that is always True. """
+    return True
+
+
+def get_check_suffix_func(suffix: str) -> Callable[[Path],bool]:
+    """ Returns a function that checks the suffix of a given path agains 
+    the suffix. """
+    def check_suffix(path: Path) -> bool:
+        return path.suffix == suffix
+    return check_suffix
+

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with README.open("r") as docs:
 DEPENDENCIES = [
     "matplotlib>=3.7.0",  # to be able to run with pandas 2.0
     "Pillow>=6.2.2",  # not our dependency but older versions crash with mpl
-    "numpy>=1.19.0",
+    "numpy>=1.19.0,<2.0.0",  # limiting numpy to < 2.0.0 until pytables is fixed
     "pandas>=2.0",
     "scipy>=1.5.0",
     "scikit-learn>=0.23.0",


### PR DESCRIPTION
Instead of having the `knobs.madx` hard-coded they will be given as modifiers from the GUI.
This avoids having to create empty `knobs.madx` file beforehand, whenever you want to create a model.

This PR also cleans up a few more things from the model creation:
- remove the `corrections.madx` from best-knowledge model, as we never used this. 
  If needed in the future, this can also be simply given as a modifier.
- Zip the mad-x output log-file from the response model creation. As this runs in parallel by default, using the number of available cores, the final (merged) log file can be quite big, even with the sequence loading not echoed.
- Also response creation: keep the 0th job-file as reference in the model directory, so that one can check that the setup of the machine is correctly performed.

