### PR TITLE
Fix knob extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### 2024-09-30 - v0.16.2 - _jdilly_
+
+- Fixed:
+  - Temporary hack to fix `knob_extractor` in CCC.
+
 #### 2024-09-20 - v0.16.1 - _fsoubelet_
 
 - Fixed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.16.1"
+__version__ = "0.16.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -283,7 +283,9 @@ def get_params():
 )
 def main(opt) -> tfs.TfsDataFrame:
     """ Main knob extracting function. """
-    ldb = pytimber.LoggingDB(source="nxcals", loglevel=logging.ERROR)
+    ldb = pytimber.LoggingDB(source="nxcals", loglevel=logging.ERROR, 
+                             sparkprops={"spark.ui.showConsoleProgress", "false"}
+    )
     time = _parse_time(opt.time, opt.timedelta)
 
     if opt.state:

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -61,6 +61,19 @@ The data is fetched from ``NXCALS`` through ``pytimber`` using the **StateTracke
 
 
 """
+
+####### WORKAROUND FOR JAVA ISSUES WITH LHCOP ##################################
+# Move `/mcr/bin` to the end of the Path.
+# This ia a hack, please remove at the earliers convenience. Fixes:
+# 'Error: Could not find or load main class (...) aircompressor-0.26.jar'
+import os
+if "PATH" in os.environ and "/mcr/bin" in os.environ["PATH"]:
+    parts = os.environ["PATH"].split(":")
+    parts.remove("/mcr/bin")
+    parts.append("/mcr/bin")  # probably not neccesary
+    os.environ["PATH"] = ":".join(parts)
+################################################################################
+
 import argparse
 import logging
 import math

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -68,7 +68,7 @@ from __future__ import annotations
 # Fixes:
 # 'Error: Could not find or load main class (...) aircompressor-0.26.jar'
 #
-# This ia a hack, please remove at the earliers convenience. For updates see: 
+# This ia a hack, please remove at the earliest convenience. For updates see: 
 # https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC3768823
 import os
 if "PATH" in os.environ and "/mcr/bin" in os.environ["PATH"]:


### PR DESCRIPTION
While we removed `/mcr/bin` from the lhcop `PATH`, which allows us to run the knob-creator in the CCC terminals,
it is still added when starting the CCM (see https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC3768823 ). 

This PR provides a hack to remove it again ...
 