### PR TITLE
Knob extractor spark props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OMC3 Changelog
 
-#### 2024-11-11 - v0.18.1 - _jgray_
+#### 2024-11-11 - v0.18.1 - _jdilly_
 
 - Fixed:
   - Setting sparkprops wrong in `knob_extractor` fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OMC3 Changelog
 
+#### 2024-11-11 - v0.18.1 - _jgray_
+
+- Fixed:
+  - Setting sparkprops wrong in `knob_extractor` fixed.
+  
+
 #### 2024-10-29 - v0.18.0 - _jgray_
 
 - Added:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -284,7 +284,7 @@ def get_params():
 def main(opt) -> tfs.TfsDataFrame:
     """ Main knob extracting function. """
     ldb = pytimber.LoggingDB(source="nxcals", loglevel=logging.ERROR, 
-                             sparkprops={"spark.ui.showConsoleProgress", "false"}
+                             sparkprops={"spark.ui.showConsoleProgress": "false"}
     )
     time = _parse_time(opt.time, opt.timedelta)
 


### PR DESCRIPTION
This fixes
```
15:43:43 - omc3.knob_extractor STDERR: Traceback (most recent call last):
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_acc_py/base/2021.12/lib/python3.9/runpy.py", line 197, in _run_module_as_main
15:43:43 - omc3.knob_extractor STDERR:     return _run_code(code, main_globals, None,
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_acc_py/base/2021.12/lib/python3.9/runpy.py", line 87, in _run_code
15:43:43 - omc3.knob_extractor STDERR:     exec(code, run_globals)
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/omc3/knob_extractor.py", line 633, in <module>
15:43:43 - omc3.knob_extractor STDERR:     main()
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/generic_parser/entrypoint_parser.py", line 451, in wrapper
15:43:43 - omc3.knob_extractor STDERR:     return func(self.parse(*args, **kwargs))
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/omc3/knob_extractor.py", line 286, in main
15:43:43 - omc3.knob_extractor STDERR:     ldb = pytimber.LoggingDB(source="nxcals", loglevel=logging.ERROR, 
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/pytimber/pytimber.py", line 1017, in __init__
15:43:43 - omc3.knob_extractor STDERR:     super().__init__(
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/pytimber/pytimber.py", line 108, in __init__
15:43:43 - omc3.knob_extractor STDERR:     self._spark = spark_session or _get_spark_session(
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/pytimber/spark_session_utils.py", line 34, in _get_spark_session
15:43:43 - omc3.knob_extractor STDERR:     maybe_spark_session = try_to_get_or_create(*args, **kwargs)
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/pytimber/spark_session_utils.py", line 30, in try_to_get_or_create
15:43:43 - omc3.knob_extractor STDERR:     return _get_or_create(flavor=flavor, *args, **kwargs)
15:43:43 - omc3.knob_extractor STDERR:   File "/afs/cern.ch/eng/sl/lintrack/omc_python3/lib/python3.9/site-packages/nxcals/spark_session_builder/__init__.py", line 189, in get_or_create
15:43:43 - omc3.knob_extractor STDERR:     for key, value in conf.items():
15:43:43 - omc3.knob_extractor STDERR: AttributeError: 'set' object has no attribute 'items'
```