### PR TITLE
Add bad bpms reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### 2024-11-21 - v0.20.2 - _jdilly_, _awegsche_
+
+- Added:
+  - `bad_bpms_summary`: Also collect the reasons for the BPMs being bad.
+
 #### 2024-11-14 - v0.20.1 - _jdilly_
 
 - Fixed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.20.1"
+__version__ = "0.20.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -18,6 +18,9 @@ LOGGER = logging_tools.get_logger(__name__)
 ARCS_CONT = 0.01
 IRS_CONT = 0.025
 
+# Columns ---
+FEATURE: str = "FEATURE"
+
 
 def clean_with_isolation_forest(input_files, meas_input, plane):
     bad_bpms = identify_bad_bpms(meas_input, input_files, plane)
@@ -59,7 +62,7 @@ def get_significant_features(bpm_tfs_data, data_for_clustering, bad_bpms, good_b
                         for col in [f"TUNE{plane}", "NOISE_SCALED", f"AMP{plane}"]])
         max_dist, sig_col = max_dist
         features_df.loc[index, "NAME"] = bad_bpms.loc[index, "NAME"]
-        features_df.loc[index, "FEATURE"] = sig_col
+        features_df.loc[index, FEATURE] = sig_col
         features_df.loc[index, "VALUE"] = bpm_tfs_data.loc[index, sig_col]
         features_df.loc[index, "AVG"] = np.mean(bpm_tfs_data.loc[good_bpms.index][sig_col])
     return features_df

--- a/omc3/scripts/bad_bpms_summary.py
+++ b/omc3/scripts/bad_bpms_summary.py
@@ -380,8 +380,7 @@ def evaluate(df: tfs.TfsDataFrame) -> tfs.TfsDataFrame:
         tfs.TfsDataFrame: TfsDataFrame with the evaluated results.
     """
     # If the dataframe was read from file, split the REASONS again
-    strings_mask = df[REASONS].apply(lambda x: isinstance(x, str))
-    df.loc[strings_mask, REASONS] = df.loc[strings_mask, REASONS].str.split("|")
+    df[REASONS] = df[REASONS].map(lambda x: x.split("|") if isinstance(x, str) else x)
 
     # Count how often a BPM is bad, combine reasons
     df_counted = (

--- a/omc3/scripts/bad_bpms_summary.py
+++ b/omc3/scripts/bad_bpms_summary.py
@@ -388,11 +388,9 @@ def evaluate(df: tfs.TfsDataFrame) -> tfs.TfsDataFrame:
                     df.groupby([NAME, ACCEL, SOURCE, PLANE], as_index=False)
                     .agg(
                         COUNT=(NAME, 'size'),  # Count the number of rows in each group
-                        REASONS=(REASONS, lambda x: sum(x, []))  # Flatten and combine the lists
+                        REASONS=(REASONS, lambda x: list(set(sum(x, []))))  # Flatten and combine the lists
                     )
                 )
-    
-    df_counted.loc[:, REASONS] = df_counted[REASONS].apply(lambda x: list(set(x)))  # unique reasons only
 
     # Count the total number of (unique) files for each combination of accelerator, source and plane
     file_count = df.groupby([ACCEL, SOURCE, PLANE])[FILE].nunique().reset_index(name=FILE_COUNT)
@@ -437,7 +435,7 @@ def print_results(df_counted: tfs.TfsDataFrame, print_percentage: float):
                 df_merged = df_merged.sort_values(by='max_pct', ascending=False)
                 df_merged = df_merged.loc[df_merged['max_pct'] >= print_percentage, :]
                 df_merged.loc[:, [f'{REASONS}X', f'{REASONS}Y']] = df_merged.loc[:, [f'{REASONS}X', f'{REASONS}Y']].map(
-                    lambda x: [] if not isinstance(x, list) else x
+                    lambda x: [] if not isinstance(x, list) else x  # could be NaN from merging
                 )
 
                 # Print Table ---

--- a/tests/unit/test_bad_bpms_summary.py
+++ b/tests/unit/test_bad_bpms_summary.py
@@ -2,7 +2,7 @@ import pytest
 import tfs 
 
 from tests.conftest import INPUTS, assert_tfsdataframe_equal
-from omc3.scripts.bad_bpms_summary import NAME, SOURCE, bad_bpms_summary, IFOREST, HARPY
+from omc3.scripts.bad_bpms_summary import NAME, SOURCE, bad_bpms_summary, IFOREST, HARPY, merge_reasons
 import logging
 
 
@@ -19,8 +19,11 @@ def test_bad_bpms_summary(tmp_path, caplog):
             print_percentage=50,
         )
 
-    # Test Data has been written
     assert df_eval is not None
+    assert "Unknown reason" not in caplog.text
+
+    # Test Data has been written
+    df_eval = merge_reasons(df_eval)
     assert_tfsdataframe_equal(df_eval.reset_index(drop=True), tfs.read(outfile))
 
     # Test some random BPMs


### PR DESCRIPTION
Looks now like

```
   INFO | Bad BPMs Summary. Hint: '[BPM]' were filtered as known bad BPMs. | scripts.bad_bpms_summary
   INFO | Highest bad BPMs of LHCB1 from HARPY:
                 BPM          X                   Y           Reasons
         BPM.11R4.B1  100.0% (18/18)      100.0% (18/18)      EXACT_ZERO | FLAT
         BPM.29L6.B1  100.0% (18/18)              -           EXACT_ZERO
          BPM.8L1.B1  100.0% (18/18)              -           EXACT_ZERO | FLAT
        BPMSX.4L8.B1  100.0% (18/18)              -           SPIKY
        BPMSE.4L6.B1  100.0% (18/18)              -           SPIKY
        BPMSX.7R1.B1  100.0% (18/18)      100.0% (18/18)      EXACT_ZERO | FLAT
         BPM.18R2.B1          -            55.6% (10/18)      EXACT_ZERO | scripts.bad_bpms_summary
 ```