### PR TITLE
Fix datetime errors in latest Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OMC3 Changelog
 
+#### 2025-01-06 - v0.20.4 - _fsoubelet_
+
+- Fixed:
+  - Solved an issue in datetime operations occuring on `Python 3.13`.
+
+- Changed:
+  - Dropped support for `Python 3.9`.
+
 #### 2024-11-21 - v0.20.3 - _jdilly_
 
 - Fixed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.20.3"
+__version__ = "0.20.4"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -132,7 +132,7 @@ class AccDatetime(datetime):
     @property
     def local(self):
         """Get local datetime object."""
-        return self.astimezone(self._LOCAL_TIMEZONE)
+        return self.datetime.astimezone(self._LOCAL_TIMEZONE)
 
     @property
     def local_string(self):

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -104,11 +104,12 @@ class AccDatetime(datetime):
             dt = datetime.__new__(cls, *args, **kwargs)
 
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=tz.tzutc())
+            if 'tzinfo' not in kwargs and len(args) < 8:  # allows forcing tz to `None`
+                dt = dt.replace(tzinfo=tz.tzutc())
 
         return datetime.__new__(cls, dt.year, dt.month, dt.day,
                                 dt.hour, dt.minute, dt.second, dt.microsecond,
-                                tzinfo=dt.tzinfo)
+                                tzinfo=dt.tzinfo, fold=dt.fold)
 
     @property
     def datetime(self):
@@ -197,7 +198,7 @@ class AccDatetime(datetime):
     @classmethod
     def from_timestamp(cls, ts):
         """Create `AccDatetime` object from timestamp."""
-        return cls(datetime.utcfromtimestamp(ts))
+        return cls(datetime.fromtimestamp(ts, tz=tz.UTC))
 
     @classmethod
     def now(cls):

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -133,7 +133,7 @@ class AccDatetime(datetime):
     @property
     def local(self):
         """Get local datetime object."""
-        return self.datetime.astimezone(self._LOCAL_TIMEZONE)
+        return self.astimezone(self._LOCAL_TIMEZONE)
 
     @property
     def local_string(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 ]
 license = "MIT"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 classifiers = [
     "Intended Audience :: Science/Research",
@@ -32,10 +32,10 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -44,15 +44,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-# TODO: when we drop python 3.9, require pytables 3.10.1 minimum and stop caring about numpy 2 compability
 dependencies = [
-  "numpy >= 1.24, < 2.0; python_version < '3.10'",  # first pytables compatible with numpy 2 is 3.10 but does not support python 3.9
-  "numpy >= 1.24; python_version >= '3.10'",  # otherwise we can use numpy 2 as on python 3.10 there is a pytables which is ok with it
+  "numpy >= 1.24",
   "scipy >= 1.10",
   "pandas >= 2.1",
   "tfs-pandas >= 3.8",
   "matplotlib >= 3.8",
-  "Pillow >= 6.2.2",  # not our dependency but older versions crash with mpl
+  # "Pillow >= 6.2.2",  # not our dependency but older versions crash with mpl
   "generic-parser >= 1.1",
   "sdds >= 0.4",
   "optics-functions >= 0.1",
@@ -60,7 +58,7 @@ dependencies = [
   "uncertainties >= 3.1",
   "scikit-learn >= 1.0",
   "h5py >= 2.9",
-  "tables >= 3.9",  # TODO: require 3.10.1 minimum when it's out and we drop python 3.9 support
+  "tables >= 3.10.1",
   "requests >= 2.27",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
   "pandas >= 2.1",
   "tfs-pandas >= 3.8",
   "matplotlib >= 3.8",
-  # "Pillow >= 6.2.2",  # not our dependency but older versions crash with mpl
   "generic-parser >= 1.1",
   "sdds >= 0.4",
   "optics-functions >= 0.1",

--- a/tests/unit/test_time_tools.py
+++ b/tests/unit/test_time_tools.py
@@ -55,9 +55,13 @@ def test_accelerator_datetime(now):
 
 @pytest.mark.basic
 def test_fold():
+    # due to daylight saving time change on the 25th of October 2020
+    # 01:00 UTC and 00:00 UTC corresponded to the same local time,
+    # which is indicated by the fold attribute (0 == earlier time, 1 == later time)
+    # see https://peps.python.org/pep-0495/
     folded = tt.AcceleratorDatetime["lhc"](2020, 10, 25, 1, 0, 0)
     no_fold = tt.AcceleratorDatetime["lhc"](2020, 10, 25, 0, 0, 0)
-
+    
     assert folded.local.hour == no_fold.local.hour
     assert folded.local.fold == 1
     assert no_fold.local.fold == 0

--- a/tests/unit/test_time_tools.py
+++ b/tests/unit/test_time_tools.py
@@ -1,7 +1,7 @@
+from datetime import datetime
+
 import dateutil.tz as tz
 import pytest
-
-from datetime import datetime
 
 from omc3.utils import time_tools as tt
 
@@ -41,10 +41,10 @@ def test_strings(now):
 
 @pytest.mark.basic
 def test_accelerator_datetime(now):
-    lhc = tt.AcceleratorDatetime['lhc'](now)
+    lhc = tt.AcceleratorDatetime["lhc"](now)
+    ps = tt.AcceleratorDatetime["ps"](now)
+    sps = tt.AcceleratorDatetime["sps"](now)
 
-    ps = tt.AcceleratorDatetime['ps'](now)
-    sps = tt.AcceleratorDatetime['sps'](now)
     assert lhc.local.time() == ps.local.time()
     assert lhc.local.time() == sps.local.time()
     assert lhc.local.time() != lhc.utc.time()
@@ -55,12 +55,13 @@ def test_accelerator_datetime(now):
 
 @pytest.mark.basic
 def test_fold():
-    folded = tt.AcceleratorDatetime['lhc'](2020, 10, 25, 1, 0, 0)
-    no_fold = tt.AcceleratorDatetime['lhc'](2020, 10, 25, 0, 0, 0)
-    
+    folded = tt.AcceleratorDatetime["lhc"](2020, 10, 25, 1, 0, 0)
+    no_fold = tt.AcceleratorDatetime["lhc"](2020, 10, 25, 0, 0, 0)
+
     assert folded.local.hour == no_fold.local.hour
     assert folded.local.fold == 1
     assert no_fold.local.fold == 0
+
 
 # Fixtures #####################################################################
 


### PR DESCRIPTION
Cron jobs have picked up that the `.local` property of our `AccDateTime` raises issues as it tries to do some non-`tzinfo` inherited comparisons.

As far as I could tell this is mostly an annoyance due to subclassing the `datetime` class. A very simple fix is to simply cast to datetime first (using our own `.datetime` property) and then ask for `.astimezone` as previously).

PR is a bit more than that since I took the opportunity of dropping Python 3.9 support for this release (as we did with `tfs-pandas`) and solve the mess of `pytables` and `numpy 2.x` dependencies.