### PR TITLE
Add qt5 binding depencendy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ cern = [
 optional = [
   "pymupdf >= 1.22",  # logbook for conversion from pdf to png
   "qtpy >= 2.3.1",  # putting plots in windows
+  "PySide2",  # A binding to Qt is needed, Qt6 does not seem to work atm
 ]
 test = [
   "jpype1 >= 1.3",


### PR DESCRIPTION
Simply having `QtPy` is not enough as a binding itself is needed.