### PR TITLE
Bad BPMs Summary: NaNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### Unreleased -
+
+- Added:
+  - Bad BPMs summary: NANS reason.
+
 #### 2025-03-13 - v0.23.0 - _jdilly_
 
 - Added:

--- a/omc3/scripts/bad_bpms_summary.py
+++ b/omc3/scripts/bad_bpms_summary.py
@@ -103,6 +103,7 @@ class HarpyReasons(str, Enum):
     NO_TUNE = "main resonance has not been found"
     TUNE_CLEAN = "too far from average"
     SVD_PEAK = "svd"
+    NANS = "found nan"
 
 
 # Files ---


### PR DESCRIPTION
Added the NaNs (see https://github.com/pylhc/omc3/tree/0.21.0 ) as a known filter/reason to the summary. 