### PR TITLE
Ruff configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           version: "latest"
+          src: "omc3"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,21 @@
+name: Ruff linting
+
+defaults:
+  run:
+    shell: bash
+
+# Runs on any push event in a PR
+on:
+  pull_request:
+  push:
+
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # This runs ruff check by default
+      - uses: astral-sh/ruff-action@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,10 +5,7 @@ defaults:
     shell: bash
 
 # Runs on any push event in a PR
-on:
-  pull_request:
-  push:
-
+on: [ push, pull_request ]
 
 jobs:
   linter:
@@ -19,3 +16,5 @@ jobs:
 
       # This runs ruff check by default
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: "latest"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           version: "latest"
-          src: "omc3"
+          src: "omc3/"

--- a/omc3/harpy/frequency.py
+++ b/omc3/harpy/frequency.py
@@ -30,7 +30,7 @@ def _get_resonance_lines(order):
     # Get all the rdts up to a given order
     fterms = get_all_to_order(order)
     # Some rdts can't be seen depending on the plane, filter them
-    for (j,k,l,m) in fterms:
+    for (j,k,l,m) in fterms:  # noqa: E741 (these variable names are ok)
         if j != 0:
             resonances['X'].append((1-j+k, m-l, 0))
         if l != 0:

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -38,7 +38,6 @@ from omc3.segment_by_segment.constants import (
     measurement_madx,
 )
 from omc3.segment_by_segment.propagables import Propagable
-from omc3.segment_by_segment.propagables.coupling import Coupling
 from omc3.segment_by_segment.segments import Segment
 from omc3.utils import iotools, logging_tools
 

--- a/omc3/plotting/plot_kmod_results.py
+++ b/omc3/plotting/plot_kmod_results.py
@@ -68,7 +68,7 @@ import tfs
 from generic_parser import EntryPointParameters, entrypoint
 from generic_parser.entry_datatypes import DictAsString
 
-from omc3.optics_measurements.constants import BEAM, BETASTAR, ERR, MDL, WAIST
+from omc3.optics_measurements.constants import BEAM, BETASTAR, ERR, WAIST
 from omc3.plotting.utils import style as pstyle
 from omc3.utils import logging_tools
 from omc3.utils.iotools import PathOrStr, PathOrStrOrDataFrame, save_config

--- a/omc3/scripts/kmod_lumi_imbalance.py
+++ b/omc3/scripts/kmod_lumi_imbalance.py
@@ -68,7 +68,6 @@ from omc3.optics_measurements.constants import (
     EXT,
     IMBALANCE,
     LUMINOSITY,
-    MDL,
     NAME,
 )
 from omc3.utils import logging_tools

--- a/omc3/segment_by_segment/propagables/utils.py
+++ b/omc3/segment_by_segment/propagables/utils.py
@@ -7,9 +7,6 @@ and functions that are common to multiple propagables.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-import numpy as np
 import pandas as pd
 
 from omc3.optics_measurements.constants import ERR

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -15,7 +15,7 @@ import warnings
 from contextlib import contextmanager
 from io import StringIO
 from logging import (  # make them available directly
-    CRITICAL,
+    CRITICAL,  # noqa: F401
     DEBUG,
     ERROR,
     INFO,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ exclude = [
 # Assume Python 3.10+
 target-version = "py310"
 
-# Same as black
 line-length = 100
 indent-width = 4
 
@@ -134,7 +133,6 @@ indent-width = 4
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ignore = [
-  "E501",  # line-too-long
   "FBT001",  # boolean-type-hint-positional-argument
   "FBT002",  # boolean-default-value-positional-argument
   "PT019",  # pytest-fixture-param-without-value (but suggested solution fails)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,37 @@ markers = [
 # log_cli = true
 # log_cli_level = "DEBUG"
 # log_format = "%(levelname)7s | %(message)s | %(name)s"
+
+# ----- Dev Tools Configuration ----- #
+
+[tool.ruff]
+exclude = [
+  ".eggs",
+  ".git",
+  ".mypy_cache",
+  ".venv",
+  "_build",
+  "build",
+  "dist",
+]
+
+# Assume Python 3.10+
+target-version = "py310"
+
+# Same as black
+line-length = 100
+indent-width = 4
+
+[tool.ruff.lint]
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+ignore = [
+  "E501",  # line-too-long
+  "FBT001",  # boolean-type-hint-positional-argument
+  "FBT002",  # boolean-default-value-positional-argument
+  "PT019",  # pytest-fixture-param-without-value (but suggested solution fails)
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []


### PR DESCRIPTION
As discussed, we want to converge on a simple setup for formatting + linting and I offer a configuration using `Ruff`. It's fast, does formatting + linting (+ a [type checker](https://x.com/charliermarsh/status/1884651482009477368) at some point), easy to install as a standalone etc.

Ruff, like Black, comes quite opinionated (actually, [they're compatible](https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black)) and I suggest minimal changes to the default settings.

**Changes in this PR:**

- Configuration in its own table in `pyproject.toml`. Very open to discussion.
- A GA file to run `Ruff` linting on commits in pull requests.
- Small fixes for the current linting complaints.

**Suggested philosophy:**

None of this runs automated. I suggest the following:

- Enforcing a soft-rule for formatting on new code and when refactoring. We should eventually converge to a coherent codebase.
- Relatively nice tolerance to the use of `# fmt: off`, `# fmt: on` and `# noqa: RULE` when it makes sense (preserving mathematical formatting, accepting "no-go" varnames where justified etc).
- Leaving the GA workflow as a pass-fail test (its default). Currently it passes, so only PR modifications & new code could break it, and we would be aware at review without the need to checkout the PR branch, run locally etc.