### PR TITLE
Maintenance - Set `pytest `import mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ markers = [
     "extended: test run on PRs",
     "cern_network: tests that require access to afs or the technical network",
 ]
+addopts = [
+    "--import-mode=importlib",
+]
 # Helpful for pytest-debugging (leave commented out on commit):
 # log_cli = true
 # log_cli_level = "DEBUG"


### PR DESCRIPTION
The default import mode in `pytest` is set to `prepend`, which is a historical thing that they don't recommend.

In their [documentation](https://docs.pytest.org/en/stable/explanation/goodpractices.html#choosing-an-import-mode) it is recommended to use `--import-mode=importlib `. It was also hinted in our minimum pytest version that this new mode was the one with no drawbacks, see 7.0.x docs [here](https://docs.pytest.org/en/7.0.x/explanation/goodpractices.html#choosing-a-test-layout-import-rules) and [here](https://docs.pytest.org/en/7.0.x/explanation/pythonpath.html#import-modes).

This should not have an impact on the tests themselves but let's see if the CI is fine with it.