### PR TITLE
Working uv settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,34 @@ repository = "https://github.com/pylhc/omc3"
 documentation = "https://pylhc.github.io/omc3/"
 changelog = "https://github.com/pylhc/omc3/blob/master/CHANGELOG.md"
 
+# ----- Some uv Specifics ----- #
+
+# Our CIs use uv and we need to let it know where to find the AccPy stuff
+# See doc on indices at https://docs.astral.sh/uv/concepts/indexes/
+
+[tool.uv]
+allow-insecure-host = ["acc-py-repo.cern.ch"]  # AccPy uses http and we need to allow that
+
+[tool.uv.pip]
+compile-bytecode = true
+
+# Specify these packages are to be found at the AccPy index
+[tool.uv.sources]
+pytimber = { index = "accpy" }
+pylogbook = { index = "accpy" }
+
+# And we define the specifics for the AccPy index
+[[tool.uv.index]]
+name = "accpy"
+url = "http://acc-py-repo.cern.ch/repository/vr-py-releases/simple"
+default = true  # default = lowest priority -> try if packages not found in other indexes
+
+# Since we make AccPy default index, we need to also provide the PyPI index or
+# it would be ignored (https://docs.astral.sh/uv/concepts/indexes/#defining-an-index)
+[[tool.uv.index]]
+bname = "pypi"
+url = "https://pypi.org/simple"
+
 # ----- Testing ----- #
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Adding some settings for `uv` to our `pyproject.toml` file. This is useful for our CI configurations, but will also work locally for anyone using `uv pip`, including for the CERN specific dependencies.

I will write here the reasoning for these settings as this can act as a little bit of documentation as well.

Main points:

- The `AccPy` index is marked as allowed unsafe since we pull from `http://acc-py-repo.cern.ch/repository/vr-py-releases/simple` which is only HTTP, so we need to allow for only HTTP.
- The `pytimber` and `pylogbook` dependencies are flagged to specifically need the `AccPy` index.
- The `AccPy` index details are added. I have marked it `default` which is a weirdly named setting (see https://docs.astral.sh/uv/concepts/indexes/#defining-an-index). This means it is the lowest priority index, and packages should be looked for in there after other indexes have been tried.
  - This allows not pulling everything through `AccPy` (which requires the GPN anyway).
  - This makes it so `uv pip` does not try to get `hatchling` (our build backend) from `AccPy` even when we don't install the `[cern]` extras, e.g. in our CI environments.
  - This allows `uv pip` to find the dependencies of `pytimber` and `pylogbook` (e.g. `nxcals` and so on) in the right index since they're not in `PyPI`.
- The `PyPI` index is also defined. It is the default naturally but since we specify another `default` it gets erased, so I need to add it back. This is where everything will be looked for before trying `AccPy`.
- I have also added a the `compile-bytecode` option so that `uv pip` does precisely that, which is something regular `pip` does by default. It will be compiled anyway by the Python VM but this way is faster (optimized and parallelized). This is redundant for our CI since I'm [adding the option to common workflows](https://github.com/pylhc/.github/pull/18) but will be set for local installs as well. Typically for `omc3` pulling all dependencies this step takes ~2 seconds on my machine.