### PR TITLE
Tightening the screws, part 1

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Run this command to always ignore formatting commits in `git blame`:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Add below, one per line, SHAs of commits corresponding to "formatting" / "revisions"

--- a/omc3/correction/response_io.py
+++ b/omc3/correction/response_io.py
@@ -106,14 +106,14 @@ def write_varmap(path: Path, varmap: dict[str, dict[str, pd.Series]]):
 # Helper -----------------------------------------------------------------------
 
 
-def _check_keys(store: pd.HDFStore, keys: Sequence[str], id: str):
+def _check_keys(store: pd.HDFStore, keys: Sequence[str], file_id: str):
     if keys is None:
         return
 
     groups = _main_store_groups(store)
     not_found = [k for k in keys if k not in groups]
     if len(not_found):
-        raise ValueError(f"The following keys could not be found in {id} file:" f" {', '.join(not_found)}")
+        raise ValueError(f"The following keys could not be found in {file_id} file:" f" {', '.join(not_found)}")
 
 
 def _main_store_groups(store: pd.HDFStore) -> set[str]:

--- a/omc3/model/accelerators/accelerator.py
+++ b/omc3/model/accelerators/accelerator.py
@@ -11,7 +11,7 @@ import re
 import os
 from pathlib import Path
 
-import numpy
+import numpy as np
 import pandas as pd
 import tfs
 from generic_parser.entrypoint_parser import EntryPointParameters
@@ -231,7 +231,7 @@ class Accelerator:
             self.error_defs_file = errordefspath
 
     def find_modifier(self, modifier: Path | str):
-        """ Try to find a modifier file, which might be given only by its name. 
+        """ Try to find a modifier file, which might be given only by its name.
         By default this is looking for full-path, model-dir and in the acc-models-path,
         but should probably be overwritten by the accelerator sub-classes.
         """
@@ -297,7 +297,7 @@ class Accelerator:
     # Class methods ###########################################
 
     @classmethod
-    def get_element_types_mask(cls, list_of_elements: list[str], types) -> numpy.ndarray:
+    def get_element_types_mask(cls, list_of_elements: list[str], types) -> np.ndarray:
         """
         Returns a boolean mask for elements in ``list_of_elements`` that belong to any of the
         specified types.
@@ -375,9 +375,9 @@ def _get_modifiers_from_modeldir(model_dir: Path) -> list[Path]:
 
 
 def find_called_files_with_tag(madx_file: Path, tag: str) -> list[Path] | None:
-    """ Parse lines that call a file and are tagged with the given tag and return 
-    a list of paths to these files. 
-    
+    """ Parse lines that call a file and are tagged with the given tag and return
+    a list of paths to these files.
+
     This is mainly used to find the modifier tag in lines and return called file in these lines.
 
     The modifier tag is used by the model creator to mark which line defines modifiers

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -211,10 +211,10 @@ class Lhc(Accelerator):
             *self._get_corrector_files("triplet_correctors.json"),
         )
 
-        vars = get_vars_by_classes(classes, all_vars_by_class)  
+        variables = get_vars_by_classes(classes, all_vars_by_class)
 
         # Sort variables by S (nice for comparing different files)
-        return self.sort_variables_by_location(vars, frm, to)
+        return self.sort_variables_by_location(variables, frm, to)
 
     def sort_variables_by_location(self, variables: Iterable[str], frm: float | None = None, to: str | None = None) -> list[str]:
         """ Sorts the variables by location and filters them between `frm` and `to`.
@@ -318,7 +318,7 @@ class Lhc(Accelerator):
             ) from e
 
     def important_phase_advances(self) -> list[list[str]]:
-        if "hl" in self.year.lower(): 
+        if "hl" in self.year.lower():
             # skip if HiLumi, TODO: insert phase advances when they are finalised
             return []
 
@@ -333,21 +333,21 @@ class Lhc(Accelerator):
             return [i in index for i in self.model.loc["BPMSW.33L2.B1":].index]
         elif self.beam == 2:
             return [i in index for i in self.model.loc["BPMSW.33R8.B2":].index]
-    
+
     def get_accel_file(self, filename: str | Path) -> Path:
         return LHC_DIR / self.year / filename
-    
-    
+
+
     # Private Methods ##############################################################
     def _get_corrector_elems(self) -> Path:
         """ Return the corrector elements file, either from the instance's specific directory,
         if it exists, or the default directory. """
         return self._get_corrector_files(f"corrector_elems_b{self.beam}.tfs")[-1]
-    
+
     def _get_corrector_files(self, file_name: str | Path) -> list[Path]:
-        """ Get the corrector files from the default directory AND 
-        the instance's specific directory if it exists AND the model directroy if it exists, 
-        in that order. 
+        """ Get the corrector files from the default directory AND
+        the instance's specific directory if it exists AND the model directroy if it exists,
+        in that order.
         See also discussion in https://github.com/pylhc/omc3/pull/458#discussion_r1764829247 .
         """
         # add file from the default directory (i.e. "model/accelerators/lhc/correctors")
@@ -356,7 +356,7 @@ class Lhc(Accelerator):
             msg = (f"Could not find {file_name} in {Lhc.DEFAULT_CORRECTORS_DIR}."
                   "Something went wrong with the variables getting logic.")
             raise FileNotFoundError(msg)
-        
+
         LOGGER.debug(
             f"Default corrector file {file_name} found in {default_file.parent}."
         )
@@ -380,11 +380,11 @@ class Lhc(Accelerator):
                     "Contents will take precedence over omc3-given defaults."
                 )
                 corrector_files.append(model_dir_file)
-        
+
         return corrector_files
 
     def find_modifier(self, modifier: Path | str):
-        """ Try to find a modifier file, which might be given only by its name. 
+        """ Try to find a modifier file, which might be given only by its name.
         This is looking for full-path, model-dir and in the acc-models-path's optics-dir.,
         """
         dirs = []

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -13,7 +13,7 @@ from generic_parser import EntryPointParameters, entrypoint
 from omc3.model import manager as model_manager
 from omc3.model.accelerators.accelerator import Accelerator, AcceleratorDefinitionError
 from omc3.model.constants import Fetcher
-from omc3.model.model_creators.abstract_model_creator import ModelCreator 
+from omc3.model.model_creators.abstract_model_creator import ModelCreator
 from omc3.model.model_creators.manager import CreatorType, get_model_creator_class
 from omc3.utils import logging_tools
 from omc3.utils.iotools import PathOrStr, save_config
@@ -42,8 +42,8 @@ def _get_params():
               "If not provided it will be written to sys.stdout.")
     )
     params.add_parameter(
-        name="show_help", 
-        action="store_true", 
+        name="show_help",
+        action="store_true",
         help="Instructs the subsequent modules to print a help message"
     )
     params.update(get_fetcher_params())
@@ -135,20 +135,20 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator | None:
             accel_class = model_manager.get_accelerator_class(accel_opt)
             print(f"---- Accelerator {accel_class.__name__}  | Usage ----\n")
             print_help(accel_class.get_parameters())
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 (ugly that we catch all exceptions here...)
             LOGGER.debug(f"An error occurred: {e}")
             pass
 
         print("---- Model Creator | Usage ----\n")
         print_help(model_manager._get_params())
         print_help(_get_params())
-        return 
+        return
 
     # proceed to the creator
     accel_inst: Accelerator = model_manager.get_accelerator(accel_opt)
     require_param("type", _get_params(), opt)
     LOGGER.debug(f"Accelerator Instance {accel_inst.NAME}, model type {opt.type}")
-    
+
     # model_dir is used as the output directory
     require_param("outputdir", _get_params(), opt)
     outputdir = Path(opt.outputdir)
@@ -168,13 +168,13 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator | None:
         if not opt.list_choices:
             raise
         return
-    
+
     # Save config only now, to not being written out for each time the choices are listed
     save_config(outputdir, opt=opt, unknown_opt=accel_opt, script=__file__)
 
     # Run the actual model creation
     creator.full_run()
-    
+
     return accel_inst
 
 

--- a/omc3/plotting/plot_spectrum.py
+++ b/omc3/plotting/plot_spectrum.py
@@ -189,7 +189,7 @@ import os
 from collections import OrderedDict
 from typing import Tuple
 
-import matplotlib
+import matplotlib as mpl
 from cycler import cycler
 
 from generic_parser.entry_datatypes import DictAsString
@@ -216,7 +216,7 @@ def get_reshuffled_tab20c():
     Reshuffle tab20c so that the colors change between next lines.
     Needs to be up here as it is used in ``DEFAULTS`` which is loaded early.
     """
-    tab20c = matplotlib.colormaps['tab20c'].colors
+    tab20c = mpl.colormaps['tab20c'].colors
     out = [None] * 20
     step, chunk = 4, 5
     for idx in range(step):
@@ -329,7 +329,7 @@ def get_params():
                          default={},
                          help='Additional style rcParameters which update the set of predefined ones.'
                          )
- 
+
     return params
 
 

--- a/omc3/plotting/plot_tfs.py
+++ b/omc3/plotting/plot_tfs.py
@@ -108,7 +108,6 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Dict
 
-import matplotlib
 from matplotlib import pyplot as plt, rcParams
 from matplotlib.axes import Axes
 
@@ -125,9 +124,9 @@ from omc3.plotting.utils.windows import (
 )
 from omc3.plotting.spectrum.utils import get_unique_filenames, output_plot
 from omc3.plotting.utils import (
-    annotations as pannot, 
+    annotations as pannot,
     lines as plines,
-    style as pstyle, 
+    style as pstyle,
     colors as pcolors,
 )
 from omc3.plotting.utils.lines import VERTICAL_LINES_TEXT_LOCATIONS
@@ -511,7 +510,7 @@ def _share_xaxis(fig_collection):
         axs = fig_container.axes.values()
 
         # Axes.get_shared_x_axes() does not work here as it returns a GrouperView
-        # instead of the Grouper (i.e. _shared_axes['x'], matplotlib < 3.8), 
+        # instead of the Grouper (i.e. _shared_axes['x'], matplotlib < 3.8),
         # so we access _shared_axes directly
         fig_container.axes[fig_container.axes_ids[-1]]._shared_axes["x"].join(*axs)
 
@@ -549,7 +548,7 @@ def _create_plots(fig_collection, opt):
                 window.add_tab(tab)
             window.show()
             return
-        
+
         if len(fig_collection) > rcParams['figure.max_open_warning']:
             log_no_qtpy_many_windows()
 
@@ -557,7 +556,7 @@ def _create_plots(fig_collection, opt):
             create_pyplot_window_from_fig(fig_container.fig, title=fig_container.id)
         plt.show()
 
-            
+
 
 def _plot_data(ax: Axes, data: Dict[str, DataSet], change_marker: bool, ebar_alpha: float):
     for idx, (label, values) in enumerate(data.items()):
@@ -594,7 +593,7 @@ def _set_axes_layout(ax, x_lim, y_lim,  xlabel, ylabel):
 def get_full_output_path(folder, filename):
     if folder is None or filename is None:
         return None
-    return Path(folder) / f"{filename}.{matplotlib.rcParams['savefig.format']}"
+    return Path(folder) / f"{filename}.{rcParams['savefig.format']}"
 
 
 # Helper -----------------------------------------------------------------------

--- a/omc3/plotting/spectrum/stem.py
+++ b/omc3/plotting/spectrum/stem.py
@@ -4,8 +4,9 @@ Plot Spectrum - Stem Plotter
 
 Stem plotting functionality for spectrum plotter.
 """
-import matplotlib
+
 from generic_parser import DotDict
+from matplotlib import rcParams
 from matplotlib import pyplot as plt, lines as mlines
 
 from omc3.plotting.spectrum.utils import (plot_lines, FigureContainer, get_cycled_color,
@@ -74,8 +75,8 @@ def _format_axes(fig_cont: FigureContainer, limits: DotDict):
 
 def _create_legend(ax, labels, lines, ncol):
     lines_params = dict(
-        marker=matplotlib.rcParams[u'lines.marker'],
-        markersize=matplotlib.rcParams[u'font.size'] * 0.5,
+        marker=rcParams[u'lines.marker'],
+        markersize=rcParams[u'font.size'] * 0.5,
         linestyle='None',
     )
     legend_params = dict(
@@ -97,6 +98,6 @@ def _create_legend(ax, labels, lines, ncol):
 
     # move above line-labels
     nlines = sum([line is not None for line in lines.values()]) + 0.05
-    label_size = get_fontsize_as_float(matplotlib.rcParams['axes.labelsize'])
+    label_size = get_fontsize_as_float(rcParams['axes.labelsize'])
     y_shift = get_approx_size_in_axes_coordinates(leg.axes, label_size=label_size) * nlines
     leg.axes.legend(handles=handles, bbox_to_anchor=(1. + x_shift, 1. + y_shift), **legend_params)

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -10,12 +10,11 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Iterable, Sized, Union
 
-import matplotlib
 import numpy as np
 import pandas as pd
 import tfs
 from generic_parser import DotDict
-from matplotlib import transforms, axes, pyplot as plt
+from matplotlib import transforms, axes, rcParams, pyplot as plt
 from matplotlib.patches import Rectangle
 
 from omc3.definitions.constants import PLANES
@@ -107,7 +106,7 @@ class FigureCollector:
 
 
 def plot_lines(fig_cont: FigureContainer, lines: DotDict) -> None:
-    label_size = get_fontsize_as_float(matplotlib.rcParams['axes.labelsize']) * 0.7
+    label_size = get_fontsize_as_float(rcParams['axes.labelsize']) * 0.7
     bottom_qlabel = 1.01
 
     for idx_plane, plane in enumerate(PLANES):
@@ -418,7 +417,7 @@ def _make_output_dir(out_dir, filename):
 
 def get_cycled_color(idx: int):
     """ Get the color at (wrapped) idx in the color cycle. The CN-Method only works until 'C9'."""
-    cycle = matplotlib.rcParams[u"axes.prop_cycle"].by_key()['color']
+    cycle = rcParams[u"axes.prop_cycle"].by_key()['color']
     return cycle[idx % len(cycle)]
 
 

--- a/omc3/plotting/spectrum/waterfall.py
+++ b/omc3/plotting/spectrum/waterfall.py
@@ -4,10 +4,10 @@ Plot Spectrum - Waterfall Plotter
 
 Waterfall plotting functionality for spectrum plotter.
 """
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 from generic_parser import DotDict
-from matplotlib import pyplot as plt, colors
+from matplotlib import pyplot as plt, colors, rcParams
 
 from omc3.plotting.spectrum.utils import (plot_lines, PLANES, LABEL_Y_WATERFALL,
                                           LABEL_X, AMPS, FREQS, output_plot)
@@ -50,7 +50,7 @@ def _plot_waterfall(fig_cont, line_width, cmap, common_plane_colors):
                 _plot_color_mesh(ax, freqs, amps, idx_data, cmap, norm)
             else:
                 _plot_vlines(ax, freqs, amps, idx_data, cmap, norm, line_width)
-        ax.figure.colorbar(matplotlib.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
+        ax.figure.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
 
 
 def _get_color_norm(minmax, plane, common):
@@ -90,11 +90,11 @@ def _format_axes(fig_cont, limits, ncol):
             ax.set_yticks(ticks=[], labels=[])
         else:
             # Provide ticks and labels together or matplotlib issues a UserWarning
-            # See "Discouraged" admonition at https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_yticklabels.html 
+            # See "Discouraged" admonition at https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_yticklabels.html
             ax.set_yticks(
                 ticks=range(len(ylabels)),
                 labels=ylabels,
-                fontdict={'fontsize': get_fontsize_as_float(matplotlib.rcParams[u'axes.labelsize']) * .5},
+                fontdict={'fontsize': get_fontsize_as_float(rcParams[u'axes.labelsize']) * .5},
             )
         ax.set_xlabel(LABEL_X)
         ax.set_ylabel(LABEL_Y_WATERFALL.format(plane=plane.upper()))

--- a/omc3/plotting/utils/annotations.py
+++ b/omc3/plotting/utils/annotations.py
@@ -10,10 +10,10 @@ import itertools
 import re
 from typing import TYPE_CHECKING
 
-import matplotlib
+import matplotlib as mpl
 import pandas as pd
 import tfs
-from matplotlib import pyplot as plt
+from matplotlib import pyplot as plt, rcParams
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -122,7 +122,7 @@ def show_ir(ip_dict, ax: Axes = None, mode: str = "inside") -> None:
 
             if not lines_only:
                 ypos = ylim[not inside] + (ylim[1] - ylim[0]) * 0.01
-                c = 'grey' if inside else matplotlib.rcParams["text.color"]
+                c = 'grey' if inside else rcParams["text.color"]
                 ax.text(xpos, ypos, ip, color=c, ha='center', va='bottom')
 
     ax.set_xlim(xlim)
@@ -251,8 +251,8 @@ def small_title(ax: Axes = None) -> None:
     # could not get set_title() to work properly, so one parameter at a time
     ax.title.set_position([1.0, 1.02])
     ax.title.set_transform(ax.transAxes)
-    ax.title.set_fontsize(matplotlib.rcParams['font.size'])
-    ax.title.set_fontweight(matplotlib.rcParams['font.weight'])
+    ax.title.set_fontsize(rcParams['font.size'])
+    ax.title.set_fontweight(rcParams['font.weight'])
     ax.title.set_verticalalignment('bottom')
     ax.title.set_horizontalalignment('right')
 
@@ -271,8 +271,8 @@ def figure_title(text: str, ax: Axes = None, pad: float = 0, **kwargs) -> None:
         ax = plt.gca()
 
     # could not get set_title() to work properly, so one parameter at a time
-    fdict = dict(fontsize=matplotlib.rcParams['font.size'],
-                 fontweight=matplotlib.rcParams['font.weight'],
+    fdict = dict(fontsize=rcParams['font.size'],
+                 fontweight=rcParams['font.weight'],
                  va="top", ha="center")
     fdict.update(kwargs)
     ax.set_title(text, transform=ax.figure.transFigure, fontdict=fdict)
@@ -337,7 +337,7 @@ def make_top_legend(
     return leg
 
 
-class OOMFormatter(matplotlib.ticker.ScalarFormatter):
+class OOMFormatter(mpl.ticker.ScalarFormatter):
     """
     Order of Magnitude Formatter.
 
@@ -349,7 +349,7 @@ class OOMFormatter(matplotlib.ticker.ScalarFormatter):
     def __init__(self, order=0, fformat="%1.1f", offset=True, mathText=True):
         self.oom = order
         self.fformat = fformat
-        matplotlib.ticker.ScalarFormatter.__init__(self, useOffset=offset, useMathText=mathText)
+        mpl.ticker.ScalarFormatter.__init__(self, useOffset=offset, useMathText=mathText)
 
     def _set_orderOfMagnitude(self, nothing):
         self.orderOfMagnitude = self.oom
@@ -357,7 +357,7 @@ class OOMFormatter(matplotlib.ticker.ScalarFormatter):
     def _set_format(self, vmin, vmax):
         self.format = self.fformat
         if self._useMathText:
-            self.format = '$%s$' % matplotlib.ticker._mathdefault(self.format)
+            self.format = '$%s$' % mpl.ticker._mathdefault(self.format)
 
 
 def set_sci_magnitude(ax, axis="both", order=0, fformat="%1.1f", offset=True, math_text=True):
@@ -400,4 +400,4 @@ def get_fontsize_as_float(font_size: str | float) -> float:
             None: 1.0}[font_size]
     except KeyError:
         return font_size
-    return scale * matplotlib.rcParams['font.size']
+    return scale * rcParams['font.size']

--- a/omc3/plotting/utils/colors.py
+++ b/omc3/plotting/utils/colors.py
@@ -7,7 +7,7 @@ Helper functions to handle colors in plots.
 import colorsys
 from itertools import cycle
 
-import matplotlib
+import matplotlib as mpl
 from matplotlib import colors as mc
 
 
@@ -76,5 +76,5 @@ def change_ebar_alpha_for_line(ebar, alpha):
 def change_ebar_alpha_for_axes(ax, alpha):
     """Wrapper for change_ebar_alpha_for_line to change all in one axes."""
     for ebar in ax.containers:
-        if isinstance(ebar, matplotlib.container.ErrorbarContainer):
+        if isinstance(ebar, mpl.container.ErrorbarContainer):
             change_ebar_alpha_for_line(ebar, alpha)

--- a/omc3/plotting/utils/colors.py
+++ b/omc3/plotting/utils/colors.py
@@ -7,8 +7,7 @@ Helper functions to handle colors in plots.
 import colorsys
 from itertools import cycle
 
-from matplotlib import colors as mc
-from matplotlib.container import ErrorbarContainer
+import matplotlib as mpl
 
 
 def get_mpl_color(idx=None):
@@ -52,14 +51,11 @@ def change_color_brightness(color, amount=0.5):
         raise ValueError("The brightness change has to be between 0 and 2."
                          " Instead it was {}".format(amount))
     try:
-        c = mc.cnames[color]
+        c = mpl.colors.cnames[color]
     except KeyError:
         c = color
 
-    try:
-        c = colorsys.rgb_to_hls(*mc.ColorConverter().to_rgb(c))  # matplotlib 1.5
-    except AttributeError:
-        c = colorsys.rgb_to_hls(*mc.to_rgb(c))  # matplotlib > 2
+    c = colorsys.rgb_to_hls(*mpl.colors.to_rgb(c))
     return colorsys.hls_to_rgb(c[0], max(0, min(1, amount * c[1])), c[2])
 
 
@@ -76,5 +72,5 @@ def change_ebar_alpha_for_line(ebar, alpha):
 def change_ebar_alpha_for_axes(ax, alpha):
     """Wrapper for change_ebar_alpha_for_line to change all in one axes."""
     for ebar in ax.containers:
-        if isinstance(ebar, ErrorbarContainer):
+        if isinstance(ebar, mpl.container.ErrorbarContainer):
             change_ebar_alpha_for_line(ebar, alpha)

--- a/omc3/plotting/utils/colors.py
+++ b/omc3/plotting/utils/colors.py
@@ -7,8 +7,8 @@ Helper functions to handle colors in plots.
 import colorsys
 from itertools import cycle
 
-import matplotlib as mpl
 from matplotlib import colors as mc
+from matplotlib.container import ErrorbarContainer
 
 
 def get_mpl_color(idx=None):
@@ -76,5 +76,5 @@ def change_ebar_alpha_for_line(ebar, alpha):
 def change_ebar_alpha_for_axes(ax, alpha):
     """Wrapper for change_ebar_alpha_for_line to change all in one axes."""
     for ebar in ax.containers:
-        if isinstance(ebar, mpl.container.ErrorbarContainer):
+        if isinstance(ebar, ErrorbarContainer):
             change_ebar_alpha_for_line(ebar, alpha)

--- a/omc3/plotting/utils/lines.py
+++ b/omc3/plotting/utils/lines.py
@@ -4,10 +4,9 @@ Plotting Utilities: Lines
 
 Line-plotting related functionality.
 """
-import matplotlib
 import matplotlib.transforms as mtrans
 import numpy as np
-from matplotlib import transforms
+from matplotlib import rcParams
 from matplotlib.markers import MarkerStyle
 from matplotlib.patches import PathPatch
 
@@ -84,7 +83,7 @@ def plot_vertical_lines_fast(ax, x, y=(0, 1), **kwargs):
 
 
 def plot_vertical_line(ax, axvline_args: dict, text: str = None, text_loc: str = None,
-                       label_size: float = matplotlib.rcParams['font.size']):
+                       label_size: float = rcParams['font.size']):
     """
     Plot a vertical line into the plot, where mline is a dictionary with arguments for ``axvline``.
     Advanced capabilities include: Automatic alpha value (if not overwritten), automatic
@@ -108,6 +107,6 @@ def plot_vertical_line(ax, axvline_args: dict, text: str = None, text_loc: str =
             raise ValueError(f"Unknown value '{text_loc}' for label location.")
 
         ax.text(x=axvline_args['x'], s=text,
-                transform=transforms.blended_transform_factory(ax.transData, ax.transAxes),
+                transform=mtrans.blended_transform_factory(ax.transData, ax.transAxes),
                 color=line.get_color(),
                 fontdict={'size': label_size}, **VERTICAL_LINES_TEXT_LOCATIONS[text_loc])

--- a/omc3/plotting/utils/style.py
+++ b/omc3/plotting/utils/style.py
@@ -6,8 +6,7 @@ Helper functions to style plots.
 """
 from typing import Dict, Any, Sequence, Union
 
-import matplotlib
-from matplotlib import pyplot as plt
+from matplotlib import pyplot as plt, rcParams
 from pathlib import Path
 
 from omc3.utils.iotools import PathOrStr
@@ -44,6 +43,6 @@ def set_style(styles: Union[Path, str, Sequence[Union[Path, str]]] = 'standard',
     if manual:
         for key, value in manual.items():
             if value == REMOVE_ENTRY:
-                manual[key] = matplotlib.rcParams[key]
+                manual[key] = rcParams[key]
         styles.append(manual)
     plt.style.use(styles)

--- a/omc3/plotting/utils/windows.py
+++ b/omc3/plotting/utils/windows.py
@@ -2,14 +2,14 @@
 Plot Window
 ------------
 
-In this module different classes are defined, allowing to put `matplotlib` figures 
+In this module different classes are defined, allowing to put `matplotlib` figures
 manually into GUI windows.
-These windows are QT-based, created with `qtpy` which allows to use 
+These windows are QT-based, created with `qtpy` which allows to use
 either PySide(2 or 6) or PyQt(5 or 6), depending on which it installed on the system.
-As the `qtpy` library is optional, there are some checks to make sure 
+As the `qtpy` library is optional, there are some checks to make sure
 the imports do not fail, but then the classes cannot be used.
 To check if QtPy is installed, either run :meth:`omc3.plotting.plot_window.is_qtpy_installed`
-or try to initialize one of the windows, which will fail with a TypeError, 
+or try to initialize one of the windows, which will fail with a TypeError,
 as they want to call QApplication which is set to `None`.
 
 An exception to all of this is  :meth:`omc3.plotting.plot_window.create_pyplot_window_from_fig`,
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import sys
 
-import matplotlib
+import matplotlib as mpl
 from matplotlib import pyplot as plt, rcParams
 from matplotlib.figure import Figure
 
@@ -44,7 +44,7 @@ else:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
     try:
-        matplotlib.use('qtagg')
+        mpl.use('qtagg')
     except ImportError as e:
         if "headless" not in str(e):
             raise
@@ -102,7 +102,7 @@ class TabWidget(QTabWidget):
         """A simple tab widget, that in addition
         to QTabWidget keeps track of the tabs via dictionary
         and can have a title.
-        
+
         Args:
             title (str): Title of the created Window
         """
@@ -119,7 +119,7 @@ class TabWidget(QTabWidget):
 class SimpleTabWindow:
 
     def __init__(self, title: str = "Simple Tab Window", size: tuple[int, int] = None):
-        """A simple GUI window, i.e. a standalone graphical application, 
+        """A simple GUI window, i.e. a standalone graphical application,
         which contains a single Tab-Widget, allowing the user to add tabs to it.
 
         Args:
@@ -132,7 +132,7 @@ class SimpleTabWindow:
         self.current_window = -1
         self.tabs_widget = TabWidget()
         self.main_window.setCentralWidget(self.tabs_widget)
-        
+
         if size is None:
             size_in_inch = rcParams["figure.figsize"]
             size = (int(size_in_inch[0] * 100), int(size_in_inch[1] * 100))  # Approximate
@@ -163,7 +163,7 @@ class VerticalTabWindow(SimpleTabWindow):
         Args:
             title (str): Title of the created Window.
             size (Tuple[int, int]): Size of the created window in pixels.
-        """        
+        """
         super().__init__(title, size)
         self.tabs_widget.setTabPosition(QTabWidget.West)
 
@@ -182,14 +182,14 @@ class VerticalTabWindow(SimpleTabWindow):
 
 
 def create_pyplot_window_from_fig(fig: Figure, title: str = None):
-    """Create a window from the given figure, which is managed by pyplot. 
+    """Create a window from the given figure, which is managed by pyplot.
     This is similar to how figures behave when created with `pyplot.figure()`,
     but you can crate the figure instance first and the manager later.
 
     Caveat: Uses private functions of pyplot.
 
     Args:
-        fig (Figure): figure to be managed by pyplot. 
+        fig (Figure): figure to be managed by pyplot.
         title (str): Title of the window.
     """
     if fig.canvas.manager is not None:

--- a/omc3/scripts/create_logbook_entry.py
+++ b/omc3/scripts/create_logbook_entry.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from typing import Iterable, Union, List
 
 import urllib3
-from requests.exceptions import HTTPError, ConnectionError, ConnectTimeout
+from requests.exceptions import HTTPError, ConnectionError, ConnectTimeout  # noqa: A004
 
 from generic_parser import entrypoint, EntryPointParameters
 from omc3.utils.iotools import PathOrStr, OptionalStr
@@ -271,4 +271,3 @@ def _convert_pdf_to_png(filepath: Path):
 
 if __name__ == '__main__':
     main()
-

--- a/omc3/scripts/fake_measurement_from_model.py
+++ b/omc3/scripts/fake_measurement_from_model.py
@@ -119,7 +119,6 @@ from omc3.utils.iotools import PathOrStr, PathOrStrOrDataFrame
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Callable
 
 LOG = logging_tools.get_logger(__name__)
 
@@ -203,14 +202,11 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
     global_correction_entrypoint uses (same format you would get from hole_in_one).
     """
     LOG.info("Generating fake measurements.")
-
     # prepare data
+    np.random.seed(opt.seed)
     randomize = opt.randomize if opt.randomize is not None else []
-    df_twiss, df_model = _get_data(
-        opt.twiss,
-        opt.model,
-        add_coupling=(F1001 in opt.parameters) or (F1010 in opt.parameters),
-    )
+    df_twiss, df_model = _get_data(opt.twiss, opt.model,
+                                   add_coupling=(F1001 in opt.parameters) or (F1010 in opt.parameters))
 
     # headers
     headers = {f"{TUNE}1": df_twiss[f"{TUNE}1"], f"{TUNE}2": df_twiss[f"{TUNE}2"]}
@@ -223,12 +219,11 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
     # create defaults
     results = {}
     for parameter, error in _get_loop_parameters(opt.parameters, opt.relative_errors):
-        create: Callable = CREATOR_MAP[parameter[:-1]]
+        create = CREATOR_MAP[parameter[:-1]]
         new_dfs = create(df_twiss, df_model, parameter,
                          relative_error=error,
                          randomize=randomize,
-                         headers=headers,
-                         seed=opt.seed)
+                         headers=headers)
         results.update(new_dfs)
 
     # maybe create normalized dispersion
@@ -256,19 +251,18 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
 # Main Creator Functions -------------------------------------------------------
 
 def create_beta(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                relative_error: float, randomize: Sequence[str], headers: dict,
-                seed: int | None = None):
+                relative_error: float, randomize: Sequence[str], headers: dict):
     """ Create both beta_amp and beta_phase measurements. """
     LOG.info(f"Creating fake beta for {parameter}.")
     plane = parameter[-1]
 
     # create beta
-    df = create_measurement(df_twiss, parameter, relative_error, randomize, seed)
+    df = create_measurement(df_twiss, parameter, relative_error, randomize)
     df[parameter] = np.abs(df[parameter])
     df = append_model_param(df, df_model, parameter, beat=True)
 
     # create alpha
-    df_alpha = create_measurement(df_twiss, f'{ALPHA}{plane}', relative_error, randomize, seed)
+    df_alpha = create_measurement(df_twiss, f'{ALPHA}{plane}', relative_error, randomize)
     df_alpha = append_model_param(df_alpha, df_model, f'{ALPHA}{plane}')
     df = tfs.concat([df, df_alpha], axis=1, join='inner')
 
@@ -280,12 +274,11 @@ def create_beta(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
 
 
 def create_dispersion(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                      relative_error: float, randomize: Sequence[str], headers: dict,
-                      seed: int | None = None):
+                      relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates dispersion measurement. """
     LOG.info(f"Creating fake dispersion for {parameter}.")
     plane = parameter[-1]
-    df = create_measurement(df_twiss, parameter, relative_error, randomize, seed)
+    df = create_measurement(df_twiss, parameter, relative_error, randomize)
     df = append_model_param(df, df_model, parameter)
     df = append_model_s_and_phaseadv(df, df_model, planes=plane)
     df.headers = headers.copy()
@@ -293,22 +286,20 @@ def create_dispersion(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter:
 
 
 def create_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                 relative_error: float, randomize: Sequence[str], headers: dict,
-                 seed: int | None = None):
+                 relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates both phase advance and total phase measurements. """
     LOG.info(f"Creating fake phases for {parameter}.")
     results = {}
-    dict_adv = create_phase_advance(df_twiss, df_model, parameter, relative_error, randomize, headers, seed)
+    dict_adv = create_phase_advance(df_twiss, df_model, parameter, relative_error, randomize, headers)
     results.update(dict_adv)
 
-    dict_tot = create_total_phase(df_twiss, df_model, parameter, relative_error, randomize, headers, seed)
+    dict_tot = create_total_phase(df_twiss, df_model, parameter, relative_error, randomize, headers)
     results.update(dict_tot)
     return results
 
 
 def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                         relative_error: float, randomize: Sequence[str], headers: dict,
-                         seed: int | None = None):
+                         relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates phase advance measurements. """
     LOG.debug(f"Creating fake phase advance for {parameter}.")
     plane = parameter[-1]
@@ -324,11 +315,10 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
     values = get_phase_advances(df_twiss)
     errors = relative_error * np.ones_like(values)
     if ERRORS in randomize:
-        errors = _get_random_errors(errors, np.ones_like(values), seed) % 0.5
+        errors = _get_random_errors(errors, np.ones_like(values)) % 0.5
 
     if VALUES in randomize:
-        rng = np.random.default_rng(seed)  # numpy random generator, the correct way
-        values = rng.normal(values, errors)
+        values = np.random.normal(values, errors)
         values = ang_interval_check(values)
 
     df_adv[parameter] = values
@@ -347,8 +337,7 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
 
 
 def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                       relative_error: float, randomize: Sequence[str], headers: dict,
-                       seed: int | None = None):
+                       relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates total phase measurements. """
     LOG.debug(f"Creating fake total phase for {parameter}.")
     plane = parameter[-1]
@@ -359,12 +348,11 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
     values = df_twiss[f"{PHASE_ADV}{plane}"] - df_twiss.loc[element0, f"{PHASE_ADV}{plane}"]
     errors = relative_error * np.ones_like(values)
     if ERRORS in randomize:
-        errors = _get_random_errors(errors, np.ones_like(values), seed) % 0.5
+        errors = _get_random_errors(errors, np.ones_like(values)) % 0.5
     errors[0] = 0.
 
     if VALUES in randomize:
-        rng = np.random.default_rng(seed)  # numpy random generator, the correct way
-        rand_val = rng.normal(values, errors) % 1
+        rand_val = np.random.normal(values, errors) % 1
         values += ang_diff(rand_val, values)
 
     df_tot[parameter] = values % 1
@@ -387,8 +375,7 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
 
 
 def create_coupling(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: str,
-                    relative_error: float, randomize: Sequence[str], headers: dict,
-                    seed: int | None = None):
+                    relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates coupling measurements for either the difference or sum RDT. """
     LOG.info(f"Creating fake coupling for {parameter}.")
     def model_column(part):
@@ -397,7 +384,7 @@ def create_coupling(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter: s
 
     # Naming with R, I, A, P as long as model is involved
     df = tfs.concat(
-        [create_measurement(df_twiss, model_col, relative_error, randomize, seed) for model_col in column_map.keys()],
+        [create_measurement(df_twiss, model_col, relative_error, randomize) for model_col in column_map.keys()],
         axis=1
     )
     for model_col in column_map.keys():
@@ -452,7 +439,7 @@ def create_normalized_dispersion(df_disp: pd.DataFrame, df_beta: pd.DataFrame,
 
 
 def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: float,
-                       randomize: Sequence[str], seed: int | None = None) -> tfs.TfsDataFrame:
+                       randomize: Sequence[str]) -> tfs.TfsDataFrame:
     """ Create a new measurement Dataframe from df_twiss from parameter. """
     LOG.debug(f"Creating fake measurement for {parameter}.")
     values = df_twiss.loc[:, parameter]
@@ -462,11 +449,10 @@ def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: f
                     f"Fake measurement will be zero as well.")
     else:
         if ERRORS in randomize:
-            errors = _get_random_errors(errors, values, seed)
+            errors = _get_random_errors(errors, values)
 
         if VALUES in randomize:
-            rng = np.random.default_rng(seed)  # numpy random generator, the correct way
-            values = rng.normal(values, errors)
+            values = np.random.normal(values, errors)
 
     df = tfs.TfsDataFrame({parameter: values,
                            f"{ERR}{parameter}": errors},
@@ -552,19 +538,17 @@ def _get_loop_parameters(parameters: Sequence[str], errors: Sequence[float] | No
     return zip(parameters, errors)
 
 
-def _get_random_errors(errors: np.array, values: np.array, seed: int | None = None) -> np.array:
+def _get_random_errors(errors: np.array, values: np.array) -> np.array:
     """ Creates normal distributed error-values that will not be lower than EPSILON. """
     LOG.debug("Calculating normal distributed random errors.")
     if any(errors == 0):
         raise ValueError("Errors were requested but given relative error was zero.")
 
-    rng = np.random.default_rng(seed)  # numpy random generator, the correct way
     random_errors = np.zeros_like(errors)
     too_small = np.ones_like(errors, dtype=bool)
     n_too_small = 1
-
     while n_too_small:
-        random_errors[too_small] = rng.normal(errors[too_small], errors[too_small])
+        random_errors[too_small] = np.random.normal(errors[too_small], errors[too_small])
         too_small = random_errors < EPSILON * np.abs(values)
         n_too_small = sum(too_small)
         LOG.debug(f"{n_too_small} error values are smaller than given eps.")

--- a/omc3/scripts/fake_measurement_from_model.py
+++ b/omc3/scripts/fake_measurement_from_model.py
@@ -227,7 +227,8 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
         new_dfs = create(df_twiss, df_model, parameter,
                          relative_error=error,
                          randomize=randomize,
-                         headers=headers)
+                         headers=headers,
+                         seed=opt.seed)
         results.update(new_dfs)
 
     # maybe create normalized dispersion

--- a/omc3/utils/parsertools.py
+++ b/omc3/utils/parsertools.py
@@ -38,9 +38,9 @@ def require_param(name: str, parameters: dict, options: dict):
         raise AttributeError(f"Missing flag `{name}`.\nUsage:\n{_get_help_str(name, parameters)}")
 
 
-def _maybe_get(space: str, category: str, map: dict)  -> str:
-    if category in map:
-        return f"{space}{category}: {map[category]}\n"
+def _maybe_get(space: str, category: str, mapping: dict)  -> str:
+    if category in mapping:
+        return f"{space}{category}: {mapping[category]}\n"
     return ""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,11 +164,32 @@ indent-width = 4
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ignore = [
+  "E501",  # line too long
   "FBT001",  # boolean-type-hint-positional-argument
   "FBT002",  # boolean-default-value-positional-argument
   "PT019",  # pytest-fixture-param-without-value (but suggested solution fails)
 ]
-
+extend-select = [
+    "F",        # Pyflakes rules
+    # "W",        # PyCodeStyle warnings
+    "E",        # PyCodeStyle errors
+    # "I",        # Sort imports properly
+    "A",        # Detect shadowed builtins
+    # "N",        # enforce naming conventions, e.g. ClassName vs function_name
+    # "UP",       # Warn if certain things can changed due to newer Python versions
+    # "C4",       # Catch incorrect use of comprehensions, dict, list, etc
+    "FA",       # Enforce from __future__ import annotations
+    "FBT",      # detect boolean traps
+    # "ISC",      # Good use of string concatenation
+    "BLE",      # disallow catch-all exceptions
+    "ICN",      # Use common import conventions
+    # "RET",      # Good return practices
+    # "SIM",      # Common simplification rules
+    # "TID",      # Some good import practices
+    # "TC",       # Enforce importing certain types in a TYPE_CHECKING block
+    # "PTH",      # Use pathlib instead of os.path
+    # "NPY",      # Some numpy-specific things
+]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ extend-select = [
     # "TID",      # Some good import practices
     # "TC",       # Enforce importing certain types in a TYPE_CHECKING block
     # "PTH",      # Use pathlib instead of os.path
-    "NPY",      # Some numpy-specific things
+    # "NPY",      # Some numpy-specific things
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ extend-select = [
     # "TID",      # Some good import practices
     # "TC",       # Enforce importing certain types in a TYPE_CHECKING block
     # "PTH",      # Use pathlib instead of os.path
-    # "NPY",      # Some numpy-specific things
+    "NPY",      # Some numpy-specific things
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
Now that we have a linting check in CI, I am suggesting adding some more rules to the `Ruff` setup on top of the default ones.

This PR introduces a list of rules, some of which I've activated and fixed (hence the file changes). All other changes in said files are the removal of trailing spaces that my IDE did.

~~There was one non-straightforward case of `NPY002` in `omc3/scripts/fake_measurement_from_model.py`, where a `np.random.seed` was set without random number generation, most likely to propagate to all called functions.~~

~~Considering the [numpy docs](https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html) actively discourage doing this, and recommend a per-generator seeding I have propagated the seed down to called functions and let those use it when creating their own Generators.~~

@JoschD @jgray-19 I am eager to get your opinion on the list of rules I have envisioned, in the `[ruff.lint]` table of the `pyproject.toml` file, including those I have not yet activated. You can look for their meaning and check at https://docs.astral.sh/ruff/rules/. They can come in a later PR.