### PR TITLE
Fix docs and tests to be in GeV

### DIFF
--- a/omc3/model/accelerators/esrf.py
+++ b/omc3/model/accelerators/esrf.py
@@ -28,7 +28,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in **Tev**.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/accelerators/iota.py
+++ b/omc3/model/accelerators/iota.py
@@ -28,7 +28,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in **Tev**.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -51,7 +51,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in Tev.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -28,7 +28,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in **Tev**.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/accelerators/psbooster.py
+++ b/omc3/model/accelerators/psbooster.py
@@ -29,7 +29,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in **Tev**.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/accelerators/skekb.py
+++ b/omc3/model/accelerators/skekb.py
@@ -38,7 +38,7 @@ Model Creation Keyword Args:
 
     - **energy** *(float)*:
 
-        Energy in **Tev**.
+        Energy in **GeV**.
 
 
     - **model_dir** *(str)*:

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -216,7 +216,8 @@ class ModelCreator(ABC):
             file_path = Path(dir_) / out_file
             if not file_path.exists():
                 raise FileNotFoundError(
-                    f"Model Creation Failed. The file '{file_path.absolute()}' was not created."
+                    f"Model Creation Failed, could not find file {out_file} in {dir_}.\n"
+                    f"The file '{file_path.absolute()}' was not created."
                 )
     
     def prepare_symlink(self):
@@ -447,7 +448,7 @@ class CorrectionModelCreator(ModelCreator):
         Args:
             accel (Accelerator): Accelerator Class Instance.
             twiss_out (Path | str): Path to the twiss(-elements) file to write.
-            change_params (Sequence[Path]): Sequence of correction/matching files.
+            corr_files (Sequence[Path]): Sequence of correction/matching files.
             update_dpp (bool): Whether to update the dpp in the machine.
         """
         LOGGER.debug("Initializing Correction Model Creator Base Attributes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,7 @@ def tmp_model(factory, year: str, beam: int, tunes: str, beta: str, suffix: str 
         model_dir=tmp_model_path,
         year=year,
         accel="lhc",
-        energy=0.45 if beta == '11m' else 6.5,
+        energy=450 if beta == '11m' else 6500,
         driven_excitation=None if beta == '11m' else 'acd'
     )
 

--- a/tests/inputs/models/create_responses_2018_inj_11m.py
+++ b/tests/inputs/models/create_responses_2018_inj_11m.py
@@ -63,7 +63,7 @@ def _create_response(beam: int, correction_params: CorrectionParameters, creator
             model_dir=model_dir,
             year="2018",
             accel="lhc",
-            energy=0.45,
+            energy=450,
             creator=creator,
             delta_k=DELTA_K,
             variable_categories=correction_params.variables,

--- a/tests/utils/lhc_rdts/functions.py
+++ b/tests/utils/lhc_rdts/functions.py
@@ -115,7 +115,7 @@ def get_rdts_from_optics_analysis(
             accel="lhc",
             beam=beam,
             year="2024",
-            energy=6.8,
+            energy=6800,
             model_dir=model_dir,
             only_coupling=only_coupling,
             compensation="none",


### PR DESCRIPTION
If you input your energy in TeV for the LHC, it will fail. 

The main usage I found of the energy is in GeV, not TeV. Also, the tests of the model creator use GeV *not* TeV. 

I sneak a couple other changes in here, one fixing the parameter argument in the docs, and the other making an error message more useful. 

Draft to see if the tests pass. 