### PR TITLE
Adding Linting Commit to Git-Rev File and Removing CodeClimate Badges

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,4 @@
 # Add below, one per line, SHAs of commits corresponding to "formatting" / "revisions"
 820a51e3c67c8675880b9c949ac09f4db8bd8e9f
 4e59cd0f7eb6a4279dc3f5cfbaed2b03b1918df3
+0c19f7f7aa2e69a46c0e72fb99d4c3a29a1726c1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# <img src="https://raw.githubusercontent.com/pylhc/pylhc.github.io/master/docs/assets/logos/OMC_logo.svg" height="28"> 3
+# <img src="https://raw.githubusercontent.com/pylhc/pylhc.github.io/master/docs/assets/logos/OMC_logo.svg" height="28" alt="omc3 logo"> 3
 
 [![Tests](https://github.com/pylhc/omc3/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/pylhc/omc3/actions/workflows/coverage.yml)
-[![Code Climate coverage](https://img.shields.io/codeclimate/coverage/pylhc/omc3.svg?style=popout)](https://codeclimate.com/github/pylhc/omc3)
-[![Code Climate maintainability (percentage)](https://img.shields.io/codeclimate/maintainability-percentage/pylhc/omc3.svg?style=popout)](https://codeclimate.com/github/pylhc/omc3)
 [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/omc3.svg?style=popout)](https://github.com/pylhc/omc3/)
 [![GitHub release](https://img.shields.io/github/release/pylhc/omc3.svg?style=popout)](https://github.com/pylhc/omc3/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5705625.svg)](https://doi.org/10.5281/zenodo.5705625)


### PR DESCRIPTION
Adding the previous master commit's hash to `.git-blame-ignore-revs` and removing the code climate badges from `README.md`.