### PR TITLE
Action calculation / rescaling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OMC3 Changelog
 
+#### 2026-??-?? - v0.28.2 - _fsoubelet_
+
+- Fixed:
+    - Fixed an inconsistency in the rescaling for the action calculation leading to wrong values of 2J (while having correct values for sqrt(2J)), noticed in B2.
+
 #### 2026-03-27 - v0.28.1 - _fsoubelet_
 
 - Changed:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.28.1"
+__version__ = "0.28.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/optics_measurements/kick.py
+++ b/omc3/optics_measurements/kick.py
@@ -5,6 +5,7 @@ Kick
 This module contains kick functionality of ``optics_measurements``.
 It provides functions to compute kick actions.
 """
+
 from __future__ import annotations
 
 from contextlib import suppress
@@ -45,7 +46,9 @@ if TYPE_CHECKING:
     from omc3.optics_measurements.data_models import InputFiles
 
 
-def calculate(measure_input: DotDict, input_files: InputFiles, scale, header_dict: dict, plane):
+def calculate(
+    measure_input: DotDict, input_files: InputFiles, scale: float, header_dict: dict, plane: str
+) -> np.ndarray:
     """
 
     Args:
@@ -56,7 +59,8 @@ def calculate(measure_input: DotDict, input_files: InputFiles, scale, header_dic
         plane: marking the horizontal or vertical plane, **X** or **Y**.
 
     Returns:
-        `TfsDataFrame` containing actions and their errors.
+        A 2D numpy array containing the sqrt(2J) and associated errors
+        for the given plane.
     """
     try:
         kick_frame = _get_kick(measure_input, input_files, plane)
@@ -64,27 +68,52 @@ def calculate(measure_input: DotDict, input_files: InputFiles, scale, header_dic
         return pd.DataFrame
     kick_frame = _rescale_actions(kick_frame, scale, plane)
     header = _get_header(header_dict, plane, scale)
-    tfs.write(Path(measure_input.outputdir) / f"{KICK_NAME}{plane.lower()}{EXT}", kick_frame, header)
+    tfs.write(
+        Path(measure_input.outputdir) / f"{KICK_NAME}{plane.lower()}{EXT}",
+        kick_frame,
+        header,
+    )
     return kick_frame.loc[:, [f"{SQRT_ACTION}{plane}", f"{ERR}{SQRT_ACTION}{plane}"]].to_numpy()
 
 
-def _get_header(header_dict, plane, scale):
+def _get_header(header_dict: dict, plane: str, scale: float) -> dict:
     header = header_dict.copy()
     header[f"{RESCALE_FACTOR}{plane}"] = scale
     return header
 
 
-def _rescale_actions(df, scaling_factor, plane):
-    for col in (f"{SQRT_ACTION}{plane}", f"{ERR}{SQRT_ACTION}{plane}", f"{ACTION}{plane}", f"{ERR}{ACTION}{plane}"):
-        df[f"{col}{RES}"] = df.loc[:, col].to_numpy() * scaling_factor
+def _rescale_actions(df: pd.DataFrame, scaling_factor: float, plane: str) -> pd.DataFrame:
+    """
+    Apply computed rescaling factor to action columns, for the given plane.
+
+    Note
+    ----
+    This function applies the scaling factor to the sqrt(2J) column and
+    uses the result to compute the rescaled 2J column afterwards. In the
+    past the same rescaling was applied to both columns which is incorrect.
+
+    Args:
+        df (pd.DataFrame): the kick file dataframe.
+        scaling_factor (float): computed scaling to apply to the sqrt(2J) column.
+        plane (str): the plane to apply for.
+
+    Returns:
+        A pandas.DataFrame with the relevant columns rescaled, consistently.
+    """
+    # Directly rescale sqrt(2J) and its error with the provided factor
+    df[f"{SQRT_ACTION}{plane}{RES}"] = (df.loc[:, f"{SQRT_ACTION}{plane}"].to_numpy() * scaling_factor)
+    df[f"{ERR}{SQRT_ACTION}{plane}{RES}"] = df.loc[:, f"{ERR}{SQRT_ACTION}{plane}"].to_numpy() * abs(scaling_factor)
+    # Infer the rescaled 2J values from the rescaled sqrt(2J) values, same for errors
+    df[f"{ACTION}{plane}{RES}"] = df.loc[:, f"{SQRT_ACTION}{plane}{RES}"].to_numpy() ** 2
+    df[f"{ERR}{ACTION}{plane}{RES}"] = abs(2 * df.loc[:, f"{SQRT_ACTION}{plane}{RES}"].to_numpy() * df.loc[:, f"{ERR}{SQRT_ACTION}{plane}{RES}"].to_numpy())
     return df
 
 
-def _get_kick(measure_input, files, plane):
+def _get_kick(measure_input: DotDict, files: InputFiles, plane: str) -> pd.DataFrame:
     load_columns, calc_columns, column_types = _get_column_mapping(plane)
-    kick_frame = pd.DataFrame(data=0.,
-                              index=range(len(files[plane])),
-                              columns=list(column_types.keys()))
+    kick_frame = pd.DataFrame(
+        data=0.0, index=range(len(files[plane])), columns=list(column_types.keys())
+    )
     kick_frame = kick_frame.astype(column_types)
 
     for i, df in enumerate(files[plane]):
@@ -98,7 +127,7 @@ def _get_kick(measure_input, files, plane):
     return kick_frame.astype(column_types)
 
 
-def _get_action(meas_input, lin: pd.DataFrame, plane: str) -> np.ndarray:
+def _get_action(meas_input: DotDict, lin: pd.DataFrame, plane: str) -> np.ndarray:
     """
     Calculates action (2J and sqrt(2J)) and its errors from BPM data in lin-df.
     Takes either PK2PK/2 for kicker excitation or AMP for AC-dipole excitation,
@@ -114,51 +143,54 @@ def _get_action(meas_input, lin: pd.DataFrame, plane: str) -> np.ndarray:
     Returns:
         sqrt(2J), error sqrt(2J), 2J, error 2J as  (1x4) array
     """
-    frame = pd.merge(_get_model_arc_betas(meas_input, plane), lin,
-                     how='inner', left_index=True, right_index=True)
+    frame: pd.DataFrame = pd.merge(
+        _get_model_arc_betas(meas_input, plane),
+        lin,
+        how="inner",
+        left_index=True,
+        right_index=True,
+    )
 
     if meas_input.accelerator.excitation:
-        amps = frame.loc[:, f"{AMPLITUDE}{plane}"].to_numpy()
+        amps: np.ndarray = frame.loc[:, f"{AMPLITUDE}{plane}"].to_numpy()
         try:  # only created when using cleaning in harpy
-            err_amps = frame.loc[:, f"{ERR}{AMPLITUDE}{plane}"].to_numpy()
+            err_amps: np.ndarray = frame.loc[:, f"{ERR}{AMPLITUDE}{plane}"].to_numpy()
         except KeyError:
-            err_amps = np.zeros_like(amps)
+            err_amps: np.ndarray = np.zeros_like(amps)
     else:
-        amps = frame.loc[:, PEAK2PEAK].to_numpy() / 2.0
+        amps: np.ndarray = frame.loc[:, PEAK2PEAK].to_numpy() / 2.0
         try:
-            err_amps = frame.loc[:, f"{CLOSED_ORBIT}{RMS}"].to_numpy()
+            err_amps: np.ndarray = frame.loc[:, f"{CLOSED_ORBIT}{RMS}"].to_numpy()
         except KeyError:
-            err_amps = np.zeros_like(amps)
+            err_amps: np.ndarray = np.zeros_like(amps)
 
-    # sqrt(2J) ---
-    sqrt_beta = np.sqrt(frame.loc[:, f"{BETA}{plane}"].to_numpy())
+    # ----- Compute the sqrt(2J) and its error ----- #
+    sqrt_beta: np.ndarray = np.sqrt(frame.loc[:, f"{BETA}{plane}"].to_numpy())
 
-    actions_sqrt2j = amps / sqrt_beta
-    errors_sqrt2j = err_amps / sqrt_beta
+    actions_sqrt2j: np.ndarray = amps / sqrt_beta
+    errors_sqrt2j: np.ndarray = err_amps / sqrt_beta
 
-    mean_sqrt2j = weighted_mean(data=actions_sqrt2j, errors=errors_sqrt2j)
-    err_sqrt2j = weighted_error(data=actions_sqrt2j, errors=errors_sqrt2j)
+    mean_sqrt2j: np.ndarray = weighted_mean(data=actions_sqrt2j, errors=errors_sqrt2j)
+    err_sqrt2j: np.ndarray = weighted_error(data=actions_sqrt2j, errors=errors_sqrt2j)
 
-    # 2J ---
-    actions_2j = np.square(amps) / frame.loc[:, f"{BETA}{plane}"].to_numpy()
-    errors_2j = 2 * amps * err_amps / frame.loc[:, f"{BETA}{plane}"].to_numpy()
-
-    mean_2j = weighted_mean(data=actions_2j, errors=errors_2j)
-    err_2j = weighted_error(data=actions_2j, errors=errors_2j)
+    # ----- Derive 2J from sqrt(2J) for consistency ----- #
+    mean_2j: np.ndarray = mean_sqrt2j**2
+    err_2j: np.ndarray = abs(2 * mean_sqrt2j * err_sqrt2j)
 
     return np.array([mean_sqrt2j, err_sqrt2j, mean_2j, err_2j])
 
 
-def _get_model_arc_betas(measure_input, plane):
+def _get_model_arc_betas(measure_input: DotDict, plane: str) -> pd.DataFrame:
     accel = measure_input.accelerator
-    model = (accel.model_driven if accel.excitation else accel.model)
+    model = accel.model_driven if accel.excitation else accel.model
     return model.loc[:, [S, f"{BETA}{plane}"]].loc[
-           accel.get_element_types_mask(model.index, [AccElementTypes.ARC_BPMS]), :]
+        accel.get_element_types_mask(model.index, [AccElementTypes.ARC_BPMS]), :
+    ]
 
 
-def _get_column_mapping(plane):
-    plane_number = PLANE_TO_NUM[plane]
-    load_columns = {
+def _get_column_mapping(plane: str) -> tuple[dict[str, str], list[str], dict[str, type]]:
+    plane_number: int = PLANE_TO_NUM[plane]
+    load_columns: dict[str, str] = {
         TIME: "TIME",
         DPP: DPP,
         DPPAMP: DPPAMP,
@@ -167,13 +199,12 @@ def _get_column_mapping(plane):
         f"{NAT_TUNE}{plane}": f"{NAT_TUNE}{plane_number}",
         f"{ERR}{NAT_TUNE}{plane}": f"{NAT_TUNE}{plane_number}{RMS}",
     }
-    calc_columns = [
+    calc_columns: list[str] = [
         f"{SQRT_ACTION}{plane}",
         f"{ERR}{SQRT_ACTION}{plane}",
         f"{ACTION}{plane}",
         f"{ERR}{ACTION}{plane}",
     ]
-
-    column_types = {TIME: str}
+    column_types: dict[str, type] = {TIME: str}
     column_types.update(dict.fromkeys(list(load_columns.keys())[1:] + calc_columns, float))
     return load_columns, calc_columns, column_types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ cern = [
   "kerberos >= 1.3.1",  # requires having krb-5config installed on the system
 ]
 madng = [
-  "pymadng >= 0.8.3",
+  # limit pymadng to maximum 0.9.2 as 0.9.3 might have coupling bug
+  "pymadng >= 0.8.3, < 0.9.3",
 ]
 optional = [
   "pymupdf >= 1.22",  # logbook for conversion from pdf to png

--- a/tests/accuracy/test_measure_optics.py
+++ b/tests/accuracy/test_measure_optics.py
@@ -36,10 +36,10 @@ LIMITS = {
     BETA: 3e-3,
     DISPERSION: 1.1e-2,
     NORM_DISPERSION: 5e-3,
-    '': 5e-3  # orbit
+    "": 5e-3,  # orbit
 }
 BASE_PATH = Path(__file__).parent.parent / "results"
-INPUTS = Path(__file__).parent.parent / 'inputs'
+INPUTS = Path(__file__).parent.parent / "inputs"
 
 DPPS = [0, 0, 0, -4e-4, -4e-4, 4e-4, 4e-4, 5e-5, -3e-5, -2e-5]  # defines the slicing
 
@@ -50,30 +50,44 @@ MEASURE_OPTICS_SETTINGS = {
     "three_bpm_method": [False],
     "second_order_disp": [False],
 }
-VALUES_GRID = list(itertools.product(*MEASURE_OPTICS_SETTINGS.values()))  # easy to add more tests in grid above
+# Easier to add more tests in grid above and let this collection do the work
+VALUES_GRID = list(itertools.product(*MEASURE_OPTICS_SETTINGS.values()))
 PARAMS = ", ".join(MEASURE_OPTICS_SETTINGS)
 
 
 @pytest.mark.basic
 def test_single_file_single_input(tmp_path, input_data):
+    """Just a run-through with a single input."""
     test_measure_optics(tmp_path, input_data, slice(0, 1), *VALUES_GRID[0])
 
 
 @pytest.mark.basic
 def test_3_onmom_files_single_input(tmp_path, input_data):
+    """Just a run-through with three inputs, similar to three bunches measurements."""
     test_measure_optics(tmp_path, input_data, slice(None, 3), *VALUES_GRID[1])
 
 
 @pytest.mark.extended
 @pytest.mark.parametrize(PARAMS, VALUES_GRID)
-@pytest.mark.parametrize("lin_slice",
-                         (slice(0, 1), slice(None, 3), slice(-3, None), slice(None, 7)),
-                         ids=("single_file", "3_files_onmom", "3_files_pseudo_onmom", "offmom"))
+@pytest.mark.parametrize(
+    "lin_slice",
+    (slice(0, 1), slice(None, 3), slice(-3, None), slice(None, 7)),
+    ids=("single_file", "3_files_onmom", "3_files_pseudo_onmom", "offmom"),
+)
 def test_measure_optics(
-        tmp_path, input_data, lin_slice,
-        compensation, coupling_method, range_of_bpms, three_bpm_method, second_order_disp):
+    tmp_path,
+    input_data,
+    lin_slice,
+    compensation,
+    coupling_method,
+    range_of_bpms,
+    three_bpm_method,
+    second_order_disp,
+):
+    """This one actually checks the results from the analysis."""
+    # Preparing the parameters
     data = input_data["free" if compensation == CompensationMode.NONE else "driven"]
-    lins, optics_opt = data['lins'], data['optics_opt']
+    lins, optics_opt = data["lins"], data["optics_opt"]
     optics_opt.update(
         outputdir=tmp_path,
         compensation=compensation,
@@ -83,9 +97,15 @@ def test_measure_optics(
         second_order_disp=second_order_disp,
         chromatic_beating=lin_slice == slice(None, 7),
     )
+
+    # Preparing the input objects
     inputs = InputFiles(lins[lin_slice], optics_opt)
+
+    # Running the analysis
     with timeit(lambda spanned: LOG.debug(f"\nTotal time for optics measurements: {spanned}")):
         measure_optics.measure_optics(inputs, optics_opt)
+
+    # Checking the results
     evaluate_accuracy(optics_opt.outputdir, LIMITS)
     evaluate_kick_consistency(optics_opt.outputdir)
 
@@ -94,22 +114,26 @@ def test_measure_optics(
 
 
 def evaluate_accuracy(meas_path, limits):
+    """
+    Check that the RMS of all DELTA columns in output
+    TFS files stays within provided limits.
+    """
     for f in meas_path.glob("*.tfs"):  # maybe a simple list of files to test wouldn't be too bad?
         if "f10" in f.name or "phase_driven" in f.name:
             continue
         df = tfs.read(f)
-        cols = df.columns[df.columns.str.startswith('DELTA')]
+        cols = df.columns[df.columns.str.startswith("DELTA")]
         for col in cols:
-            if f.name.startswith('normalised_dispersion') and col.startswith('DELTAD'):
+            if f.name.startswith("normalised_dispersion") and col.startswith("DELTAD"):
                 continue
 
             rms = stats.weighted_rms(
-                data=df.loc[:, col].to_numpy(),
-                errors=df.loc[:, f"ERR{col}"].to_numpy()
+                data=df.loc[:, col].to_numpy(), errors=df.loc[:, f"ERR{col}"].to_numpy()
             )
             assert rms < limits[col[5:-1]], f"\n{f.name:25}  {col:15}   RMS: {rms:.1e}"
             LOG.info(f"{f.name:25}  {col[5:]:15}   RMS: {rms:.1e}")
-    assert ((meas_path / f"{SPECIAL_PHASE_NAME}x.tfs").is_file() and (meas_path / f"{SPECIAL_PHASE_NAME}y.tfs").is_file())
+    assert (meas_path / f"{SPECIAL_PHASE_NAME}x.tfs").is_file()
+    assert (meas_path / f"{SPECIAL_PHASE_NAME}y.tfs").is_file()
 
 
 def evaluate_kick_consistency(meas_path, tolerance=1e-10):
@@ -141,7 +165,11 @@ def evaluate_kick_consistency(meas_path, tolerance=1e-10):
             # Ensure consistency between the errors of the above 2 quantities values
             np.testing.assert_allclose(
                 df[f"{ERR}{ACTION}{plane}{RES}"].to_numpy(),
-                np.abs(2 * df[f"{SQRT_ACTION}{plane}{RES}"].to_numpy() * df[f"{ERR}{SQRT_ACTION}{plane}{RES}"].to_numpy()),
+                np.abs(
+                    2
+                    * df[f"{SQRT_ACTION}{plane}{RES}"].to_numpy()
+                    * df[f"{ERR}{SQRT_ACTION}{plane}{RES}"].to_numpy()
+                ),
                 atol=tolerance,
                 err_msg=f"kick_{plane.lower()}: {ERR}{ACTION}{plane}{RES} inconsistent with {SQRT_ACTION}{plane}{RES}",
             )
@@ -149,7 +177,11 @@ def evaluate_kick_consistency(meas_path, tolerance=1e-10):
 
 @pytest.fixture(scope="module", params=(1, 2), ids=("Beam1", "Beam2"))
 def input_data(request, tmp_path_factory):
-    """Creates the input lin data and optics_options."""
+    """
+    Creates the input lin data and optics_options.
+    Using this fixture for a test triggers it for both
+    beam 1 and beam 2, aka 2 runs of the test.
+    """
     data = {}
     beam = request.param
     for motion in ("free", "driven"):
@@ -163,11 +195,12 @@ def input_data(request, tmp_path_factory):
             "beam": beam,
             "files": [""],
             "model_dir": INPUTS / "models" / f"2018_col_b{beam}_25cm",
-            "outputdir": output_path
+            "outputdir": output_path,
         }
         optics_opt, rest = _optics_entrypoint(opt_dict)
         optics_opt.accelerator = manager.get_accelerator(rest)
-        lins = optics_measurement_test_files(opt_dict["model_dir"], DPPS, motion,
-                                             beam_direction=(1 if beam == 1 else -1))
-        data[motion] = {'lins': lins, 'optics_opt': optics_opt}
+        lins = optics_measurement_test_files(
+            opt_dict["model_dir"], DPPS, motion, beam_direction=(1 if beam == 1 else -1)
+        )
+        data[motion] = {"lins": lins, "optics_opt": optics_opt}
     return data

--- a/tests/accuracy/test_measure_optics.py
+++ b/tests/accuracy/test_measure_optics.py
@@ -5,16 +5,21 @@ import numpy as np
 import pytest
 import tfs
 
+from omc3.definitions.constants import PLANES
 from omc3.hole_in_one import _optics_entrypoint  # <- Protected member of module. Make public?
 from omc3.model import manager
 from omc3.optics_measurements import measure_optics
 from omc3.optics_measurements.constants import (
+    ACTION,
     ALPHA,
     BETA,
     DISPERSION,
+    ERR,
     NORM_DISPERSION,
     PHASE,
+    RES,
     SPECIAL_PHASE_NAME,
+    SQRT_ACTION,
 )
 from omc3.optics_measurements.data_models import InputFiles
 from omc3.optics_measurements.phase import CompensationMode
@@ -83,6 +88,7 @@ def test_measure_optics(
     with timeit(lambda spanned: LOG.debug(f"\nTotal time for optics measurements: {spanned}")):
         measure_optics.measure_optics(inputs, optics_opt)
     evaluate_accuracy(optics_opt.outputdir, LIMITS)
+    evaluate_kick_consistency(optics_opt.outputdir)
 
 
 # Helper ---
@@ -107,8 +113,42 @@ def evaluate_accuracy(meas_path, limits):
     assert ((meas_path / f"{SPECIAL_PHASE_NAME}x.tfs").is_file() and (meas_path / f"{SPECIAL_PHASE_NAME}y.tfs").is_file())
 
 
+def evaluate_kick_consistency(meas_path, tolerance=1e-10):
+    """
+    Verify that 2J columns are consistent with sqrt(2J) columns in kick files.
+    This test was added after we noticed a wrong rescaling was applied.
+    """
+    for plane in PLANES:
+        kick_file: Path = meas_path / f"kick_{plane}.tfs"
+        if not kick_file.is_file():
+            continue
+        df: tfs.TfsDataFrame = tfs.read(kick_file)
+        # Ensure consistency between 2J and sqrt(2J) values
+        np.testing.assert_allclose(
+            df[f"{ACTION}{plane}"].to_numpy(),
+            df[f"{SQRT_ACTION}{plane}"].to_numpy() ** 2,
+            atol=tolerance,
+            err_msg=f"kick_{plane.lower()}: {ACTION}{plane} != {SQRT_ACTION}{plane}^2",
+        )
+        # We also check for the output *RES columns
+        if f"{ACTION}{plane}{RES}" in df.columns:
+            # Ensure consistency between 2J and sqrt(2J) values
+            np.testing.assert_allclose(
+                df[f"{ACTION}{plane}{RES}"].to_numpy(),
+                df[f"{SQRT_ACTION}{plane}{RES}"].to_numpy() ** 2,
+                atol=tolerance,
+                err_msg=f"kick_{plane.lower()}: {ACTION}{plane}{RES} != {SQRT_ACTION}{plane}{RES}^2",
+            )
+            # Ensure consistency between the errors of the above 2 quantities values
+            np.testing.assert_allclose(
+                df[f"{ERR}{ACTION}{plane}{RES}"].to_numpy(),
+                np.abs(2 * df[f"{SQRT_ACTION}{plane}{RES}"].to_numpy() * df[f"{ERR}{SQRT_ACTION}{plane}{RES}"].to_numpy()),
+                atol=tolerance,
+                err_msg=f"kick_{plane.lower()}: {ERR}{ACTION}{plane}{RES} inconsistent with {SQRT_ACTION}{plane}{RES}",
+            )
 
-@pytest.fixture(scope="module", params=(1,), ids=("Beam1",))
+
+@pytest.fixture(scope="module", params=(1, 2), ids=("Beam1", "Beam2"))
 def input_data(request, tmp_path_factory):
     """Creates the input lin data and optics_options."""
     data = {}

--- a/tests/accuracy/test_measure_optics.py
+++ b/tests/accuracy/test_measure_optics.py
@@ -65,7 +65,6 @@ def test_3_onmom_files_single_input(tmp_path, input_data):
 
 
 @pytest.mark.extended
-@pytest.mark.parametrize('input_data', (1, 2), ids=["Beam1", "Beam2"], indirect=True)
 @pytest.mark.parametrize(PARAMS, VALUES_GRID)
 @pytest.mark.parametrize("lin_slice",
                          (slice(0, 1), slice(None, 3), slice(-3, None), slice(None, 7)),


### PR DESCRIPTION
This was triggered by #530, where some LHCB2 measurement highlighted inconsistency between the 2J and the sqrt(2J) columns, with the latter being correct.

I looked into the code in `omc3.optics_measurements.kick.py` and there were two things that stood out to me:

1. The `_get_action()` function computes sqrt(2J) and 2J as weighted averages with different data and weight functions. See:

| Quantity   | Weights (per BPM)                    |
|------------|--------------------------------------|
| `sqrt(2J)` | `beta / err_amps^2`                  |
| `2J`       | `beta^2 / (4 * amps^2 * err_amps^2)` |

Per BPM the values should always be consistent (for BPM `i` we fall back on `2J_i = sqrt(2J)_i^2` using the right side formulas), but the weighted means diverge when per-BPM actions vary.

2. The rescaling is inconsistent: `_rescale_actions()` multiplies both sqrt(2J) and 2J by the same `scaling_factor` variable. Considering the relationship and assuming the values for sqrt(2J) are correct (their rescaling too, then), we should be seeing `2J_RES = 2J * scaling_factor^2` but we are using `2J_RES = 2J * scaling_factor`.

Amplitude detuning analysis reads the rescaled `2J` column (aka 2J_RES) via `get_action_col()` which is how #530 stumbled onto this.

------

In this PR I propose to rebase our calculations on the observed correct `sqrt(2J)` values. This is done by:

1. Deriving `2J` from `sqrt(2J)` in `_get_action()` instead of its previous calculation using a different weighted mean.

2. Deriving the rescaled `2J` from the rescaled `sqrt(2J)` in `_rescale_actions()` instead of applying the wrong rescaling factor for this quantity. We could also just use the proper rescaling value but I've decided to go this way for consistency with the point 1 above.

-----

There was a new check added in the `test_optics_measurements` to ensure the consistency between the `2J` and `sqrt(2J)` in our output results. Same for the rescaled values and the corresponding errors.

The rest of the changes are type hints, an entry in the `CHANGELOG` and a patch version bump.

It would be good to run this branch's code on the analysis @emaclean mentioned in #530 so we can attest values for each column are alright.

Closes #530