### PR TITLE
Deprecation and warning fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OMC3 Changelog
 
-#### 2026-??-?? - v0.28.2 - _fsoubelet_
+#### 2026-06-19 - v0.28.2 - _fsoubelet_
 
 - Fixed:
     - Fixed an inconsistency in the rescaling for the action calculation leading to wrong values of 2J (while having correct values for sqrt(2J)), noticed in B2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fixed:
     - Fixed an inconsistency in the rescaling for the action calculation leading to wrong values of 2J (while having correct values for sqrt(2J)), noticed in B2.
+    - Fixed a deprecation warning from `scipy.odr`.
+    - Fixed some `pandas` `PerformanceWarning`s in `omc3.harpy`.
+    - Fixed some type hints and docstrings in the `omc3.optics_measurements` modules.
 
 #### 2026-03-27 - v0.28.1 - _fsoubelet_
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -48,6 +48,8 @@ from omc3.utils import logging_tools
 from omc3.utils.contexts import timeit
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from generic_parser import DotDict
     from turn_by_turn import TbtData
 
@@ -238,12 +240,12 @@ def _sync_phase(lin_frame: pd.DataFrame, plane: str) -> pd.DataFrame:
     return lin_frame
 
 
-def _compute_headers(panda: pd.DataFrame, date: None | pd.Timestamp = None) -> dict[str, float]:
+def _compute_headers(df: pd.DataFrame, date: None | date | pd.Timestamp = None) -> dict[str, str | float]:
     headers = {}
     for plane in ALL_PLANES:
         for prefix in ("", "NAT"):
             try:
-                bpm_tunes = panda[f"{prefix}{COL_TUNE}{plane}"]
+                bpm_tunes = df[f"{prefix}{COL_TUNE}{plane}"]
             except KeyError:
                 pass
             else:

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -271,11 +271,11 @@ def _write_spectrum(
 ) -> None:
     tfs.write(
         f"{output_path_without_suffix}{FILE_AMPS_EXT.format(plane=plane.lower())}",
-        spectra[COL_COEFFS].abs().T,
+        spectra[COL_COEFFS].abs().T,  # ty:ignore[unresolved-attribute]
     )
     tfs.write(
         f"{output_path_without_suffix}{FILE_FREQS_EXT.format(plane=plane.lower())}",
-        spectra[COL_FREQS].T,
+        spectra[COL_FREQS].T,  # ty:ignore[unresolved-attribute]
     )
 
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -132,6 +132,7 @@ def run_per_bunch(
                 order_resonances=harpy_input.resonances,
             )
         )
+        lins[plane] = lins[plane].copy()  # defragment after joins / col assignments etc from previous operations
         lins[plane] = _add_calculated_phase_errors(lins[plane])
         lins[plane] = _sync_phase(lins[plane], plane)
         lins[plane] = _rescale_amps_to_main_line_and_compute_noise(lins[plane], plane)

--- a/omc3/optics_measurements/beta_from_amplitude.py
+++ b/omc3/optics_measurements/beta_from_amplitude.py
@@ -5,6 +5,7 @@ Beta from Amplitude
 This module contains some of the beta calculation related functionality of ``optics_measurements``.
 It provides functions to calculate beta functions from amplitude data.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -50,8 +51,17 @@ def calculate(
     beta_amp = beta_from_amplitude(meas_input, input_files, plane, tune_dict)
     x_ratio = phase_to_amp_ratio(meas_input, beta_phase, beta_amp, plane)
     beta_amp = add_rescaled_beta_columns(beta_amp, x_ratio, plane)
-    header_d = _get_header(header_dict, np.std(beta_amp.loc[:, f"{DELTA}BET{plane}"].to_numpy()), x_ratio)
-    tfs.write(Path(meas_input.outputdir) / f"{AMP_BETA_NAME}{plane.lower()}{EXT}", beta_amp, header_d, save_index='NAME')
+    header_d = _get_header(
+        header_dict,
+        np.std(beta_amp.loc[:, f"{DELTA}BET{plane}"].to_numpy()),
+        x_ratio,
+    )
+    tfs.write(
+        Path(meas_input.outputdir) / f"{AMP_BETA_NAME}{plane.lower()}{EXT}",
+        beta_amp,
+        header_d,
+        save_index="NAME",
+    )
     return x_ratio
 
 
@@ -73,11 +83,20 @@ def phase_to_amp_ratio(
     Returns:
         The mean ratio of phase-beta over amplitude-beta in arc BPMs.
     """
-    ratio = pd.merge(beta_phase.loc[:, [f"BET{plane}"]], beta_amp.loc[:, [f"BET{plane}"]],
-                     how='inner', left_index=True, right_index=True, suffixes=("ph", "amp"))
+    ratio = pd.merge(
+        beta_phase.loc[:, [f"BET{plane}"]],
+        beta_amp.loc[:, [f"BET{plane}"]],
+        how="inner",
+        left_index=True,
+        right_index=True,
+        suffixes=("ph", "amp"),
+    )
     ph_over_amp = df_ratio(ratio, f"BET{plane}ph", f"BET{plane}amp")
-    mask = (np.array(np.abs(ph_over_amp) > 0.1) & np.array(np.abs(ph_over_amp) < 10.0) &
-            np.array(measure_input.accelerator.get_element_types_mask(ratio.index, ["arc_bpm"])))
+    mask = (
+        np.array(np.abs(ph_over_amp) > 0.1)
+        & np.array(np.abs(ph_over_amp) < 10.0)
+        & np.array(measure_input.accelerator.get_element_types_mask(ratio.index, ["arc_bpm"]))
+    )
     return np.mean(ph_over_amp[mask])
 
 
@@ -99,7 +118,10 @@ def add_rescaled_beta_columns(df: pd.DataFrame, ratio: float, plane: str) -> pd.
 
 
 def beta_from_amplitude(
-    meas_input: DotDict, input_files: InputFiles, plane: str, tunes: TuneDict,
+    meas_input: DotDict,
+    input_files: InputFiles,
+    plane: str,
+    tunes: TuneDict,
 ) -> pd.DataFrame:
     """
     Calculates beta function from measured amplitudes across input files.
@@ -114,11 +136,12 @@ def beta_from_amplitude(
         A `DataFrame` with measured beta, model beta, errors, and beating columns.
     """
     df = pd.DataFrame(meas_input.accelerator.model).loc[:, [S, f"MU{plane}", f"BET{plane}"]]
-    df.rename(columns={f"MU{plane}": f"MU{plane}{MDL}",
-                       f"BET{plane}": f"BET{plane}{MDL}"}, inplace=True)
-    df = pd.merge(df, input_files.joined_frame(plane, [f"AMP{plane}", f"MU{plane}"], dpp_value=meas_input.analyse_dpp),
-                  how='inner', left_index=True, right_index=True)
-    df['COUNT'] = len(input_files.get_columns(df, f"AMP{plane}"))
+    df.rename(columns={f"MU{plane}": f"MU{plane}{MDL}", f"BET{plane}": f"BET{plane}{MDL}"}, inplace=True)
+    df = pd.merge(
+        df, input_files.joined_frame(plane, [f"AMP{plane}", f"MU{plane}"], dpp_value=meas_input.analyse_dpp),
+        how="inner", left_index=True, right_index=True
+    )
+    df["COUNT"] = len(input_files.get_columns(df, f"AMP{plane}"))
 
     if meas_input.compensation == "model":
         df = _compensate_by_model(input_files, meas_input, df, plane)
@@ -133,12 +156,15 @@ def beta_from_amplitude(
     df[f"{ERR}BET{plane}"] = np.std(betas, axis=1)
     df[f"{DELTA}BET{plane}"] = df_rel_diff(df, f"BET{plane}", f"BET{plane}{MDL}")
     df[f"{ERR}{DELTA}BET{plane}"] = df_ratio(df, f"{ERR}BET{plane}", f"BET{plane}{MDL}")
-    return df.loc[:, ['S', 'COUNT', f"BET{plane}", f"{ERR}BET{plane}", f"BET{plane}{MDL}",
-                      f"MU{plane}{MDL}", f"{DELTA}BET{plane}", f"{ERR}{DELTA}BET{plane}"]]
+    return df.loc[:, ["S","COUNT", f"BET{plane}", f"{ERR}BET{plane}", f"BET{plane}{MDL}", f"MU{plane}{MDL}", f"{DELTA}BET{plane}", f"{ERR}{DELTA}BET{plane}"]]
 
 
 def _compensate_by_equation(
-    input_files: InputFiles, meas_input: DotDict, df: pd.DataFrame, plane: str, tunes: TuneDict,
+    input_files: InputFiles,
+    meas_input: DotDict,
+    df: pd.DataFrame,
+    plane: str,
+    tunes: TuneDict,
 ) -> pd.DataFrame:
     phases_meas = input_files.get_data(df, f"MU{plane}") * meas_input.accelerator.beam_direction
     driven_tune, _free_tune, ac2bpmac = tunes[plane]["Q"], tunes[plane]["QF"], tunes[plane]["ac2bpm"]
@@ -147,25 +173,35 @@ def _compensate_by_equation(
     phases_meas = phases_meas + phase_corr[np.newaxis, :]
     r = tunes.get_lambda(plane)
     phases_meas[k_bpmac:, :] = phases_meas[k_bpmac:, :] - driven_tune
-    amp_compensation = np.sqrt((1 + r ** 2 + 2 * r * np.cos(4 * np.pi * phases_meas)) / (1 - r ** 2))
-    df[input_files.get_columns(df, f"AMP{plane}")] = input_files.get_data(df, f"AMP{plane}") * amp_compensation
+    amp_compensation = np.sqrt((1 + r**2 + 2 * r * np.cos(4 * np.pi * phases_meas)) / (1 - r**2))
+    df[input_files.get_columns(df, f"AMP{plane}")] = (
+        input_files.get_data(df, f"AMP{plane}") * amp_compensation
+    )
     return df
 
 
 def _compensate_by_model(
-    input_files: InputFiles, meas_input: DotDict, df: pd.DataFrame, plane: str,
+    input_files: InputFiles,
+    meas_input: DotDict,
+    df: pd.DataFrame,
+    plane: str,
 ) -> pd.DataFrame:
-    df = pd.merge(df, pd.DataFrame(meas_input.accelerator.model_driven.loc[:, [f"BET{plane}"]]
-                                   .rename(columns={f"BET{plane}": f"BET{plane}comp"})),
-                  how='inner', left_index=True, right_index=True)
+    df = pd.merge(
+        df,
+        pd.DataFrame(meas_input.accelerator.model_driven.loc[:, [f"BET{plane}"]].rename(columns={f"BET{plane}": f"BET{plane}comp"})),
+        how="inner",
+        left_index=True,
+        right_index=True
+    )
     amp_compensation = np.sqrt(df_ratio(df, f"BET{plane}{MDL}", f"BET{plane}comp"))
-    df[input_files.get_columns(df, f"AMP{plane}")] = (input_files.get_data(df, f"AMP{plane}")
-                                                      * amp_compensation[:, np.newaxis])
+    df[input_files.get_columns(df, f"AMP{plane}")] = (
+        input_files.get_data(df, f"AMP{plane}") * amp_compensation[:, np.newaxis]
+    )
     return df
 
 
 def _get_header(header_dict: dict, rmsbbeat: float, scaling_factor: float) -> dict:
     header = header_dict.copy()
-    header['RMSbetabeat'] = rmsbbeat
-    header['RescalingFactor'] = scaling_factor
+    header["RMSbetabeat"] = rmsbbeat
+    header["RescalingFactor"] = scaling_factor
     return header

--- a/omc3/optics_measurements/beta_from_amplitude.py
+++ b/omc3/optics_measurements/beta_from_amplitude.py
@@ -21,21 +21,31 @@ if TYPE_CHECKING:
     from generic_parser import DotDict
 
     from omc3.optics_measurements.data_models import InputFiles
+    from omc3.optics_measurements.tune import TuneDict
 
 
-def calculate(meas_input: DotDict, input_files: InputFiles, tune_dict, beta_phase, header_dict, plane):
+def calculate(
+    meas_input: DotDict,
+    input_files: InputFiles,
+    tune_dict: TuneDict,
+    beta_phase: pd.DataFrame,
+    header_dict: dict,
+    plane: str,
+) -> float:
     """
-    Calculates beta and fills the following `TfsFiles`: ``f"{AMP_BETA_NAME}{plane.lower()}{EXT}"``
+    Calculates beta and returns the phase to amplitude ratio.
+    Also writes the following `TfsFiles`: ``f"{AMP_BETA_NAME}{plane.lower()}{EXT}"``
 
     Args:
         meas_input: `OpticsInput` object.
         input_files: `InputFiles` object contains measurement files.
         tune_dict: `TuneDict` contains measured tunes.
-        beta_phase: contains beta functions from measured from phase.
+        beta_phase: Dataframe containing beta functions measured from phase.
         header_dict: dictionary of header items common for all output files.
         plane: marking the horizontal or vertical plane, **X** or **Y**.
 
     Returns:
+        The phase-to-amplitude beta ratio (rescaling factor).
     """
     beta_amp = beta_from_amplitude(meas_input, input_files, plane, tune_dict)
     x_ratio = phase_to_amp_ratio(meas_input, beta_phase, beta_amp, plane)

--- a/omc3/optics_measurements/beta_from_amplitude.py
+++ b/omc3/optics_measurements/beta_from_amplitude.py
@@ -55,7 +55,24 @@ def calculate(
     return x_ratio
 
 
-def phase_to_amp_ratio(measure_input, beta_phase, beta_amp, plane):
+def phase_to_amp_ratio(
+    measure_input: DotDict,
+    beta_phase: pd.DataFrame,
+    beta_amp: pd.DataFrame,
+    plane: str,
+) -> float:
+    """
+    Computes the mean ratio of phase-beta to amplitude-beta for arc BPMs.
+
+    Args:
+        measure_input: `OpticsInput` object.
+        beta_phase: Dataframe with beta from phase measurement.
+        beta_amp: Dataframe with beta from amplitude measurement.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        The mean ratio of phase-beta over amplitude-beta in arc BPMs.
+    """
     ratio = pd.merge(beta_phase.loc[:, [f"BET{plane}"]], beta_amp.loc[:, [f"BET{plane}"]],
                      how='inner', left_index=True, right_index=True, suffixes=("ph", "amp"))
     ph_over_amp = df_ratio(ratio, f"BET{plane}ph", f"BET{plane}amp")

--- a/omc3/optics_measurements/beta_from_amplitude.py
+++ b/omc3/optics_measurements/beta_from_amplitude.py
@@ -81,13 +81,37 @@ def phase_to_amp_ratio(
     return np.mean(ph_over_amp[mask])
 
 
-def add_rescaled_beta_columns(df, ratio, plane):
+def add_rescaled_beta_columns(df: pd.DataFrame, ratio: float, plane: str) -> pd.DataFrame:
+    """
+    Adds rescaled beta and error columns to the DataFrame using the given ratio.
+
+    Args:
+        df: DataFrame of beta from amplitude to extend.
+        ratio: phase-to-amplitude rescaling factor.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        The input DataFrame with added rescaled columns.
+    """
     df[f"BET{plane}{RES}"] = df.loc[:, f"BET{plane}"].to_numpy() * ratio
     df[f"{ERR}BET{plane}{RES}"] = df.loc[:, f"{ERR}BET{plane}"].to_numpy() * ratio
     return df
 
 
-def beta_from_amplitude(meas_input, input_files, plane, tunes):
+def beta_from_amplitude(
+    meas_input: DotDict, input_files: InputFiles, plane: str, tunes: TuneDict,
+) -> pd.DataFrame:
+    """Calculates beta function from measured amplitudes across input files.
+
+    Args:
+        meas_input: `OpticsInput` object.
+        input_files: `InputFiles` object containing measurement data.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+        tunes: `TuneDict` contains measured tunes.
+
+    Returns:
+        A `DataFrame` with measured beta, model beta, errors, and beating columns.
+    """
     df = pd.DataFrame(meas_input.accelerator.model).loc[:, [S, f"MU{plane}", f"BET{plane}"]]
     df.rename(columns={f"MU{plane}": f"MU{plane}{MDL}",
                        f"BET{plane}": f"BET{plane}{MDL}"}, inplace=True)

--- a/omc3/optics_measurements/beta_from_amplitude.py
+++ b/omc3/optics_measurements/beta_from_amplitude.py
@@ -101,7 +101,8 @@ def add_rescaled_beta_columns(df: pd.DataFrame, ratio: float, plane: str) -> pd.
 def beta_from_amplitude(
     meas_input: DotDict, input_files: InputFiles, plane: str, tunes: TuneDict,
 ) -> pd.DataFrame:
-    """Calculates beta function from measured amplitudes across input files.
+    """
+    Calculates beta function from measured amplitudes across input files.
 
     Args:
         meas_input: `OpticsInput` object.
@@ -136,7 +137,9 @@ def beta_from_amplitude(
                       f"MU{plane}{MDL}", f"{DELTA}BET{plane}", f"{ERR}{DELTA}BET{plane}"]]
 
 
-def _compensate_by_equation(input_files, meas_input, df, plane, tunes):
+def _compensate_by_equation(
+    input_files: InputFiles, meas_input: DotDict, df: pd.DataFrame, plane: str, tunes: TuneDict,
+) -> pd.DataFrame:
     phases_meas = input_files.get_data(df, f"MU{plane}") * meas_input.accelerator.beam_direction
     driven_tune, _free_tune, ac2bpmac = tunes[plane]["Q"], tunes[plane]["QF"], tunes[plane]["ac2bpm"]
     k_bpmac = ac2bpmac[2]
@@ -149,7 +152,9 @@ def _compensate_by_equation(input_files, meas_input, df, plane, tunes):
     return df
 
 
-def _compensate_by_model(input_files, meas_input, df, plane):
+def _compensate_by_model(
+    input_files: InputFiles, meas_input: DotDict, df: pd.DataFrame, plane: str,
+) -> pd.DataFrame:
     df = pd.merge(df, pd.DataFrame(meas_input.accelerator.model_driven.loc[:, [f"BET{plane}"]]
                                    .rename(columns={f"BET{plane}": f"BET{plane}comp"})),
                   how='inner', left_index=True, right_index=True)
@@ -159,7 +164,7 @@ def _compensate_by_model(input_files, meas_input, df, plane):
     return df
 
 
-def _get_header(header_dict, rmsbbeat, scaling_factor):
+def _get_header(header_dict: dict, rmsbbeat: float, scaling_factor: float) -> dict:
     header = header_dict.copy()
     header['RMSbetabeat'] = rmsbbeat
     header['RescalingFactor'] = scaling_factor

--- a/omc3/optics_measurements/beta_from_phase.py
+++ b/omc3/optics_measurements/beta_from_phase.py
@@ -143,7 +143,7 @@ def write(beta_df: pd.DataFrame, header: dict[str, Any], outputdir: str|Path, pl
 
 def n_bpm_method(
     meas_input: DotDict,
-    phase: pd.DataFrame,
+    phase: PhaseDict,
     plane: str,
     meas_and_mdl_tunes: tuple[float, float]
 ) -> tuple[tfs.TfsDataFrame, str]:
@@ -171,7 +171,7 @@ def n_bpm_method(
 
     Args:
         meas_input: `OpticsInput` object with optics CLI options.
-        phase: phase matrices of measurement with errors and model tfs (bpm x bpm).
+        phase: `PhaseDict` of phase matrices of measurement with errors and model tfs (bpm x bpm).
         plane: marking the horizontal or vertical plane, **X** or **Y**.
         meas_and_mdl_tunes: measured and model tunes.
 
@@ -761,7 +761,7 @@ def _get_header(header_dict: dict[str, Any], error_method: str, range_of_bpms: i
 
 def three_bpm_method(
     meas_input: DotDict,
-    phase: pd.DataFrame,
+    phase: PhaseDict,
     plane: str,
     meas_and_mdl_tunes: tuple[float, float],
 ) -> pd.DataFrame:
@@ -821,7 +821,7 @@ def three_bpm_method(
 
     Args:
         meas_input: `OpticsInput` object with optics CLI options.
-        phase: phase matrices of measurement with errors and model tfs (bpm x bpm).
+        phase: `PhaseDict` of phase matrices of measurement with errors and model tfs (bpm x bpm).
         plane: marking the horizontal or vertical plane, **X** or **Y**.
         meas_and_mdl_tunes: measured and model tunes.
 

--- a/omc3/optics_measurements/beta_from_phase.py
+++ b/omc3/optics_measurements/beta_from_phase.py
@@ -897,11 +897,14 @@ def three_bpm_method(
         sin_quadrup_model = tilted_errmeas**2 / np.power(np.sin(tilted_model), 4) * betmdl
 
     # Square to get variance terms (summed in quadrature across the two BPMs of each triplet)
+    # These terms can be zero when model phase advances are multiples of pi (e.g. in SPS) so
+    # we wrap it into the np.errstate context.
     sin_squared_model = np.square(sin_squared_model)
-    sin_squ_model_shift1 = sin_squared_model + np.roll(sin_squared_model, -1, axis=0) / np.square(cot_phase_model_shift1)
-    sin_squ_model_shift2 = sin_squared_model + np.roll(sin_squared_model, -2, axis=0) / np.square(cot_phase_model_shift2)
-    sin_quad_model_shift1 = sin_quadrup_model + np.roll(sin_quadrup_model, -1, axis=0) / np.square(cot_phase_model_shift1)
-    sin_quad_model_shift2 = sin_quadrup_model + np.roll(sin_quadrup_model, -2, axis=0) / np.square(cot_phase_model_shift2)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sin_squ_model_shift1 = sin_squared_model + np.roll(sin_squared_model, -1, axis=0) / np.square(cot_phase_model_shift1)
+        sin_squ_model_shift2 = sin_squared_model + np.roll(sin_squared_model, -2, axis=0) / np.square(cot_phase_model_shift2)
+        sin_quad_model_shift1 = sin_quadrup_model + np.roll(sin_quadrup_model, -1, axis=0) / np.square(cot_phase_model_shift1)
+        sin_quad_model_shift2 = sin_quadrup_model + np.roll(sin_quadrup_model, -2, axis=0) / np.square(cot_phase_model_shift2)
 
     # beterr = (1/3) · sqrt(Σ variance over 3 combinations): propagated σ_β
     beterr = np.sqrt(sin_squ_model_shift1[0] + sin_squ_model_shift1[3] + sin_squ_model_shift2[1]) / 3

--- a/omc3/optics_measurements/chromatic.py
+++ b/omc3/optics_measurements/chromatic.py
@@ -5,6 +5,7 @@ Chromatic
 This module contains chromatic calculations functionality of ``optics_measurements``.
 It provides functions to compute various chromatic beam properties.
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -46,40 +47,64 @@ def calculate_w_and_phi(
     columns = [f"{pref}{DELTA}{col}{plane}" for pref in ("", ERR) for col in ("BET", "ALF")]
     joined = betas[0].loc[:, columns]
     for i, beta in enumerate(betas[1:]):
-        joined = pd.merge(joined, beta.loc[:, columns], how="inner", left_index=True,
-                          right_index=True, suffixes=('', '__' + str(i + 1)))
+        joined = pd.merge(
+            joined,
+            beta.loc[:, columns],
+            how="inner",
+            left_index=True,
+            right_index=True,
+            suffixes=("", "__" + str(i + 1)),
+        )
+
     for column in columns:
-        joined.rename(columns={column: column + '__0'}, inplace=True)
-    joined = pd.merge(joined,
-                      betas[np.argmin(np.abs(dpps))].loc[:, [f"ALF{plane}", f"{ERR}ALF{plane}"]],
-                      how="inner",
-                      left_index=True, right_index=True)
+        joined.rename(columns={column: column + "__0"}, inplace=True)
+
+    joined = pd.merge(
+        joined,
+        betas[np.argmin(np.abs(dpps))].loc[:, [f"ALF{plane}", f"{ERR}ALF{plane}"]],
+        how="inner",
+        left_index=True,
+        right_index=True,
+    )
+
     for col in ("BET", "ALF"):
-        fit = np.polyfit(np.repeat(dpps, 2),
-                         np.repeat(input_files.get_data(joined, f"{DELTA}{col}{plane}").T, 2,
-                                   axis=0), 1, cov=True)
+        fit = np.polyfit(
+            np.repeat(dpps, 2),
+            np.repeat(input_files.get_data(joined, f"{DELTA}{col}{plane}").T, 2, axis=0),
+            1,
+            cov=True,
+        )
         joined[f"D{col}{plane}"] = fit[0][-2, :].T
         joined[f"{ERR}D{col}{plane}"] = np.sqrt(fit[1][-2, -2, :].T)
+
     a = joined.loc[:, f"DBET{plane}"].to_numpy()
     aerr = joined.loc[:, f"{ERR}DBET{plane}"].to_numpy()
-    b = joined.loc[:, f"DALF{plane}"].to_numpy() - joined.loc[:, f"ALF{plane}"].to_numpy() * joined.loc[:,
-                                                                                     f"DBET{plane}"].to_numpy()
-    berr = np.sqrt(df_prod(joined, f"{ERR}DALF{plane}", f"{ERR}DALF{plane}") +
-                   np.square(df_prod(joined, f"{ERR}ALF{plane}", f"DBET{plane}")) +
-                   np.square(df_prod(joined, f"ALF{plane}", f"{ERR}DBET{plane}")))
+    b = (
+        joined.loc[:, f"DALF{plane}"].to_numpy()
+        - joined.loc[:, f"ALF{plane}"].to_numpy() * joined.loc[:, f"DBET{plane}"].to_numpy()
+    )
+    berr = np.sqrt(
+        df_prod(joined, f"{ERR}DALF{plane}", f"{ERR}DALF{plane}")
+        + np.square(df_prod(joined, f"{ERR}ALF{plane}", f"DBET{plane}"))
+        + np.square(df_prod(joined, f"ALF{plane}", f"{ERR}DBET{plane}"))
+    )
     w = np.sqrt(np.square(a) + np.square(b))
+
     joined[f"W{plane}"] = w
     joined[f"{ERR}W{plane}"] = np.sqrt(np.square(a * aerr / w) + np.square(b * berr / w))
     joined[f"PHI{plane}"] = np.arctan2(b, a) / (2 * np.pi)
-    joined[f"{ERR}PHI{plane}"] = 1 / (1 + np.square(a / b)) * np.sqrt(
-        np.square(aerr / b) + np.square(berr * a / np.square(b))) / (2 * np.pi)
-    output_df = pd.merge(measure_input.accelerator.model.loc[:,
-                         [S, f"{PHASE_ADV}{plane}", f"BET{plane}", f"ALF{plane}", f"W{plane}",
-                          f"PHI{plane}"]],
-                         joined.loc[:,
-                         [f"{pref}{col}{plane}" for pref in ("", ERR) for col in ("W", "PHI")]],
-                         how="inner", left_index=True,
-                         right_index=True, suffixes=(MDL, ''))
+    joined[f"{ERR}PHI{plane}"] = 1 / (1 + np.square(a / b)) * np.sqrt(np.square(aerr / b) + np.square(berr * a / np.square(b))) / (2 * np.pi)
+
+    output_df = pd.merge(
+        measure_input.accelerator.model.loc[
+            :, [S, f"{PHASE_ADV}{plane}", f"BET{plane}", f"ALF{plane}", f"W{plane}", f"PHI{plane}"]
+        ],
+        joined.loc[:, [f"{pref}{col}{plane}" for pref in ("", ERR) for col in ("W", "PHI")]],
+        how="inner",
+        left_index=True,
+        right_index=True,
+        suffixes=(MDL, ""),
+    )
     output_df.rename(columns={"SMDL": S}, inplace=True)
     return output_df
 
@@ -102,28 +127,51 @@ def calculate_chromatic_coupling(
         A `DataFrame` with chromatic coupling amplitudes and components.
     """
     # TODO how to treat the model values?
-    columns = [f"{pref}{col}{part}" for pref in ("", ERR) for col in ("F1001", "F1010") for part in ("RE", "IM")]
+    columns = [
+        f"{pref}{col}{part}"
+        for pref in ("", ERR)
+        for col in ("F1001", "F1010")
+        for part in ("RE", "IM")
+    ]
     joined = couplings[0].loc[:, columns]
-    for i, coup in enumerate(couplings[1:]):
-        joined = pd.merge(joined, coup.loc[:, columns], how="inner", left_index=True,
-                          right_index=True, suffixes=('', '__' + str(i + 1)))
-    for column in columns:
-        joined.rename(columns={column: column + '__0'}, inplace=True)
 
-    for col in ("F1001", "F1010"):
-        for part in ("RE", "IM"):
-            fit = np.polyfit(np.repeat(dpps, 2),
-                             np.repeat(input_files.get_data(joined, f"{col}{part}").T, 2,
-                                       axis=0), 1, cov=True)
-            joined[f"D{col}{part}"] = fit[0][-2, :].T
-            joined[f"{ERR}D{col}{part}"] = np.sqrt(fit[1][-2, -2, :].T)
-        joined[f"D{col}"] = np.sqrt(np.square(joined.loc[:, f"D{col}RE"].to_numpy()) + np.square(joined.loc[:, f"D{col}IM"].to_numpy()))
-        joined[f"{ERR}D{col}"] = np.sqrt(np.square(joined.loc[:, f"D{col}RE"].to_numpy() * df_ratio(joined, f"{ERR}D{col}RE", f"D{col}")) +
-                                         np.square(joined.loc[:, f"D{col}IM"].to_numpy() * df_ratio(joined, f"{ERR}D{col}IM", f"D{col}")))
-    return pd.merge(
-            measure_input.accelerator.model.loc[:, [S]],
-            joined.loc[:,[f"{pref}{col}{part}" for pref in ("", ERR) for col in ("F1001", "F1010") for part in ("", "RE", "IM")]],
+    for i, coup in enumerate(couplings[1:]):
+        joined = pd.merge(
+            joined,
+            coup.loc[:, columns],
             how="inner",
             left_index=True,
             right_index=True,
+            suffixes=("", "__" + str(i + 1)),
         )
+
+    for column in columns:
+        joined.rename(columns={column: column + "__0"}, inplace=True)
+
+    for col in ("F1001", "F1010"):
+        for part in ("RE", "IM"):
+            fit = np.polyfit(
+                np.repeat(dpps, 2),
+                np.repeat(input_files.get_data(joined, f"{col}{part}").T, 2, axis=0),
+                1,
+                cov=True,
+            )
+            joined[f"D{col}{part}"] = fit[0][-2, :].T
+            joined[f"{ERR}D{col}{part}"] = np.sqrt(fit[1][-2, -2, :].T)
+
+        joined[f"D{col}"] = np.sqrt(
+            np.square(joined.loc[:, f"D{col}RE"].to_numpy())
+            + np.square(joined.loc[:, f"D{col}IM"].to_numpy())
+        )
+        joined[f"{ERR}D{col}"] = np.sqrt(
+            np.square(joined.loc[:, f"D{col}RE"].to_numpy() * df_ratio(joined, f"{ERR}D{col}RE", f"D{col}"))
+            + np.square( joined.loc[:, f"D{col}IM"].to_numpy() * df_ratio(joined, f"{ERR}D{col}IM", f"D{col}"))
+        )
+
+    return pd.merge(
+        measure_input.accelerator.model.loc[:, [S]],
+        joined.loc[:,[f"{pref}{col}{part}" for pref in ("", ERR) for col in ("F1001", "F1010") for part in ("", "RE", "IM")]],
+        how="inner",
+        left_index=True,
+        right_index=True,
+    )

--- a/omc3/optics_measurements/chromatic.py
+++ b/omc3/optics_measurements/chromatic.py
@@ -84,7 +84,23 @@ def calculate_w_and_phi(
     return output_df
 
 
-def calculate_chromatic_coupling(couplings, dpps, input_files, measure_input):
+def calculate_chromatic_coupling(
+    couplings: Sequence[pd.DataFrame],
+    dpps: Sequence[float],
+    input_files: InputFiles,
+    measure_input: DotDict,
+) -> pd.DataFrame:
+    """Calculates chromatic coupling from coupling data at different dp/p values.
+
+    Args:
+        couplings: Sequence of coupling DataFrames, one per dp/p value.
+        dpps: Sequence of corresponding dp/p values.
+        input_files: `InputFiles` object containing measurement data.
+        measure_input: `OpticsInput` object containing analysis settings.
+
+    Returns:
+        A `DataFrame` with chromatic coupling amplitudes and components.
+    """
     # TODO how to treat the model values?
     columns = [f"{pref}{col}{part}" for pref in ("", ERR) for col in ("F1001", "F1010") for part in ("RE", "IM")]
     joined = couplings[0].loc[:, columns]

--- a/omc3/optics_measurements/chromatic.py
+++ b/omc3/optics_measurements/chromatic.py
@@ -7,14 +7,42 @@ It provides functions to compute various chromatic beam properties.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 
 from omc3.optics_measurements.constants import DELTA, ERR, MDL, PHASE_ADV, S
 from omc3.optics_measurements.toolbox import df_prod, df_ratio
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
-def calculate_w_and_phi(betas, dpps, input_files, measure_input, plane):
+    from generic_parser import DotDict
+
+    from omc3.optics_measurements.data_models import InputFiles
+
+
+def calculate_w_and_phi(
+    betas: Sequence[pd.DataFrame],
+    dpps: Sequence[float],
+    input_files: InputFiles,
+    measure_input: DotDict,
+    plane: str,
+) -> pd.DataFrame:
+    """
+    Calculates chromatic amplitude function W and its phase Phi.
+
+    Args:
+        betas: Sequence of beta DataFrames, one per dp/p value.
+        dpps: Sequence of corresponding dp/p values.
+        input_files: `InputFiles` object containing measurement data.
+        measure_input: `OpticsInput` object containing analysis settings.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A `DataFrame` with measured and model W and Phi columns.
+    """
     columns = [f"{pref}{DELTA}{col}{plane}" for pref in ("", ERR) for col in ("BET", "ALF")]
     joined = betas[0].loc[:, columns]
     for i, beta in enumerate(betas[1:]):

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -64,20 +64,22 @@ def calculate_coupling(
     meas_input: DotDict,
     input_files: InputFiles,
     phase_results: dict[str, tuple[PhaseDict, Sequence[tfs.TfsDataFrame]]],
-    tune_dict: dict[str, float],
+    tune_dict: dict[str, dict[str, float]],
     header_dict: dict,
 ) -> None:
     """
-    Calculates the coupling RDTs f1001 and f1010, as well as the closest tune approach Cminus (|C-|).
-    This represents the "2 BPM method" in https://cds.cern.ch/record/1264111/files/CERN-BE-Note-2010-016.pdf
-    (a more up-to-date reference will come in the near future).
+    Calculates the coupling RDTs f1001 and f1010, as well as the closest tune approach
+    Cminus (|C-|). This represents the "2 BPM method" in
+    https://cds.cern.ch/record/1264111/files/CERN-BE-Note-2010-016.pdf.
 
     Two formulae are used to calculate the Cminus, taken from the following reference:
     https://cds.cern.ch/record/2135848/files/PhysRevSTAB.17.051004.pdf
-    The first one (Eq(1)) is an approximation using only the amplitudes of the RDTs, while the second one
-    (Eq(2) in the same paper) is more exact but needs also the phase of the RDT.
+    The first one (Eq(1)) is an approximation using only the amplitudes of the RDTs,
+    while the second one (Eq(2) in the same paper) is more exact but needs also the
+    phase of the RDT.
 
-    The results are written down in the optics_measurements outputs as **f1001.tfs** and **f1010.tfs** files.
+    The results are written down in the optics_measurements outputs as
+    **f1001.tfs** and **f1010.tfs** files.
 
     Args:
         meas_input (dict): `OpticsInput` object containing analysis settings from the command-line.

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -225,13 +225,18 @@ def compensate_rdts_by_model(
     return f1001, f1010
 
 
-def compensate_rdts_ryoichi():
-    pass
+def compensate_rdts_ryoichi() -> None:
+    """
+    Placeholder for Ryoichi's RDT compensation method (not yet implemented).
+    See https://github.com/pylhc/omc3/issues/295 for details and refs.
+    """
+    raise NotImplementedError
 
 
 # ----- Helpers ----- #
 
-def _find_pair(phases: tfs.TfsDataFrame, mode: int = 1):
+
+def _find_pair(phases: tfs.TfsDataFrame, mode: int = 1) -> tuple[np.ndarray, np.ndarray]:
     """
     Does the BPM pairing for coupling calculation.
 
@@ -245,7 +250,7 @@ def _find_pair(phases: tfs.TfsDataFrame, mode: int = 1):
     return _take_next(phases, mode)
 
 
-def _take_next(phases: tfs.TfsDataFrame, shift: int = 1):
+def _take_next(phases: tfs.TfsDataFrame, shift: int = 1) -> tuple[np.ndarray, np.ndarray]:
     """
     Takes the following BPM for momentum reconstruction by a given shift.
 

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -89,8 +89,9 @@ def calculate_coupling(
             the measured phase advances, with an entry for each transverse plane. In said entry is a
             dictionary with the measured phase advances for 'free' and 'uncompensated' cases, as well as
             the location of the output ``TfsDataFrames`` for the phases.
-        tune_dict (dict[str, float]): `TuneDict` object containing measured tunes. There is an entry
-            calculated for the 'Q', 'QF', 'QM', 'QFM' and 'ac2bpm' modes, each value being a float.
+        tune_dict (dict[str, dict[str, float]]): `TuneDict` object containing measured and model tunes.
+            For each plane, there is an entry calculated for the 'Q', 'QF', 'QM', 'QFM' and 'ac2bpm'
+            modes, each value being a float.
         header_dict (dict): header dictionary of common items for coupling output files,
             will be attached as the header to the **f1001.tfs** and **f1010.tfs** files..
     """

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -185,18 +185,19 @@ def calculate_coupling(
 
 
 def compensate_rdts_by_model(
-    f1001: np.ndarray, f1010: np.ndarray, tune_dict: dict[str, float]
+    f1001: np.ndarray, f1010: np.ndarray, tune_dict: dict[str, dict[str, float]]
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Compensate coupling RDTs by model (equation) only, implies we're providing a driven model (ACD / ATD
-    kick). The scaling factors are calculated from the model's free and driven tunes, and the scaled RDTs
-    are returned.
+    Compensate coupling RDTs by model (factor) only, which implies we're providing
+    a driven model (ACD / ATD kick). The scaling factors are calculated from the model's
+    free and driven tunes, and the scaled RDTs are returned.
 
     Args:
-        f1001 (np.ndarray): the pre-calculated driven coupling RDTs as an array.
-        f1010 (np.ndarray): the pre-calculated driven coupling RDTs as an array.
-        tune_dict (dict[str, float]): `TuneDict` object containing measured tunes. There is an entry
-            calculated for the 'Q', 'QF', 'QM', 'QFM' and 'ac2bpm' modes, each value being a float.
+        f1001 (np.ndarray): the pre-calculated driven coupling RDTs as a numpy array.
+        f1010 (np.ndarray): the pre-calculated driven coupling RDTs as a numpy array.
+        tune_dict (dict[str, dict[str, float]]): `TuneDict` object containing measured and model tunes.
+            For each plane, there is an entry calculated for the 'Q', 'QF', 'QM', 'QFM' and 'ac2bpm'
+            modes, each value being a float.
 
     Returns:
         The scaled RDTs.

--- a/omc3/optics_measurements/coupling.py
+++ b/omc3/optics_measurements/coupling.py
@@ -117,14 +117,14 @@ def calculate_coupling(
 
     LOGGER.debug("Averaging (arithmetic mean) amplitude columns")
     for col in [SECONDARY_AMPLITUDE_X, SECONDARY_AMPLITUDE_Y]:
-        arithmetically_averaved_columns = [c for c in joined.columns if c.startswith(col)]
-        joined[col] = stats.weighted_mean(joined[arithmetically_averaved_columns], axis=1)
+        arithmetically_averaged_columns = [c for c in joined.columns if c.startswith(col)]
+        joined[col] = stats.weighted_mean(joined[arithmetically_averaged_columns], axis=1)
 
     LOGGER.debug("Averaging (circular mean) frequency columns")  # make sure to use period=1 here
     for col in [SECONDARY_FREQUENCY_X, SECONDARY_FREQUENCY_Y]:
-        circularly_averaved_columns = [x for x in joined.columns if x.startswith(col)]
+        arithmetically_averaged_columns = [x for x in joined.columns if x.startswith(col)]
         joined[col] = bd * stats.circular_mean(
-            joined[circularly_averaved_columns], axis=1, period=1
+            joined[arithmetically_averaged_columns], axis=1, period=1
         )
 
     LOGGER.debug("Finding BPM pairs for momentum reconstruction")

--- a/omc3/optics_measurements/crdt.py
+++ b/omc3/optics_measurements/crdt.py
@@ -162,9 +162,9 @@ def calculate(
 
 
 def generic_dataframe(
-    input_files: InputFiles, measure_input: DotDict, bpm_names: Sequence[str], dpp_value: int = 0
-):
-    """Generate a dataframe based on the MU-MDL columns from each measuement."""
+    input_files: InputFiles, measure_input: DotDict, bpm_names: Sequence[str], dpp_value: float = 0,
+) -> pd.DataFrame:
+    """Generate a dataframe based on the MU-MDL columns from each measurement."""
     result_df = pd.DataFrame(measure_input.accelerator.model).loc[bpm_names, [COL_S, "MUX", "MUY"]]
     result_df.rename(
         columns={f"{COL_MU}X": f"{COL_MU}X{MDL}", f"{COL_MU}Y": f"{COL_MU}Y{MDL}"}, inplace=True
@@ -180,7 +180,8 @@ def generic_dataframe(
     return result_df
 
 
-def add_line_and_freq_to_header(header, crdt):
+def add_line_and_freq_to_header(header: dict[str, Any], crdt: dict) -> dict[str, Any]:
+    """Adds spectral line and frequency information to the output header."""
     mod_header = header.copy()
     mod_header["LINE"] = f"{crdt['plane']}({crdt['line'][0]}, {crdt['line'][1]})"
     freq = np.mod(crdt["line"] @ np.array([header["Q1"], header["Q2"]]), 1)
@@ -188,13 +189,14 @@ def add_line_and_freq_to_header(header, crdt):
     return mod_header
 
 
-def write_to_crdt_folder(df, header, meas_input, order, crdt):
+def write_to_crdt_folder(df: pd.DataFrame, header: dict[str, Any], meas_input: DotDict, order: str, crdt: str) -> None:
     outputdir = Path(meas_input.outputdir) / CRDT_FOLDER / order
     iotools.create_dirs(outputdir)
     tfs.write(str(outputdir / f"{crdt}{EXT}"), df, header, save_index=NAME)
 
 
-def get_column_names(line):
+def get_column_names(line: str) -> dict[str, str]:
+    """Returns the mapping of CRDT column identifiers to their suffixed column names."""
     return dict(
         zip(
             CRDT_COLUMNS,
@@ -207,7 +209,8 @@ def get_column_names(line):
     )
 
 
-def get_crdt_invariant(crdt, invariants):
+def get_crdt_invariant(crdt: dict, invariants: dict[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+    """Computes the combined invariant and its error for the given CRDT from per-plane invariants."""
     exp = {"X": np.abs(crdt["line"][0]), "Y": np.abs(crdt["line"][1])}
     # compensate for the normalization with tune line
     exp[crdt["plane"]] = (exp[crdt["plane"]] - 1)
@@ -220,7 +223,10 @@ def get_crdt_invariant(crdt, invariants):
     return crdt_invariant, err_crdt_invariant
 
 
-def get_crdt_amplitude(crdt, invariants, line_amps, line_amp_errors):
+def get_crdt_amplitude(
+    crdt: dict, invariants: dict[str, np.ndarray], line_amps: np.ndarray, line_amp_errors: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fits CRDT amplitudes per BPM from spectral line amplitudes and invariants."""
     crdt_invariants, err_crdt_invariants = get_crdt_invariant(crdt, invariants)
     amps, err_amps = np.zeros(line_amps.shape[0]), np.zeros(line_amps.shape[0])
 
@@ -232,7 +238,12 @@ def get_crdt_amplitude(crdt, invariants, line_amps, line_amp_errors):
     return amps, err_amps
 
 
-def fit_amplitude(lineamplitudes, err_lineamplitudes, crdt_invariant, err_crdt_invariant):
+def fit_amplitude(
+    lineamplitudes: np.ndarray,
+    err_lineamplitudes: np.ndarray,
+    crdt_invariant: np.ndarray,
+    err_crdt_invariant: np.ndarray,
+) -> tuple[float, float]:
     """
     Was translated from using scipy.odr to using odrpack as they recommended.
     See https://docs.scipy.org/doc/scipy/reference/odr.html for explanations.

--- a/omc3/optics_measurements/crdt.py
+++ b/omc3/optics_measurements/crdt.py
@@ -76,8 +76,23 @@ def calculate(
     input_files: InputFiles,
     invariants: dict[str, tfs.TfsDataFrame],
     header: dict[str, Any],
-):
-    """Calculate the CRDT values."""
+) -> None:
+    """Calculates Combined Resonance Driving Terms and writes results to file.
+
+    Iterates over all defined CRDTs (see module-level ``CRDTS`` list), computing
+    amplitudes via ODR fits to the invariants and phases via circular averaging
+    of the spectral lines. Results are written into per-order subfolders of the
+    CRDT output directory.
+
+    The derivation follows https://arxiv.org/pdf/1402.1461.pdf.
+
+    Args:
+        measure_input: `OpticsInput` object containing analysis settings.
+        input_files: `InputFiles` object containing frequency spectra files (linx/y).
+        invariants: dictionary mapping planes to DataFrames of actions and errors
+            per kick, e.g. from :func:`omc3.optics_measurements.kick.calculate`.
+        header: headers to include in the written result files.
+    """
     LOGGER.info("Start of CRDT analysis")
 
     dpp_value = measure_input.analyse_dpp

--- a/omc3/optics_measurements/data_models.py
+++ b/omc3/optics_measurements/data_models.py
@@ -104,7 +104,16 @@ class InputFiles(dict):
         """
         return np.array([df.DPP for df in self[plane]])
 
-    def dpp_frames(self, plane: str, dpp_value: float | None):
+    def dpp_frames(self, plane: str, dpp_value: float | None) -> list[tfs.TfsDataFrame]:
+        """Returns the list of DataFrames matching the given ``dpp_value`` for the given plane.
+
+        Args:
+            plane: marking the horizontal or vertical plane, **X** or **Y**.
+            dpp_value: the dp/p value to filter for. If ``None``, all frames are returned.
+
+        Returns:
+            A list of `TfsDataFrame` objects.
+        """
         if dpp_value is None:
             return self._all_frames(plane)
 
@@ -113,14 +122,14 @@ class InputFiles(dict):
             raise ValueError(f"No data found for dp/p {dpp_value} in plane {plane}")
         return dpp_dfs
 
-    def dpp_frames_indices(self, plane: str, dpp_value: float | None):
+    def dpp_frames_indices(self, plane: str, dpp_value: float | None) -> np.ndarray | list[int]:
         """ Return the indices of the frames that match the dpp. """
         if dpp_value is None:
             return list(range(len(self[plane])))
 
         return np.argwhere(np.abs(self.dpps(plane) - dpp_value) < dpp.DPP_TOLERANCE).T[0]
 
-    def _all_frames(self, plane: str):
+    def _all_frames(self, plane: str) -> list[tfs.TfsDataFrame]:
         return self[plane]
 
     def joined_frame(self,
@@ -183,7 +192,16 @@ class InputFiles(dict):
             joined_frame = joined_frame.astype(dtype)
         return joined_frame
 
-    def bpms(self, plane=None, dpp_value=None):
+    def bpms(self, plane: str | None = None, dpp_value: float | None = None) -> pd.Index:
+        """Returns the intersection of BPM indices across all input files for the given plane and dpp.
+
+        Args:
+            plane: **X** or **Y**. If ``None``, returns intersection of both planes.
+            dpp_value: filter for given dp/p value. If ``None``, uses all frames.
+
+        Returns:
+            A `pd.Index` of common BPM names.
+        """
         if plane is None:
             return self.bpms(plane="X", dpp_value=dpp_value).intersection(self.bpms(plane="Y", dpp_value=dpp_value))
         indices = [df.index for df in (self.dpp_frames(plane, dpp_value) if dpp_value is not None else self._all_frames(plane))]
@@ -221,8 +239,8 @@ class InputFiles(dict):
                         ((self[plane][i][f"{AMPLITUDE}{plane}"] * data.loc[:, ERR_CALIBRATION]).fillna(bpm_resolution))**2
                     )
 
-    @ staticmethod
-    def get_columns(frame, column):
+    @staticmethod
+    def get_columns(frame: pd.DataFrame, column: str) -> list[str]:
         """
         Returns list of columns of frame corresponding to column in original files.
 
@@ -238,8 +256,8 @@ class InputFiles(dict):
         new_list.sort(key=int)
         return [f"{column}__{x}" for x in new_list]
 
-    @ staticmethod
-    def get_data(frame, column) -> np.ndarray:
+    @staticmethod
+    def get_data(frame: pd.DataFrame, column: str) -> np.ndarray:
         """
         Returns data in columns of frame corresponding to column in original files.
 
@@ -248,7 +266,7 @@ class InputFiles(dict):
             column: name of column in original files.
 
         Returns:
-            A `np.narray` corresponding to column in original files.
+            A `np.ndarray` corresponding to column in original files.
         """
         columns = InputFiles.get_columns(frame, column)
         return frame.loc[:, columns].to_numpy(dtype=np.float64)
@@ -256,7 +274,7 @@ class InputFiles(dict):
 
 # DPP Filtering related functions ------------------------------------------------------------------
 
-def check_and_warn_about_offmomentum_data(input_files: InputFiles, plane: str, id_: str = None):
+def check_and_warn_about_offmomentum_data(input_files: InputFiles, plane: str, id_: str | None = None):
     """ A helper function to check if off-momentum data is present in the input files,
     but no dpp-value is given by the user.
 
@@ -286,6 +304,6 @@ def check_and_warn_about_offmomentum_data(input_files: InputFiles, plane: str, i
     LOGGER.warning(msg)
 
 
-def filter_for_dpp(to_filter: dict[str, Sequence], input_files: InputFiles, dpp_value: float):
+def filter_for_dpp(to_filter: dict[str, Sequence], input_files: InputFiles, dpp_value: float) -> dict:
     """ Filter the given data for the given dpp-value. """
     return {plane: values[input_files.dpp_frames_indices(plane, dpp_value)] for plane, values in to_filter.items()}

--- a/omc3/optics_measurements/dispersion.py
+++ b/omc3/optics_measurements/dispersion.py
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def calculate_orbit(meas_input: DotDict, input_files: InputFiles, header: dict, plane):
+def calculate_orbit(meas_input: DotDict, input_files: InputFiles, header: dict, plane: str) -> tfs.TfsDataFrame:
     """
-    Calculates orbit.
+    Calculates orbit data from measurements.
 
     Args:
         meas_input: `OpticsInput` object
@@ -62,9 +62,11 @@ def calculate_orbit(meas_input: DotDict, input_files: InputFiles, header: dict, 
     return output_df
 
 
-def calculate_dispersion(meas_input: DotDict, input_files: InputFiles, header_dict: dict, plane: str):
+def calculate_dispersion(
+    meas_input: DotDict, input_files: InputFiles, header_dict: dict, plane: str,
+) -> pd.DataFrame | None:
     """
-    Calculates dispersion.
+    Calculates dispersion data from measurements.
 
     Args:
         meas_input: `OpticsInput` object.
@@ -73,16 +75,18 @@ def calculate_dispersion(meas_input: DotDict, input_files: InputFiles, header_di
         plane: marking the horizontal or vertical plane, **X** or **Y**.
 
     Returns:
-        `TfsDataFrame` corresponding to output file.
+        `TfsDataFrame` corresponding to output file, or ``None`` if only a single dp/p bin is present.
     """
     if meas_input.three_d_excitation:
         return _calculate_dispersion_3d(meas_input, input_files, header_dict, plane)
     return _calculate_dispersion_2d(meas_input, input_files, header_dict, plane)
 
 
-def calculate_normalised_dispersion(meas_input: DotDict, input_files: InputFiles, beta, header_dict: dict):
+def calculate_normalised_dispersion(
+    meas_input: DotDict, input_files: InputFiles, beta: pd.DataFrame, header_dict: dict,
+) -> pd.DataFrame | None:
     """
-    Calculates normalised dispersion.
+    Calculates normalised dispersion data from measurements.
 
     Args:
         meas_input: `OpticsInput` object.

--- a/omc3/optics_measurements/dispersion.py
+++ b/omc3/optics_measurements/dispersion.py
@@ -95,14 +95,14 @@ def calculate_normalised_dispersion(
         header_dict: `dict` containing information about the analysis.
 
     Returns:
-        `TfsDataFrame` corresponding to output file.
+        `TfsDataFrame` corresponding to output file, or ``None`` if only a single dp/p bin is present.
     """
     if meas_input.three_d_excitation:
         return _calculate_normalised_dispersion_3d(meas_input, input_files, beta, header_dict)
     return _calculate_normalised_dispersion_2d(meas_input, input_files, beta, header_dict)
 
 
-def _calculate_dispersion_2d(meas_input: DotDict, input_files: InputFiles, header, plane):
+def _calculate_dispersion_2d(meas_input: DotDict, input_files: InputFiles, header: dict, plane: str) -> pd.DataFrame | None:
     dpps = input_files.dpps(plane)
     if _is_single_dpp_bin(dpps):
         return None
@@ -128,7 +128,7 @@ def _calculate_dispersion_2d(meas_input: DotDict, input_files: InputFiles, heade
     return output_df
 
 
-def _calculate_dispersion_3d(meas_input: DotDict, input_files: InputFiles, header_dict: dict, plane):
+def _calculate_dispersion_3d(meas_input: DotDict, input_files: InputFiles, header_dict: dict, plane: str) -> pd.DataFrame:
     """Computes dispersion from 3D kicks."""
     output, accelerator = meas_input.outputdir, meas_input.accelerator
     model = accelerator.model
@@ -148,7 +148,7 @@ def _calculate_dispersion_3d(meas_input: DotDict, input_files: InputFiles, heade
     return output_df
 
 
-def _calculate_normalised_dispersion_2d(meas_input: DotDict, input_files: InputFiles, beta, header):
+def _calculate_normalised_dispersion_2d(meas_input: DotDict, input_files: InputFiles, beta: pd.DataFrame, header: dict) -> pd.DataFrame | None:
     # TODO there are no errors from orbit
     plane = "X"
 
@@ -187,7 +187,7 @@ def _calculate_normalised_dispersion_2d(meas_input: DotDict, input_files: InputF
     return output_df
 
 
-def _calculate_normalised_dispersion_3d(meas_input: DotDict, input_files: InputFiles, beta, header):
+def _calculate_normalised_dispersion_3d(meas_input: DotDict, input_files: InputFiles, beta: pd.DataFrame, header: dict) -> pd.DataFrame:
     """
     Computes horizontal normalised dispersion from 3D kicks, and performs model-based
     compensation, i.e. as in _free2 files.
@@ -214,7 +214,7 @@ def _calculate_normalised_dispersion_3d(meas_input: DotDict, input_files: InputF
     return output_df
 
 
-def _calculate_dp(model, disp, plane):
+def _calculate_dp(model: pd.DataFrame, disp: pd.DataFrame, plane: str) -> pd.Series:
     _m = "meas"
     df = pd.DataFrame(model).loc[:, ['S', f"MU{plane}", f"DP{plane}", f"D{plane}",
                                      f"BET{plane}", f"ALF{plane}"]]
@@ -231,7 +231,7 @@ def _calculate_dp(model, disp, plane):
     return (-m13 + df.loc[shifted, f"D{plane}{_m}"] - m11 * df.loc[:, f"D{plane}{_m}"]) / m12
 
 
-def _get_merged_df(meas_input, input_files, plane, meas_columns):
+def _get_merged_df(meas_input: DotDict, input_files: InputFiles, plane: str, meas_columns: list[str]) -> pd.DataFrame:
     model = meas_input.accelerator.model
     df = pd.DataFrame(model).reindex(columns=[S, plane, f"D{plane}", f"DP{plane}", f"MU{plane}",
                                               f"BET{plane}", f"DD{plane}"], fill_value=np.nan)
@@ -244,7 +244,7 @@ def _get_merged_df(meas_input, input_files, plane, meas_columns):
     return df
 
 
-def _get_signed_dispersion(input_files, df_orbit, scaled_amps, mask):
+def _get_signed_dispersion(input_files: InputFiles, df_orbit: pd.DataFrame, scaled_amps: np.ndarray, mask: np.ndarray) -> tuple[np.ndarray, np.ndarray | float]:
     same_interval_phase = np.angle(np.exp(PI2I * df_orbit.loc[:, input_files.get_columns(df_orbit, 'MUZ')].to_numpy())) / (2 * np.pi)
     phase_wrt_arcs = same_interval_phase - stats.circular_mean(same_interval_phase[mask, :], period=1, axis=0)
     phase_wrt_arcs = np.abs(np.where(np.abs(phase_wrt_arcs) > 0.5, phase_wrt_arcs - np.sign(phase_wrt_arcs), phase_wrt_arcs))
@@ -257,7 +257,7 @@ def _get_signed_dispersion(input_files, df_orbit, scaled_amps, mask):
     return scaled_amps * np.sign(0.25 - np.abs(phase_wrt_arcs)), 0.0
 
 
-def _get_output_columns(plane, df):
+def _get_output_columns(plane: str, df: pd.DataFrame) -> list[str]:
     cols = ([S, "COUNT", f"MU{plane}MDL"] +           # common columns
             _single_column_set_list(plane) +            # orbit columns
             _single_column_set_list(f"ND{plane}") +     # normalized dispersion columns
@@ -268,18 +268,18 @@ def _get_output_columns(plane, df):
     return [col for col in cols if col in df.columns]
 
 
-def _single_column_set_list(base_name):
+def _single_column_set_list(base_name: str) -> list[str]:
     return [f"{base_name}", f"{ERR}{base_name}", f"{DELTA}{base_name}", f"{ERR}{DELTA}{base_name}", f"{base_name}{MDL}"]
 
 
-def _calculate_from_norm_disp(df, model, plane):
+def _calculate_from_norm_disp(df: pd.DataFrame, model: pd.DataFrame, plane: str) -> pd.DataFrame:
     df[f"D{plane}"] = df.loc[:, f"ND{plane}"] * np.sqrt(df.loc[:, f"BET{plane}"])
     df[f"{ERR}D{plane}"] = df.loc[:, f"{ERR}ND{plane}"] * np.sqrt(df.loc[:, f"BET{plane}"])
     df[f"DP{plane}"] = _calculate_dp(model, df.loc[:, [f"D{plane}", f"{ERR}D{plane}"]], plane)
     return _get_delta_columns(df, plane)
 
 
-def _get_delta_columns(df, plane):
+def _get_delta_columns(df: pd.DataFrame, plane: str) -> pd.DataFrame:
     for col in [f"{plane}", f"D{plane}", f"ND{plane}", f"D2{plane}", f"ND2{plane}"]:
         if col in df.columns:
             df[f"{DELTA}{col}"] = df.loc[:, col] - df.loc[:, f"{col}{MDL}"]

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -5,6 +5,7 @@ Dpp
 This module contains deltap over p calculations related functionality of ``optics_measurements``.
 It provides functions to computes and arrange dp over p.
 """
+
 from __future__ import annotations
 
 import logging
@@ -36,8 +37,10 @@ def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE) ->
     zero_offset = np.mean(_values_in_range(_find_range_with_element(ranges, closest_to_zero), dpps))
     LOGGER.debug(f"dp/p closest to zero is {dpps[closest_to_zero]}")
     if np.abs(zero_offset) > tolerance:
-        LOGGER.warning(f"Analysed files have large momentum deviation {zero_offset}. "
-                       f"Optics parameters might be wrong.")
+        LOGGER.warning(
+            f"Analysed files have large momentum deviation {zero_offset}. "
+            "Optics parameters might be wrong."
+        )
     LOGGER.debug(f"Detected dpp differences, aranging as: {ranges}, zero offset: {zero_offset}.")
     arranged_dpps = []
     for idx in range(len(dpps)):
@@ -55,12 +58,14 @@ def _find_range_with_element(ranges: list[list[int]], element: int) -> list[int]
 
 
 def _compute_ranges(dpps: Sequence[float], tolerance: float) -> list[list[int]]:
-    """ Groups the indices of dpps in bins of tolerance.
-    The function first sorts the indices by their dpp value
-    adds a new group whenever the dpp of the next index is larger than the first value in the group.
+    """
+    Groups the indices of dpps in bins of tolerance.
+    The function first sorts the indices by their dpp value,
+    adds a new group whenever the dpp of the next index is larger
+    than the first value in the group.
 
-    Works for now, but we could improve by using the mean dpp of the group to check against,
-    i.e. `abs(np.mean(dpps[ranges[-1]]) - dpps[idx]) < tolerance`.
+    Works for now, but we could improve by using the mean dpp of the group to
+    check against, i.e. `abs(np.mean(dpps[ranges[-1]]) - dpps[idx]) < tolerance`.
     Only neccessary if we have some weird outliers. (jdilly)
     """
     ordered_ids = np.argsort(dpps)
@@ -75,18 +80,24 @@ def _compute_ranges(dpps: Sequence[float], tolerance: float) -> list[list[int]]:
     return ranges
 
 
-def append_amp_dpp(list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]) -> Sequence[tfs.TfsDataFrame]:
+def append_amp_dpp(
+    list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]
+) -> Sequence[tfs.TfsDataFrame]:
     """
     Add the dpp values to the DPP-header of the tfs files, if larger than the DPP-tolerance,
     otherwise set to zero. This is intended to the DPP value for on-momentum files to zero.
     """
     for i, dpp in enumerate(dpp_values):
-        list_of_tfs[i].headers["DPPAMP"] = dpp if (not np.isnan(dpp) and np.abs(dpp) > DPP_TOLERANCE) else 0.0
+        list_of_tfs[i].headers["DPPAMP"] = (
+            dpp if (not np.isnan(dpp) and np.abs(dpp) > DPP_TOLERANCE) else 0.0
+        )
     return list_of_tfs
 
 
-def append_dpp(list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]) -> Sequence[tfs.TfsDataFrame]:
-    """ Add the dpp values to the DPP-header of the tfs dataframes."""
+def append_dpp(
+    list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]
+) -> Sequence[tfs.TfsDataFrame]:
+    """Add the dpp values to the DPP-header of the tfs dataframes."""
     for i, dpp in enumerate(dpp_values):
         list_of_tfs[i].headers["DPP"] = dpp
     return list_of_tfs
@@ -103,14 +114,19 @@ def calculate_dpoverp(input_files: InputFiles, meas_input: DotDict) -> float | n
     Returns:
         Scalar dp/p for a single file, or an array of dp/p values per file.
     """
-    df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ['S', 'DX']]
-    df_orbit = pd.merge(df_orbit, input_files.joined_frame('X', ['CO', 'CORMS']), how='inner',
-                        left_index=True, right_index=True)
+    df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ["S", "DX"]]
+    df_orbit = pd.merge(
+        df_orbit,
+        input_files.joined_frame("X", ["CO", "CORMS"]),
+        how="inner",
+        left_index=True,
+        right_index=True,
+    )
     mask = meas_input.accelerator.get_element_types_mask(df_orbit.index, ["arc_bpm"])
     df_filtered = df_orbit.loc[mask, :]
     dispersions = df_filtered.loc[:, "DX"].to_numpy()
-    denom = np.sum(dispersions ** 2)
-    if denom == 0.:
+    denom = np.sum(dispersions**2)
+    if denom == 0.0:
         raise ValueError("Cannot compute dpp probably no arc BPMs.")
     amps = input_files.get_data(df_filtered, "CO")
     if amps.ndim == 1:
@@ -131,19 +147,24 @@ def calculate_amp_dpoverp(input_files: InputFiles, meas_input: DotDict) -> float
     Returns:
         Scalar dp/p amplitude for a single file, or an array of values per file.
     """
-    df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ['S', 'DX']]
-    df_orbit = pd.merge(df_orbit, input_files.joined_frame('X', ['AMPX', 'AMPZ']), how='inner',
-                        left_index=True, right_index=True)
+    df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ["S", "DX"]]
+    df_orbit = pd.merge(
+        df_orbit,
+        input_files.joined_frame("X", ["AMPX", "AMPZ"]),
+        how="inner",
+        left_index=True,
+        right_index=True,
+    )
     # TODO often missing AMPZ causes FutureWarning in future will be KeyError
     if np.all(np.isnan(input_files.get_data(df_orbit, "AMPZ"))):
         return np.zeros(len(input_files["X"]))
     mask = meas_input.accelerator.get_element_types_mask(df_orbit.index, ["arc_bpm"])
     df_filtered = df_orbit.loc[mask, :]
-    amps = input_files.get_data(df_filtered, 'AMPX') * input_files.get_data(df_filtered, 'AMPZ')
+    amps = input_files.get_data(df_filtered, "AMPX") * input_files.get_data(df_filtered, "AMPZ")
     mask_zeros = (amps > 0) if amps.ndim == 1 else (np.sum(amps, axis=1) > 0)
     dispersions = df_filtered.loc[mask_zeros, "DX"].to_numpy()
-    denom = np.sum(dispersions ** 2)
-    if denom == 0.:
+    denom = np.sum(dispersions**2)
+    if denom == 0.0:
         raise ValueError("Cannot compute dpp probably no arc BPMs.")
     if amps.ndim == 1:
         numer = np.sum(dispersions * amps[mask_zeros])

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -86,7 +86,7 @@ def append_amp_dpp(
 ) -> Sequence[tfs.TfsDataFrame]:
     """
     Add the dpp values to the DPP-header of the tfs files, if larger than the DPP-tolerance,
-    otherwise set to zero. This is intended to the DPP value for on-momentum files to zero.
+    otherwise set to zero. This is intended to set the DPP value for on-momentum files to zero.
     """
     for i, dpp in enumerate(dpp_values):
         list_of_tfs[i].headers["DPPAMP"] = (

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from logging import Logger
 
     import tfs
     from generic_parser import DotDict
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 DPP_BIN_TOLERANCE: float = 1e-4
 DPP_TOLERANCE: float = 1e-5  # not sure if these should be different! (jdilly)
 
-LOGGER = logging.getLogger(__name__)
+LOGGER: Logger = logging.getLogger(__name__)
 
 
 def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE) -> np.ndarray:

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -32,11 +32,26 @@ LOGGER: Logger = logging.getLogger(__name__)
 def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE) -> np.ndarray:
     """
     Grouping of dpp-values and averaging them in the bins, also zeroes the bin closest to zero.
+
+    Args:
+        dpps: Sequence of dp/p values, one per analysed file.
+        tolerance: Maximum difference between dp/p values to be grouped
+            into the same bin.
+
+    Returns:
+        Array of arranged dp/p values, same length as *dpps*, where each
+        entry is the bin-averaged value with the zero-bin offset subtracted.
     """
     closest_to_zero = np.argmin(np.abs(dpps))
     ranges = _compute_ranges(dpps, tolerance)
     zero_offset = np.mean(_values_in_range(_find_range_with_element(ranges, closest_to_zero), dpps))
     LOGGER.debug(f"dp/p closest to zero is {dpps[closest_to_zero]}")
+
+    # We re-center the dp/p values so the bin closest to 0 becomes 0, but the 'zero_offset'
+    # is the actual mean dp/p of that "on-momentum" bin. Warning below is emitted when
+    # 'zero_offset' is large, which mean that even the "on-momentum" were taken with
+    # significant momentum deviation from the design closed orbit (aka when we do off-momentum
+    # measurements). Or it could be that the optics parameters are wrong.
     if np.abs(zero_offset) > tolerance:
         LOGGER.warning(
             f"Analysed files have large momentum deviation {zero_offset}. "

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -83,14 +83,24 @@ def append_amp_dpp(list_of_tfs: Sequence[tfs.TfsFile], dpp_values: Sequence[floa
     return list_of_tfs
 
 
-def append_dpp(list_of_tfs: Sequence[tfs.TfsFile], dpp_values: Sequence[float]):
+def append_dpp(list_of_tfs: Sequence[tfs.TfsFile], dpp_values: Sequence[float]) -> Sequence[tfs.TfsFile]:
     """ Add the dpp values to the DPP-header of the tfs files. """
     for i, dpp in enumerate(dpp_values):
         list_of_tfs[i].headers["DPP"] = dpp
     return list_of_tfs
 
 
-def calculate_dpoverp(input_files: InputFiles, meas_input: DotDict):
+def calculate_dpoverp(input_files: InputFiles, meas_input: DotDict) -> float | np.ndarray:
+    """
+    Calculates dp/p from closed orbit and model dispersion at arc BPMs.
+
+    Args:
+        input_files: `InputFiles` object containing measurement data.
+        meas_input: `OpticsInput` object containing analysis settings.
+
+    Returns:
+        Scalar dp/p for a single file, or an array of dp/p values per file.
+    """
     df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ['S', 'DX']]
     df_orbit = pd.merge(df_orbit, input_files.joined_frame('X', ['CO', 'CORMS']), how='inner',
                         left_index=True, right_index=True)
@@ -108,7 +118,17 @@ def calculate_dpoverp(input_files: InputFiles, meas_input: DotDict):
     return numer / denom
 
 
-def calculate_amp_dpoverp(input_files: InputFiles, meas_input: DotDict):
+def calculate_amp_dpoverp(input_files: InputFiles, meas_input: DotDict) -> float | np.ndarray:
+    """
+    Calculates dp/p amplitude from synchrotron sideband amplitudes and model dispersion.
+
+    Args:
+        input_files: `InputFiles` object containing measurement data.
+        meas_input: `OpticsInput` object containing analysis settings.
+
+    Returns:
+        Scalar dp/p amplitude for a single file, or an array of values per file.
+    """
     df_orbit = pd.DataFrame(meas_input.accelerator.model).loc[:, ['S', 'DX']]
     df_orbit = pd.merge(df_orbit, input_files.joined_frame('X', ['AMPX', 'AMPZ']), how='inner',
                         left_index=True, right_index=True)

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -27,7 +27,7 @@ DPP_TOLERANCE: float = 1e-5  # not sure if these should be different! (jdilly)
 LOGGER = logging.getLogger(__name__)
 
 
-def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE):
+def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE) -> np.ndarray:
     """
     Grouping of dpp-values and averaging them in the bins, also zeroes the bin closest to zero.
     """
@@ -46,11 +46,11 @@ def arrange_dpps(dpps: Sequence[float], tolerance: float = DPP_BIN_TOLERANCE):
     return np.array(arranged_dpps)
 
 
-def _values_in_range(range_to_use, dpp_values):
+def _values_in_range(range_to_use: list[int], dpp_values: Sequence[float]) -> list[float]:
     return [dpp_values[idx] for idx in range_to_use]
 
 
-def _find_range_with_element(ranges, element):
+def _find_range_with_element(ranges: list[list[int]], element: int) -> list[int]:
     return [dpp_range for dpp_range in ranges if element in dpp_range][0]
 
 
@@ -75,16 +75,18 @@ def _compute_ranges(dpps: Sequence[float], tolerance: float) -> list[list[int]]:
     return ranges
 
 
-def append_amp_dpp(list_of_tfs: Sequence[tfs.TfsFile], dpp_values: Sequence[float]):
-    """ Add the dpp values to the DPP-header of the tfs files, if larger than the DPP-tolerance, otherwise set to zero.
-    This is intended to the DPP value for on-momentum files to zero. """
+def append_amp_dpp(list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]) -> Sequence[tfs.TfsDataFrame]:
+    """
+    Add the dpp values to the DPP-header of the tfs files, if larger than the DPP-tolerance,
+    otherwise set to zero. This is intended to the DPP value for on-momentum files to zero.
+    """
     for i, dpp in enumerate(dpp_values):
         list_of_tfs[i].headers["DPPAMP"] = dpp if (not np.isnan(dpp) and np.abs(dpp) > DPP_TOLERANCE) else 0.0
     return list_of_tfs
 
 
-def append_dpp(list_of_tfs: Sequence[tfs.TfsFile], dpp_values: Sequence[float]) -> Sequence[tfs.TfsFile]:
-    """ Add the dpp values to the DPP-header of the tfs files. """
+def append_dpp(list_of_tfs: Sequence[tfs.TfsDataFrame], dpp_values: Sequence[float]) -> Sequence[tfs.TfsDataFrame]:
+    """ Add the dpp values to the DPP-header of the tfs dataframes."""
     for i, dpp in enumerate(dpp_values):
         list_of_tfs[i].headers["DPP"] = dpp
     return list_of_tfs

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -114,12 +114,34 @@ def identify_single_cluster_bad_bpms(
     return signif_feature
 
 
-def reassign_index(data):
+def reassign_index(data: pd.DataFrame) -> pd.DataFrame:
+    """Resets the index of the DataFrame to a sequential integer range."""
     data["NEW_INDEX"] = range(len(data.NAME))
     return data.set_index("NEW_INDEX")
 
 
-def get_significant_features(bpm_tfs_data, data_for_clustering, bad_bpms, good_bpms, plane):
+def get_significant_features(
+    bpm_tfs_data: pd.DataFrame,
+    data_for_clustering: pd.DataFrame,
+    bad_bpms: pd.DataFrame,
+    good_bpms: pd.DataFrame,
+    plane: str,
+) -> pd.DataFrame:
+    """Determines the most significant feature for each anomalous BPM.
+
+    For each bad BPM, finds the feature (tune, noise, or amplitude) with the
+    largest deviation from the mean of good BPMs.
+
+    Args:
+        bpm_tfs_data: concatenated BPM data from all input files.
+        data_for_clustering: normalized feature data used for clustering.
+        bad_bpms: DataFrame of BPMs flagged as anomalous.
+        good_bpms: DataFrame of BPMs considered normal.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A `DataFrame` indexed like ``bad_bpms`` with columns NAME, FEATURE, VALUE, and AVG.
+    """
     features_df = pd.DataFrame(index=bad_bpms.index)
     for index in bad_bpms.index:
         max_dist = max([(abs(data_for_clustering.loc[index, col] -
@@ -133,7 +155,19 @@ def get_significant_features(bpm_tfs_data, data_for_clustering, bad_bpms, good_b
     return features_df
 
 
-def detect_anomalies(contamination, data, plane):
+def detect_anomalies(
+    contamination: float, data: pd.DataFrame, plane: str,
+) -> tuple[pd.DataFrame, pd.DataFrame, np.ndarray]:
+    """Fits an isolation forest and separates data into anomalous and normal BPMs.
+
+    Args:
+        contamination: expected proportion of outliers in the data.
+        data: normalized BPM feature data.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A tuple of (bad_bpms, good_bpms, bad_bpms_scores).
+    """
     iforest = IsolationForest(n_estimators=100, max_samples='auto',
                               contamination=contamination, max_features=1.0,
                               bootstrap=False)

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -204,13 +204,28 @@ def get_data_for_clustering(
     return arc_bpm_data_for_clustering, ir_bpm_data_for_clustering
 
 
-def _normalize_parameter(column_data):
+def _normalize_parameter(column_data: pd.Series) -> pd.Series:
+    """Rescales a Series to the [0, 1] range via min-max normalization."""
     return (column_data - column_data.min()) / (column_data.max() - column_data.min())
 
 
-def remove_bad_bpms(tfs_dfs, bad_bpm_names, plane):
-    for i in range(len(tfs_dfs)):
-        tfs_dfs[i] = tfs_dfs[i].loc[~tfs_dfs[i].index.isin(bad_bpm_names)]
-        tfs_dfs[i].headers[f"Q{PLANE_TO_NUM[plane]}"] = np.mean(tfs_dfs[i][f"TUNE{plane}"])
-        tfs_dfs[i].headers[f"Q{PLANE_TO_NUM[plane]}RMS"] = np.std(tfs_dfs[i][f"TUNE{plane}"])
-    return tfs_dfs
+def remove_bad_bpms(
+    tfs_dfs: Sequence[tfs.TfsDataFrame], bad_bpm_names: list[str], plane: str,
+) -> list[tfs.TfsDataFrame]:
+    """Removes flagged BPMs from all input file DataFrames and recalculates tune statistics.
+
+    Args:
+        tfs_dfs: list of measurement DataFrames.
+        bad_bpm_names: names of BPMs to remove.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A list of the input TfsDataFrames with bad BPMs filtered out.
+    """
+    cleaned: list[tfs.TfsDataFrame] = []
+    for df in tfs_dfs:
+        filtered_df = df.loc[~df.index.isin(bad_bpm_names)]
+        filtered_df.headers[f"Q{PLANE_TO_NUM[plane]}"] = np.mean(filtered_df[f"TUNE{plane}"])
+        filtered_df.headers[f"Q{PLANE_TO_NUM[plane]}RMS"] = np.std(filtered_df[f"TUNE{plane}"])
+        cleaned.append(filtered_df)
+    return cleaned

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -63,15 +63,48 @@ def clean_with_isolation_forest(
     return input_files
 
 
-def identify_bad_bpms(meas_input, input_files, plane):
-    bpm_data = pd.concat([tfs_df[["NAME", f"TUNE{plane}", "NOISE_SCALED", f"AMP{plane}"]]
-                          for tfs_df in input_files])
+def identify_bad_bpms(
+    meas_input: DotDict,
+    input_files: Sequence[tfs.TfsDataFrame],
+    plane: str,
+) -> pd.DataFrame:
+    """
+    Identifies anomalous BPMs across arc and IR regions using isolation forest.
+
+    Args:
+        meas_input: `OpticsInput` object containing analysis settings.
+        input_files: list of measurement DataFrames.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A `DataFrame` listing the detected bad BPMs with their significant features and scores.
+    """
+    bpm_data = pd.concat(
+                            [tfs_df[["NAME", f"TUNE{plane}", "NOISE_SCALED", f"AMP{plane}"]]
+                            for tfs_df in input_files]
+                        )
     arc_bpm_data, ir_bpm_data = get_data_for_clustering(bpm_data, plane, meas_input.accelerator)
     return pd.concat([identify_single_cluster_bad_bpms(bpm_data, ARCS_CONT, arc_bpm_data, plane),
                       identify_single_cluster_bad_bpms(bpm_data, IRS_CONT, ir_bpm_data, plane)])
 
 
-def identify_single_cluster_bad_bpms(bpm_tfs_data, cont, data_for_clustering, plane):
+def identify_single_cluster_bad_bpms(
+    bpm_tfs_data: pd.DataFrame,
+    cont: float,
+    data_for_clustering: pd.DataFrame,
+    plane: str,
+) -> pd.DataFrame:
+    """Runs isolation forest on a single cluster and returns the significant features of detected anomalies.
+
+    Args:
+        bpm_tfs_data: concatenated BPM data from all input files.
+        cont: contamination parameter for the isolation forest.
+        data_for_clustering: normalized feature data for clustering.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A `DataFrame` with anomalous BPM names, their most significant feature, and anomaly scores.
+    """
     bad_bpms, good_bpms, bad_bpms_scores = detect_anomalies(cont, data_for_clustering, plane)
     bpm_tfs_data, data_for_clustering, bad_bpms, good_bpms = \
         [reassign_index(data) for data in (bpm_tfs_data, data_for_clustering, bad_bpms, good_bpms)]

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
     from generic_parser import DotDict
 
+    from omc3.model.accelerators.accelerator import Accelerator
+
 LOGGER: Logger = logging_tools.get_logger(__name__)
 ARCS_CONT = 0.01
 IRS_CONT = 0.025
@@ -180,7 +182,19 @@ def detect_anomalies(
     return bad_bpms, good_bpms, bad_bpms_scores
 
 
-def get_data_for_clustering(bpm_tfs_data, plane, accelerator):
+def get_data_for_clustering(
+    bpm_tfs_data: pd.DataFrame, plane: str, accelerator: Accelerator,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Splits BPM data into arc and IR subsets and normalizes features for clustering.
+
+    Args:
+        bpm_tfs_data: concatenated BPM data from all input files.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+        accelerator: accelerator instance providing the element types mask.
+
+    Returns:
+        A tuple of (arc_bpm_data, ir_bpm_data) with normalized features.
+    """
     arc_bpm_mask = accelerator.get_element_types_mask(bpm_tfs_data.NAME, types=["arc_bpm"])
     ir_bpm_data_for_clustering = bpm_tfs_data.iloc[~arc_bpm_mask].copy()
     arc_bpm_data_for_clustering = bpm_tfs_data.iloc[arc_bpm_mask].copy()

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -14,6 +14,7 @@ This should be tested and possibly mitigated. (jdilly, 2024)
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -23,7 +24,13 @@ from sklearn.ensemble import IsolationForest
 from omc3.definitions.constants import PLANE_TO_NUM
 from omc3.utils import logging_tools
 
-LOGGER = logging_tools.get_logger(__name__)
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from logging import Logger
+
+    from generic_parser import DotDict
+
+LOGGER: Logger = logging_tools.get_logger(__name__)
 ARCS_CONT = 0.01
 IRS_CONT = 0.025
 

--- a/omc3/optics_measurements/iforest.py
+++ b/omc3/optics_measurements/iforest.py
@@ -38,7 +38,23 @@ IRS_CONT = 0.025
 FEATURE: str = "FEATURE"
 
 
-def clean_with_isolation_forest(input_files, meas_input, plane):
+def clean_with_isolation_forest(
+    input_files: Sequence[tfs.TfsDataFrame], meas_input: DotDict, plane: str,
+) -> Sequence[tfs.TfsDataFrame]:
+    """
+    Runs isolation forest anomaly detection and removes flagged BPMs from input files.
+    For every file where a cleaning is performed, a TfsDataFrame with information on
+    the identified and cleaned BPMs is written to disk in an adjacent location in the
+    corresponding output dir.
+
+    Args:
+        input_files: list of measurement DataFrames.
+        meas_input: `OpticsInput` object containing analysis settings.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        The input files with anomalous BPMs removed.
+    """
     bad_bpms = identify_bad_bpms(meas_input, input_files, plane)
     input_files = remove_bad_bpms(input_files, list(set(bad_bpms.NAME)), plane)
     LOGGER.info(str(list(set(bad_bpms.NAME))))

--- a/omc3/optics_measurements/interaction_point.py
+++ b/omc3/optics_measurements/interaction_point.py
@@ -32,7 +32,7 @@ LOGGER = logging_tools.get_logger(__name__)
 COLUMNS = ("IP", "BETASTAR", "ERRBETASTAR", "PHASEADV", "ERRPHASEADV", "PHASEDVMDL", "LSTAR")
 
 
-def betastar_from_phase(meas_input: DotDict, phase_d: phase.PhaseDict) -> pd.DataFrame:
+def betastar_from_phase(meas_input: DotDict, phase_d: phase.PhaseDict) -> pd.DataFrame | None:
     """
     Calculate beta* and l* from the phase advance of the IP-BPMs.
 
@@ -64,7 +64,7 @@ def betastar_from_phase(meas_input: DotDict, phase_d: phase.PhaseDict) -> pd.Dat
     return pd.DataFrame(columns=COLUMNS, data=rows)
 
 
-def write(df_ips: pd.DataFrame, headers: dict[str, Any], output_dir: str|Path, plane: str):
+def write(df_ips: pd.DataFrame, headers: dict[str, Any], output_dir: str | Path, plane: str) -> None:
     """ Write the interaction point data to disk.
     Empty DataFrames are skipped on write.
 
@@ -100,16 +100,16 @@ def phase_to_betastar(lstar: float, phase: float, errphase: float) -> tuple[floa
     )
 
 
-def _phase_to_betastar_value(lstar, phase):
+def _phase_to_betastar_value(lstar: float, phase: float) -> float:
     tan_phase = np.tan(phase)
     return (lstar * (1 - np.sqrt(tan_phase ** 2 + 1))) / tan_phase
 
 
-def _phase_to_betastar_error(lstar: float, phase: float, errphase: float):
+def _phase_to_betastar_error(lstar: float, phase: float, errphase: float) -> float:
     return abs((errphase * lstar * (abs(np.cos(phase)) - 1)) / (np.sin(phase) ** 2))
 
 
-def _get_meas_phase(bpm_left, bpm_right, phases_df):
+def _get_meas_phase(bpm_left: str, bpm_right: str, phases_df: phase.PhaseDict) -> tuple[float, float, float]:
     return (
         phases_df[MEASUREMENT].loc[bpm_left, bpm_right],
         phases_df[f"{ERR}{MEASUREMENT}"].loc[bpm_left, bpm_right],
@@ -117,5 +117,5 @@ def _get_meas_phase(bpm_left, bpm_right, phases_df):
     )
 
 
-def _get_lstar(bpm_left, bpm_right, model):
+def _get_lstar(bpm_left: str, bpm_right: str, model: pd.DataFrame) -> float:
     return abs(model.loc[bpm_left, S] - model.loc[bpm_right, S]) / 2.

--- a/omc3/optics_measurements/interaction_point.py
+++ b/omc3/optics_measurements/interaction_point.py
@@ -42,7 +42,8 @@ def betastar_from_phase(meas_input: DotDict, phase_d: phase.PhaseDict) -> pd.Dat
 
     Returns:
         A DataFrame with the beta* and l* as well as the phases used for the calculation
-        as columns and the IP names as index.
+        as columns and the IP names as index. Can return `None` if the provided accelerator
+        class has no `.get_ips` method.
     """
     accel = meas_input.accelerator
     model = accel.model

--- a/omc3/optics_measurements/measure_optics.py
+++ b/omc3/optics_measurements/measure_optics.py
@@ -170,7 +170,18 @@ def _get_header(meas_input: DotDict, tune_dict: tune.TuneDict) -> dict[str, Any]
     }
 
 
-def copy_calibration_files(outputdir: str|Path, calibrationdir: str|Path):
+def copy_calibration_files(outputdir: str | Path, calibrationdir: str | Path | None) -> dict[str, tfs.TfsDataFrame] | None:
+    """
+    Copies calibration files from calibrationdir to outputdir,
+    then reads them and returns the data.
+
+    Args:
+        outputdir: path to the output directory.
+        calibrationdir: path to the calibration directory. If ``None``, returns ``None``.
+
+    Returns:
+        A dictionary mapping planes to calibration DataFrames, or ``None`` if no calibration directory is given.
+    """
     if calibrationdir is None:
         return None
     calibs = {}

--- a/omc3/optics_measurements/measure_optics.py
+++ b/omc3/optics_measurements/measure_optics.py
@@ -132,16 +132,14 @@ def measure_optics(input_files: InputFiles, measure_input: DotDict) -> None:
         chromatic_beating(input_files, measure_input, tune_dict)
 
 
-def chromatic_beating(input_files: InputFiles, measure_input: DotDict, tune_dict: tune.TuneDict):
+def chromatic_beating(input_files: InputFiles, measure_input: DotDict, tune_dict: tune.TuneDict) -> None:
     """
     Main function to compute chromatic optics beating.
 
     Args:
-        tune_dict:
         input_files: `InputFiles` object containing frequency spectra files (linx/y).
-        measure_input:` OpticsInput` object containing analysis settings.
-
-    Returns:
+        measure_input: `OpticsInput` object containing analysis settings.
+        tune_dict: `TuneDict` object containing measured tunes.
     """
     dpps = np.array(list(set(input_files.dpps("X"))))
     if np.max(dpps) - np.min(dpps) == 0.0:

--- a/omc3/optics_measurements/measure_optics.py
+++ b/omc3/optics_measurements/measure_optics.py
@@ -61,7 +61,6 @@ def measure_optics(input_files: InputFiles, measure_input: DotDict) -> None:
         input_files: `InputFiles` object containing frequency spectra files (linx/y).
         measure_input: `OpticsInput` object containing analysis settings.
 
-    Returns:
     """
     outputdir = Path(measure_input.outputdir)
     iotools.create_dirs(outputdir)

--- a/omc3/optics_measurements/phase.py
+++ b/omc3/optics_measurements/phase.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from omc3.optics_measurements.tune import TuneDict
 
 PhaseDict = TypedDict(
-    'PhaseDict', {
+    "PhaseDict", {
         MODEL: pd.DataFrame,
         MEASUREMENT: pd.DataFrame,
         f'{ERR}{MEASUREMENT}': pd.DataFrame
@@ -54,6 +54,7 @@ PhaseDict = TypedDict(
 LOGGER = logging_tools.get_logger(__name__)
 
 class CompensationMode:
+    """Available modes for AC-dipole driven motion compensation in phase advance calculations."""
     NONE: str = "none"
     MODEL: str = "model"
     EQUATION: str = "equation"
@@ -145,7 +146,7 @@ def _calculate_phase_advances(
     model_df: pd.DataFrame,
     compensation: str,
     no_errors: bool,
-) -> tuple[PhaseDict, list[pd.DataFrame, pd.DataFrame]]:
+) -> tuple[PhaseDict, list[pd.DataFrame]]:
     """
     Calculates phase advances.
 
@@ -325,13 +326,13 @@ def _create_output_df(phase_advances: PhaseDict, model: pd.DataFrame, plane: str
     return output_data
 
 
-def _get_all_phase_diff(phases_a: ArrayLike, phases_b: ArrayLike = None) -> ArrayLike:
+def _get_all_phase_diff(phases_a: ArrayLike, phases_b: ArrayLike | None = None) -> ArrayLike:
     if phases_b is None:
         phases_b = phases_a
     return (phases_a[np.newaxis, :] - phases_b[:, np.newaxis]) % 1.0
 
 
-def _get_square_data_frame(data, index) -> pd.DataFrame:
+def _get_square_data_frame(data: np.ndarray, index: pd.Index) -> pd.DataFrame:
     return pd.DataFrame(data=data, index=index, columns=index)
 
 

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -179,12 +179,12 @@ def _check_amp_error(rdt: RDTTuple):
         LOGGER.warning(f"{message}: {error_str}")
 
 
-def _rdt_to_str(rdt: RDTTuple):
+def _rdt_to_str(rdt: RDTTuple) -> str:
     j, k, l, m = rdt  # noqa: E741
     return f"{j}{k}{l}{m}"
 
 
-def _rdt_to_order_and_type(rdt: RDTTuple):
+def _rdt_to_order_and_type(rdt: RDTTuple) -> str:
     j, k, l, m = rdt  # noqa: E741
     rdt_type = "normal" if (l + m) % 2 == 0 else "skew"
     orders = {
@@ -234,17 +234,17 @@ def _best_90_degree_phases(meas_input, bpm_names, phases, tunes, plane):
     )
 
 
-def _get_n_upper_diagonals(n, shape):
+def _get_n_upper_diagonals(n: int, shape: tuple[int, int]) -> np.ndarray:
     return diags(np.ones((n, shape[0])), np.arange(n) + 1, shape=shape).toarray()
 
 
-def _determine_line(rdt: RDTTuple, plane: str) -> dict[str, LineTuple]:
+def _determine_line(rdt: RDTTuple, plane: str) -> LineTuple:
     j, k, l, m = rdt  # noqa: E741
     lines = {"X": (1 - j + k, m - l, 0), "Y": (k - j, 1 - l + m, 0)}
     return lines[plane]
 
 
-def add_freq_to_header(header: dict[str, Any], plane: str, rdt: RDTTuple):
+def add_freq_to_header(header: dict[str, Any], plane: str, rdt: RDTTuple) -> dict[str, Any]:
     mod_header = header.copy()
     line = _determine_line(rdt, plane)
     freq = np.mod(line @ np.array([header["Q1"], header["Q2"], 0]), 1)
@@ -299,8 +299,8 @@ def _process_rdt(
 
 
 def _add_tunes_if_in_second_turn(
-    df: pd.DataFrame, input_files: InputFiles, line, phase2, dpp_value
-):
+    df: pd.DataFrame, input_files: InputFiles, line: LineTuple, phase2: np.ndarray, dpp_value: float | None,
+) -> np.ndarray:
     # With pandas 3.x phase2 might be passed as a read-only view so we ensure
     # a copy is made here since we intend to mutate before returning
     phase2 = np.array(phase2, copy=True)
@@ -315,8 +315,8 @@ def _add_tunes_if_in_second_turn(
 
 
 def _calculate_rdt_phases_from_line_phases(
-    df: pd.DataFrame, input_files: InputFiles, line, line_phase, dpp_value
-):
+    df: pd.DataFrame, input_files: InputFiles, line: LineTuple, line_phase: np.ndarray, dpp_value: float | None,
+) -> np.ndarray:
     phases = np.zeros((2, df.index.size, len(input_files.dpp_frames("X", dpp_value))))
     for i, plane in enumerate(PLANES):
         if line[i] != 0:
@@ -329,7 +329,9 @@ def _calculate_rdt_phases_from_line_phases(
     return line_phase - line[0] * phases[0] - line[1] * phases[1] + 0.25
 
 
-def _fit_rdt_amplitudes(invariants, line_amp, plane, rdt):
+def _fit_rdt_amplitudes(
+    invariants: dict[str, pd.DataFrame], line_amp: np.ndarray, plane: str, rdt: RDTTuple,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Returns RDT amplitudes in units of meters ^ {1 - n/2}, where n is the order of RDT.
     """
@@ -362,7 +364,7 @@ def _fit_rdt_amplitudes(invariants, line_amp, plane, rdt):
     return amps, err_amps
 
 
-def get_linearized_problem(invs: dict[str, np.ndarray], plane: str, rdt: RDTTuple):
+def get_linearized_problem(invs: dict[str, np.ndarray], plane: str, rdt: RDTTuple) -> np.ndarray:
     """
     2 * j * f_jklm * (powers of 2Jx and 2Jy) : f_jklm is later a parameter of a fit
     we use sqrt(2J): unit is sqrt(m).
@@ -425,7 +427,7 @@ def complex_secondary_lines(
     return (np.abs(sig), (np.angle(sig) / tp) % 1, np.abs(esig), (np.angle(esig) / tp) % 1)
 
 
-def to_complex(amplitudes: ArrayLike, phases: ArrayLike, period: float = 1):
+def to_complex(amplitudes: ArrayLike, phases: ArrayLike, period: float = 1) -> np.ndarray:
     with suppress(AttributeError):
         amplitudes = amplitudes.to_numpy()
 

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -207,7 +207,8 @@ def _best_90_degree_phases(
     tunes: TuneDict,
     plane: str,
 ) -> pd.DataFrame:
-    """Finds BPM pairs with phase advance closest to 90 degrees for RDT measurement.
+    """
+    Finds BPM pairs with phase advance closest to 90 degrees for RDT measurement.
 
     Args:
         meas_input: `OpticsInput` object containing analysis settings.

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -274,8 +274,27 @@ def add_freq_to_header(header: dict[str, Any], plane: str, rdt: RDTTuple) -> dic
 
 
 def _process_rdt(
-    meas_input: DotDict, input_files: InputFiles, phase_data, invariants, plane, rdt: RDTTuple
-):
+    meas_input: DotDict,
+    input_files: InputFiles,
+    phase_data: pd.DataFrame,
+    invariants: dict[str, pd.DataFrame],
+    plane: str,
+    rdt: RDTTuple,
+) -> pd.DataFrame:
+    """
+    Computes amplitude and phase of a single RDT from spectral lines at BPM pairs.
+
+    Args:
+        meas_input: `OpticsInput` object containing analysis settings.
+        input_files: `InputFiles` object containing frequency spectra files (linx/y).
+        phase_data: BPM-pair data from :func:`_best_90_degree_phases`.
+        invariants: dictionary mapping planes to DataFrames of actions and errors per kick.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+        rdt: RDTTuple (j, k, l, m) identifying the RDT.
+
+    Returns:
+        A `DataFrame` with columns for amplitude, phase, real/imaginary parts and their errors.
+    """
     dpp_value = meas_input.analyse_dpp
 
     df = pd.DataFrame(phase_data)

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -436,12 +436,12 @@ def get_line_sign_and_suffix(
 
 
 def complex_secondary_lines(
-    phase_adv: ArrayLike[float],
-    err_padv: ArrayLike[float],
-    sig1: ArrayLike[complex],
-    sig2: ArrayLike[complex],
-):
-    """
+    phase_adv: ArrayLike,
+    err_padv: ArrayLike,
+    sig1: ArrayLike,
+    sig2: ArrayLike,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Extracts amplitude and phase of secondary spectral lines from BPM pairs.
 
     Args:
         phase_adv: phase advances between two BPMs.
@@ -450,7 +450,7 @@ def complex_secondary_lines(
         sig2: Complex coefficients of a secondary lines at the second BPM of the pairs.
 
     Returns:
-         `Tuple` with amplitudes, phases err_amplitudes and err_phases of the complex signal.
+         `Tuple` with amplitudes, phases, err_amplitudes and err_phases of the complex signal.
     """
     tp = 2.0 * np.pi
     # computing complex secondary line (h-) = x - ip_x. Why do we divide by 2? (jgray 2024)

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -226,9 +226,8 @@ def _best_90_degree_phases(
     if phase_dict is None:
         phase_dict = phases[plane][COMPENSATED]
 
-    bpm_names = phase_dict[MEASUREMENT].index.intersection(
-        bpm_names
-    )  # removes BPMs that are not in model
+    # Remove BPMs that are not in model
+    bpm_names = phase_dict[MEASUREMENT].index.intersection(bpm_names)
     filtered = phase_dict[MEASUREMENT].loc[bpm_names, bpm_names]
 
     # fmt: off

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -200,7 +200,27 @@ def _rdt_to_order_and_type(rdt: RDTTuple) -> str:
     return f"{rdt_type}_{orders[j + k + l + m]}"
 
 
-def _best_90_degree_phases(meas_input, bpm_names, phases, tunes, plane):
+def _best_90_degree_phases(
+    meas_input: DotDict,
+    bpm_names: pd.Index,
+    phases: dict[str, dict[str, PhaseDict]],
+    tunes: TuneDict,
+    plane: str,
+) -> pd.DataFrame:
+    """Finds BPM pairs with phase advance closest to 90 degrees for RDT measurement.
+
+    Args:
+        meas_input: `OpticsInput` object containing analysis settings.
+        bpm_names: index of BPM names to consider.
+        phases: nested dictionary of phase advance data, keyed by plane and
+            compensation mode.
+        tunes: `TuneDict` with tune values per plane.
+        plane: marking the horizontal or vertical plane, **X** or **Y**.
+
+    Returns:
+        A `DataFrame` indexed by BPM name with columns for the partner BPM name,
+        measured phase advance to the partner, its error, and longitudinal position.
+    """
     phase_dict: PhaseDict = phases[plane][UNCOMPENSATED]
     if phase_dict is None:
         phase_dict = phases[plane][COMPENSATED]

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -102,7 +102,7 @@ def calculate(
     measure_input: DotDict,
     input_files: InputFiles,
     tunes: TuneDict,
-    phases: dict[str, PhaseDict],
+    phases: dict[str, dict[str, PhaseDict]],
     invariants: dict[str, pd.DataFrame],
     header: dict,
 ) -> None:
@@ -115,8 +115,8 @@ def calculate(
         input_files: `InputFiles` object containing frequency spectra files (linx/y).
         tunes: `TuneDict` object mapping planes to tunes, as given by
             :func:`omc3.optics_measurements.tune.calculate`.
-        phases:
-        invariants (dict[str, pd.DataFrame]): dictionnary mapping planes to dataframes
+        phases: dictionary mapping planes to `PhaseDict` for compensated and uncompensated cases.
+        invariants: dictionary mapping planes to dataframes
             of actions/errors per kick, e.g. from :func:`omc3.optics_measurements.kick.calculate`.
         header: headers to include to the written result files.
     """

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -155,7 +155,7 @@ def calculate(
                     write(df, add_freq_to_header(header, plane, rdt), meas_input, plane, rdt)
 
 
-def write(df: pd.DataFrame, header: dict[str, Any], meas_input: DotDict, plane: str, rdt: RDTTuple):
+def write(df: pd.DataFrame, header: dict[str, Any], meas_input: DotDict, plane: str, rdt: RDTTuple) -> None:
     outputdir = Path(meas_input.outputdir) / RDT_FOLDER / _rdt_to_order_and_type(rdt)
     iotools.create_dirs(outputdir)
     tfs.write(outputdir / f"f{_rdt_to_str(rdt)}_{plane.lower()}{EXT}", df, header, save_index=NAME)

--- a/omc3/optics_measurements/toolbox.py
+++ b/omc3/optics_measurements/toolbox.py
@@ -5,73 +5,97 @@ Toolbox
 This module contains helper functionality for ``optics_measurements``.
 It provides functions to perform regularly used simple calculations.
 """
+
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 
+if TYPE_CHECKING:
+    import pandas as pd
 
-def df_diff(df, a_col, b_col):
-    """ Returns a column containing the difference between a_col and b_col """
+
+def df_diff(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the difference between a_col and b_col"""
     return df.loc[:, a_col].to_numpy() - df.loc[:, b_col].to_numpy()
 
 
-def df_sum(df, a_col, b_col):
-    """ Returns a column containing the sum of a_col and b_col """
+def df_sum(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the sum of a_col and b_col"""
     return df.loc[:, a_col].to_numpy() + df.loc[:, b_col].to_numpy()
 
 
-def df_ratio(df, a_col, b_col):
-    """ Returns a column containing the ratio between a_col and b_col """
+def df_ratio(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the ratio between a_col and b_col"""
     return df.loc[:, a_col].to_numpy() / df.loc[:, b_col].to_numpy()
 
 
-def df_prod(df, a_col, b_col):
-    """ Returns a column containing the product of a_col and b_col """
+def df_prod(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the product of a_col and b_col"""
     return df.loc[:, a_col].to_numpy() * df.loc[:, b_col].to_numpy()
 
 
-def df_rel_diff(df, a_col, b_col):
-    """ Returns a column containing the difference between a_col and b_col relative to b_col """
+def df_rel_diff(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the difference between a_col and b_col relative to b_col"""
     return df_ratio(df, a_col, b_col) - 1
 
 
 # with Errors ---
 
 
-def df_err_sum(df, a_err_col, b_err_col):
-    """ Returns a column containing the root of the sum-of-squares of a_err_col and b_err_col """
-    return np.sqrt(np.square(df.loc[:, a_err_col].to_numpy()) + np.square(df.loc[:, b_err_col].to_numpy()))
+def df_err_sum(df: pd.DataFrame, a_err_col: str, b_err_col: str) -> np.ndarray:
+    """Returns a column containing the root of the sum-of-squares of a_err_col and b_err_col"""
+    return np.sqrt(
+        np.square(df.loc[:, a_err_col].to_numpy()) + np.square(df.loc[:, b_err_col].to_numpy())
+    )
 
 
-def df_rel_err_sum(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns a column containing the root of the relative sum-of-square of a_col/a_err_col and b_col/b_err_col """
-    return np.sqrt(np.square(df_ratio(df, a_err_col, a_col)) + np.square(df_ratio(df, b_err_col, b_col)))
+def df_rel_err_sum(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> np.ndarray:
+    """Returns a column containing the root of the relative sum-of-square of a_col/a_err_col and b_col/b_err_col"""
+    return np.sqrt(
+        np.square(df_ratio(df, a_err_col, a_col)) + np.square(df_ratio(df, b_err_col, b_col))
+    )
 
 
-def df_sum_with_err(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns two columns containing the sum and the total errors of the given columns."""
+def df_sum_with_err(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Returns two columns containing the sum and the total errors of the given columns."""
     return df_sum(df, a_col, b_col), df_err_sum(df, a_err_col, b_err_col)
 
 
-def df_diff_with_err(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns two columns containing the difference and the total errors of the given columns."""
+def df_diff_with_err(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Returns two columns containing the difference and the total errors of the given columns."""
     return df_diff(df, a_col, b_col), df_err_sum(df, a_err_col, b_err_col)
 
 
-def df_rel_diff_with_err(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns two columns containing the relative difference and the total errors of the given columns."""
-    return (df_rel_diff(df, a_col, b_col),
-            np.abs(df_ratio(df, a_col, b_col)) * df_rel_err_sum(df, a_col, b_col, a_err_col, b_err_col))
+def df_rel_diff_with_err(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Returns two columns containing the relative difference and the total errors of the given columns."""
+    return (
+        df_rel_diff(df, a_col, b_col),
+        np.abs(df_ratio(df, a_col, b_col)) * df_rel_err_sum(df, a_col, b_col, a_err_col, b_err_col),
+    )
 
 
-def df_ratio_with_err(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns two columns containing the ratio and the total errors of the given columns."""
+def df_ratio_with_err(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Returns two columns containing the ratio and the total errors of the given columns."""
     ratio = df_ratio(df, a_col, b_col)
     return ratio, np.abs(ratio) * df_rel_err_sum(df, a_col, b_col, a_err_col, b_err_col)
 
 
-def df_prod_with_err(df, a_col, b_col, a_err_col, b_err_col):
-    """ Returns two columns containing the product and the total errors of the given columns."""
+def df_prod_with_err(
+    df: pd.DataFrame, a_col: str, b_col: str, a_err_col: str, b_err_col: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Returns two columns containing the product and the total errors of the given columns."""
     prod = df_prod(df, a_col, b_col)
     return prod, np.abs(prod) * df_rel_err_sum(df, a_col, b_col, a_err_col, b_err_col)
 
@@ -79,20 +103,21 @@ def df_prod_with_err(df, a_col, b_col, a_err_col, b_err_col):
 # Angular Calculations ---
 
 
-def df_ang_diff(df, a_col, b_col):
-    """ Returns a column containing the angular difference between angles a and b in [-0.5 , 0.5] """
+def df_ang_diff(df: pd.DataFrame, a_col: str, b_col: str) -> np.ndarray:
+    """Returns a column containing the angular difference between angles a and b in [-0.5 , 0.5]"""
     return ang_diff(df.loc[:, a_col].to_numpy(), df.loc[:, b_col].to_numpy())
 
 
-def ang_diff(a, b):
+def ang_diff(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Returns the angular difference between angles a and b in [-0.5, 0.5]."""
     return ang_interval_check(ang_interval_check(a) - ang_interval_check(b))
 
 
-def ang_sum(a, b):
-    """ Returns a column containing the angular sum between angles a and b in [-0.5 , 0.5] """
+def ang_sum(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Returns a column containing the angular sum between angles a and b in [-0.5 , 0.5]"""
     return ang_interval_check(ang_interval_check(a) + ang_interval_check(b))
 
 
-def ang_interval_check(ang):
-    """ Returns ang wrapped into [-0.5, 0.5] """
+def ang_interval_check(ang: np.ndarray) -> np.ndarray:
+    """Returns ang wrapped into [-0.5, 0.5]"""
     return np.where(np.abs(ang) > 0.5, ang - np.sign(ang), ang)

--- a/omc3/optics_measurements/tune.py
+++ b/omc3/optics_measurements/tune.py
@@ -21,7 +21,20 @@ if TYPE_CHECKING:
     from omc3.optics_measurements.data_models import InputFiles
 
 
-def calculate(measure_input: DotDict, input_files: InputFiles):
+def calculate(measure_input: DotDict, input_files: InputFiles) -> TuneDict:
+    """
+    Computes measured, model and free tunes from input files.
+
+    Averages per-file tune values weighted by their RMS, and determines
+    the free tune when AC-dipole excitation compensation is active.
+
+    Args:
+        measure_input: `OpticsInput` object containing analysis settings.
+        input_files: `InputFiles` object containing frequency spectra files.
+
+    Returns:
+        A `TuneDict` populated with model, measured and free tunes per plane.
+    """
     tune_d = TuneDict()
     accelerator = measure_input.accelerator
     for plane in PLANES:

--- a/omc3/optics_measurements/tune.py
+++ b/omc3/optics_measurements/tune.py
@@ -67,7 +67,7 @@ class TuneDict(dict):
         super().__init__(zip(PLANES, ({"Q": 0.0, "QF": 0.0, "QM": 0.0, "QFM": 0.0, "ac2bpm": None},
                                                     {"Q": 0.0, "QF": 0.0, "QM": 0.0, "QFM": 0.0, "ac2bpm": None})))
 
-    def get_lambda(self, plane):
+    def get_lambda(self, plane: str) -> float:
         """
         Computes lambda compensation factor.
 
@@ -80,7 +80,7 @@ class TuneDict(dict):
         return (np.sin(np.pi * (self[plane]["Q"] - self[plane]["QF"])) /
                 np.sin(np.pi * (self[plane]["Q"] + self[plane]["QF"])))
 
-    def phase_ac2bpm(self, df_idx_by_bpms: pd.DataFrame, plane: str, accelerator):
+    def phase_ac2bpm(self, df_idx_by_bpms: pd.DataFrame, plane: str, accelerator) -> tuple[str, float, int, str]:
         """
         Returns the necessary values for the exciter compensation.
         See **DOI: 10.1103/PhysRevSTAB.11.084002**

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -140,10 +140,10 @@ from omc3.utils.iotools import PathOrStr, UnionPathStr, save_config
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    import odrpack
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
     from numpy.typing import ArrayLike
-    from scipy import odr
 
     from omc3.tune_analysis.kick_file_modifiers import AmpDetData
 
@@ -347,7 +347,7 @@ def _plot_2d(tune_plane: str, opt: DotDict) -> dict[str, Figure]:
     return figs
 
 
-def plot_odr(ax: Axes, odr_fit: odr.Output, xmax: float, label: str = '', color=None):
+def plot_odr(ax: Axes, odr_fit: odrpack.OdrResult, xmax: float, label: str = '', color=None):
     """Adds a quadratic odr fit to axes."""
 
     color = 'k' if color is None else color
@@ -355,7 +355,7 @@ def plot_odr(ax: Axes, odr_fit: odr.Output, xmax: float, label: str = '', color=
 
     # get fits
     order = len(odr_fit.beta) - 1
-    fit_fun = fitting_tools.get_poly_fun(order)
+    fit_fun = fitting_tools.get_polynomial_function(order)
     f = partial(fit_fun, odr_fit.beta)
     f_low = partial(fit_fun, np.array(odr_fit.beta)-np.array(odr_fit.sd_beta))
     f_upp = partial(fit_fun, np.array(odr_fit.beta)+np.array(odr_fit.sd_beta))
@@ -370,7 +370,7 @@ def plot_odr(ax: Axes, odr_fit: odr.Output, xmax: float, label: str = '', color=
 
 
 def _plot_detuning(ax: Axes, data: AmpDetData, label: str, color=None,
-                   limits: dict[str, float] = None, odr_fit: odr.Output=None, odr_label: str =""):
+                   limits: dict[str, float] = None, odr_fit: odrpack.OdrResult=None, odr_label: str =""):
     """Plot the detuning and the ODR into axes."""
     x_lim = _get_default(limits, 'x_lim', [0, max(data.action+data.action_err)])
     offset = 0
@@ -547,7 +547,7 @@ def fit_fun_odr_1d(x, y, q0, qdx, qdy):
     return q0 + qdx * x + qdy * y
 
 
-def plot_odr_3d(ax: Axes, odr_fits: dict[str, odr.Output], xymax: Sequence[float], color=None):
+def plot_odr_3d(ax: Axes, odr_fits: dict[str, odrpack.OdrResult], xymax: Sequence[float], color=None):
     """Plot the odr fit in 3D."""
 
     color = 'k' if color is None else color
@@ -666,7 +666,7 @@ def _format_axes_3d(
 
 # Labels -----------------------------------------------------------------------
 
-def _get_odr_label(odr_fit: odr.Output, tune_plane: str, action_plane: str,
+def _get_odr_label(odr_fit: odrpack.OdrResult, tune_plane: str, action_plane: str,
                    action_unit: str, do_acd_correction: bool):
     """ Returns the label for the ODR fit, nicely formatted and scaled. """
     order = len(odr_fit.beta) - 1
@@ -751,7 +751,7 @@ def _get_default(ddict, key, default):
     return ddict[key]
 
 
-def _scale_data(data: AmpDetData, odr_fit: odr.Output,
+def _scale_data(data: AmpDetData, odr_fit: odrpack.OdrResult,
                 action_unit: str, action_plot_unit: str, tune_scale: float):
     """Scale data to plot-units (y=tune_scale, x=um)."""
     x_scale = UNIT_IN_METERS[action_unit] / UNIT_IN_METERS[action_plot_unit]

--- a/omc3/scripts/fake_measurement_from_model.py
+++ b/omc3/scripts/fake_measurement_from_model.py
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     import pandas as pd
+    from numpy.random import Generator
 
 LOG = logging_tools.get_logger(__name__)
 
@@ -212,7 +213,7 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
     """
     LOG.info("Generating fake measurements.")
     # prepare data
-    np.random.seed(opt.seed)
+    np.random.seed(opt.seed)  # noqa: NPY002  | can't adapt without changing reproducibility (PCG64 vs old MT19937)
     randomize = opt.randomize if opt.randomize is not None else []
     df_twiss, df_model = _get_data(opt.twiss, opt.model,
                                    add_coupling=(F1001 in opt.parameters) or (F1010 in opt.parameters))
@@ -318,6 +319,7 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
                          relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates phase advance measurements. """
     LOG.debug(f"Creating fake phase advance for {parameter}.")
+    rng: Generator = np.random.default_rng()
     plane = parameter[-1]
     df_adv = tfs.TfsDataFrame(index=df_twiss.index[:-1])
     df_adv[NAME2] = df_twiss.index[1:].to_numpy()
@@ -334,7 +336,7 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
         errors = _get_random_errors(errors, np.ones_like(values)) % 0.5
 
     if VALUES in randomize:
-        values = np.random.normal(values, errors)
+        values = rng.normal(values, errors)
         values = ang_interval_check(values)
 
     df_adv[parameter] = values
@@ -356,6 +358,7 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
                        relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates total phase measurements. """
     LOG.debug(f"Creating fake total phase for {parameter}.")
+    rng: Generator = np.random.default_rng()
     plane = parameter[-1]
     df_tot = tfs.TfsDataFrame(index=df_twiss.index)
     element0 = df_twiss.index[0]
@@ -368,7 +371,7 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
     errors[0] = 0.
 
     if VALUES in randomize:
-        rand_val = np.random.normal(values, errors) % 1
+        rand_val = rng.normal(values, errors) % 1
         values += ang_diff(rand_val, values)
 
     df_tot[parameter] = values % 1
@@ -471,6 +474,7 @@ def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: f
                        randomize: Sequence[str]) -> tfs.TfsDataFrame:
     """ Create a new measurement Dataframe from df_twiss from parameter. """
     LOG.debug(f"Creating fake measurement for {parameter}.")
+    rng: Generator = np.random.default_rng()
     values = df_twiss.loc[:, parameter]
     errors = relative_error * values.abs()
     if all(values == 0):
@@ -481,7 +485,7 @@ def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: f
             errors = _get_random_errors(errors, values)
 
         if VALUES in randomize:
-            values = np.random.normal(values, errors)
+            values = rng.normal(values, errors)
 
     return tfs.TfsDataFrame({parameter: values, f"{ERR}{parameter}": errors}, index=df_twiss.index)
 
@@ -567,6 +571,7 @@ def _get_loop_parameters(parameters: Sequence[str], errors: Sequence[float] | No
 def _get_random_errors(errors: npt.NDArray, values: npt.NDArray) -> npt.NDArray:
     """ Creates normal distributed error-values that will not be lower than EPSILON. """
     LOG.debug("Calculating normal distributed random errors.")
+    rng: Generator = np.random.default_rng()
     if any(errors == 0):
         raise ValueError("Errors were requested but given relative error was zero.")
 
@@ -574,7 +579,7 @@ def _get_random_errors(errors: npt.NDArray, values: npt.NDArray) -> npt.NDArray:
     too_small = np.ones_like(errors, dtype=bool)
     n_too_small = 1
     while n_too_small:
-        random_errors[too_small] = np.random.normal(errors[too_small], errors[too_small])
+        random_errors[too_small] = rng.normal(errors[too_small], errors[too_small])
         too_small = random_errors < EPSILON * np.abs(values)
         n_too_small = sum(too_small)
         LOG.debug(f"{n_too_small} error values are smaller than given eps.")

--- a/omc3/scripts/fake_measurement_from_model.py
+++ b/omc3/scripts/fake_measurement_from_model.py
@@ -130,23 +130,26 @@ LOG = logging_tools.get_logger(__name__)
 
 OUTPUTNAMES_MAP = {
     # Names to be output on input of certain parameters.
-    f'{BETA}X': tuple(f"{name}x" for name in (BETA_NAME, AMP_BETA_NAME)),
-    f'{BETA}Y': tuple(f"{name}y" for name in (BETA_NAME, AMP_BETA_NAME)),
-    f'{DISPERSION}X': (f"{DISPERSION_NAME}x",),
-    f'{DISPERSION}Y': (f"{DISPERSION_NAME}y",),
-    f'{PHASE}X': tuple(f"{name}x" for name in (PHASE_NAME, TOTAL_PHASE_NAME)),
-    f'{PHASE}Y': tuple(f"{name}y" for name in (PHASE_NAME, TOTAL_PHASE_NAME)),
+    f"{BETA}X": tuple(f"{name}x" for name in (BETA_NAME, AMP_BETA_NAME)),
+    f"{BETA}Y": tuple(f"{name}y" for name in (BETA_NAME, AMP_BETA_NAME)),
+    f"{DISPERSION}X": (f"{DISPERSION_NAME}x",),
+    f"{DISPERSION}Y": (f"{DISPERSION_NAME}y",),
+    f"{PHASE}X": tuple(f"{name}x" for name in (PHASE_NAME, TOTAL_PHASE_NAME)),
+    f"{PHASE}Y": tuple(f"{name}y" for name in (PHASE_NAME, TOTAL_PHASE_NAME)),
     F1010: (F1010_NAME,),
     F1001: (F1001_NAME,),
-    f'{NORM_DISPERSION}X': tuple(f"{name}x" for name in (BETA_NAME, AMP_BETA_NAME, DISPERSION_NAME, NORM_DISP_NAME)),
+    f"{NORM_DISPERSION}X": tuple(
+        f"{name}x" for name in (BETA_NAME, AMP_BETA_NAME, DISPERSION_NAME, NORM_DISP_NAME)
+    ),
     f"{ORBIT}X": (f"{ORBIT_NAME}x",),
     f"{ORBIT}Y": (f"{ORBIT_NAME}y",),
 }
 FAKED_HEADER: str = "FAKED_FROM"
-VALUES: str = 'values'
-ERRORS: str = 'errors'
-EPSILON: float = 1e-14  # smallest allowed relative error, empirical value
-                        # could be smaller but then normal(mean, err) == mean sometimes
+VALUES: str = "values"
+ERRORS: str = "errors"
+# smallest allowed relative error, empirical value
+# could be smaller but then normal(mean, err) == mean sometimes
+EPSILON: float = 1e-14
 
 
 def get_params():

--- a/omc3/scripts/fake_measurement_from_model.py
+++ b/omc3/scripts/fake_measurement_from_model.py
@@ -124,7 +124,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     import pandas as pd
-    from numpy.random import Generator
 
 LOG = logging_tools.get_logger(__name__)
 
@@ -216,7 +215,7 @@ def generate(opt) -> dict[str, tfs.TfsDataFrame]:
     """
     LOG.info("Generating fake measurements.")
     # prepare data
-    np.random.seed(opt.seed)  # noqa: NPY002  | can't adapt without changing reproducibility (PCG64 vs old MT19937)
+    np.random.seed(opt.seed)
     randomize = opt.randomize if opt.randomize is not None else []
     df_twiss, df_model = _get_data(opt.twiss, opt.model,
                                    add_coupling=(F1001 in opt.parameters) or (F1010 in opt.parameters))
@@ -322,7 +321,6 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
                          relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates phase advance measurements. """
     LOG.debug(f"Creating fake phase advance for {parameter}.")
-    rng: Generator = np.random.default_rng()
     plane = parameter[-1]
     df_adv = tfs.TfsDataFrame(index=df_twiss.index[:-1])
     df_adv[NAME2] = df_twiss.index[1:].to_numpy()
@@ -339,7 +337,7 @@ def create_phase_advance(df_twiss: pd.DataFrame, df_model: pd.DataFrame, paramet
         errors = _get_random_errors(errors, np.ones_like(values)) % 0.5
 
     if VALUES in randomize:
-        values = rng.normal(values, errors)
+        values = np.random.normal(values, errors)
         values = ang_interval_check(values)
 
     df_adv[parameter] = values
@@ -361,7 +359,6 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
                        relative_error: float, randomize: Sequence[str], headers: dict):
     """ Creates total phase measurements. """
     LOG.debug(f"Creating fake total phase for {parameter}.")
-    rng: Generator = np.random.default_rng()
     plane = parameter[-1]
     df_tot = tfs.TfsDataFrame(index=df_twiss.index)
     element0 = df_twiss.index[0]
@@ -374,7 +371,7 @@ def create_total_phase(df_twiss: pd.DataFrame, df_model: pd.DataFrame, parameter
     errors[0] = 0.
 
     if VALUES in randomize:
-        rand_val = rng.normal(values, errors) % 1
+        rand_val = np.random.normal(values, errors) % 1
         values += ang_diff(rand_val, values)
 
     df_tot[parameter] = values % 1
@@ -477,7 +474,6 @@ def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: f
                        randomize: Sequence[str]) -> tfs.TfsDataFrame:
     """ Create a new measurement Dataframe from df_twiss from parameter. """
     LOG.debug(f"Creating fake measurement for {parameter}.")
-    rng: Generator = np.random.default_rng()
     values = df_twiss.loc[:, parameter]
     errors = relative_error * values.abs()
     if all(values == 0):
@@ -488,7 +484,7 @@ def create_measurement(df_twiss: pd.DataFrame, parameter: str, relative_error: f
             errors = _get_random_errors(errors, values)
 
         if VALUES in randomize:
-            values = rng.normal(values, errors)
+            values = np.random.normal(values, errors)
 
     return tfs.TfsDataFrame({parameter: values, f"{ERR}{parameter}": errors}, index=df_twiss.index)
 
@@ -574,7 +570,6 @@ def _get_loop_parameters(parameters: Sequence[str], errors: Sequence[float] | No
 def _get_random_errors(errors: npt.NDArray, values: npt.NDArray) -> npt.NDArray:
     """ Creates normal distributed error-values that will not be lower than EPSILON. """
     LOG.debug("Calculating normal distributed random errors.")
-    rng: Generator = np.random.default_rng()
     if any(errors == 0):
         raise ValueError("Errors were requested but given relative error was zero.")
 
@@ -582,7 +577,7 @@ def _get_random_errors(errors: npt.NDArray, values: npt.NDArray) -> npt.NDArray:
     too_small = np.ones_like(errors, dtype=bool)
     n_too_small = 1
     while n_too_small:
-        random_errors[too_small] = rng.normal(errors[too_small], errors[too_small])
+        random_errors[too_small] = np.random.normal(errors[too_small], errors[too_small])
         too_small = random_errors < EPSILON * np.abs(values)
         n_too_small = sum(too_small)
         LOG.debug(f"{n_too_small} error values are smaller than given eps.")

--- a/omc3/tune_analysis/fitting_tools.py
+++ b/omc3/tune_analysis/fitting_tools.py
@@ -4,15 +4,15 @@ Fitting Tools
 
 This module contains fitting functionality for ``tune_analysis``.
 It provides tools for fitting functions, mainly via odr.
-
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 import numpy as np
+import odrpack
 from numpy.polynomial import Polynomial
-from scipy.odr import ODR, Model, RealData
 from scipy.optimize import curve_fit
 
 from omc3.tune_analysis.constants import FakeOdrOutput
@@ -20,67 +20,78 @@ from omc3.utils import logging_tools
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from logging import Logger
 
     import pandas as pd
     from numpy.typing import ArrayLike
+    from odrpack.result import OdrResult
 
-LOG = logging_tools.get_logger(__name__)
+LOG: Logger = logging_tools.get_logger(__name__)
 
 
 # ODR ###################################################################
 
 
-def get_poly_fun(order: int):
-    """Returns the function of polynomial order. (is this pythonic enough?)."""
-    def poly_func(beta, x):
-        return sum(beta[i] * np.power(x, i) for i in range(order+1))
+def get_polynomial_function(order: int):
+    """Returns the function of polynomial order."""
+
+    def poly_func(x, beta):
+        return sum(beta[i] * np.power(x, i) for i in range(order + 1))
+
     return poly_func
 
 
-def do_odr(x: pd.Series, y: pd.Series, xerr: pd.Series, yerr: pd.Series, order: int):
+def do_odr(x: pd.Series, y: pd.Series, xerr: pd.Series, yerr: pd.Series, order: int) -> OdrResult:
     """
-    Returns the odr fit.
+    Returns the odr fit from the provided data and associated error bars.
 
     Important Convention:
-    The beta-parameter in the ODR models go upwards with order, i.e.
+        The beta-parameter in the ODR models go upwards with order, i.e.
 
-    |  beta[0] = y-Axis offset
-    |  beta[1] = slope
-    |  beta[2] = quadratic term
-    |  etc.
+        |  beta[0] = y-Axis offset
+        |  beta[1] = slope
+        |  beta[2] = quadratic term
+        |  etc.
 
     Args:
-        x: `Series` of x data.
-        y: `Series` of y data.
-        xerr: `Series` of x data errors.
-        yerr: `Series` of y data errors.
-        order: fit order, ``1`` for linear, ``2`` for quadratic.
+        x: `pandas.Series` of x data.
+        y: `pandas.Series` of y data.
+        xerr: `pandas.Series` of x data errors.
+        yerr: `pandas.Series` of y data errors.
+        order: fit order, ``1`` for linear, ``2`` for quadratic, etc.
 
-    Returns: Odr fit. Betas order is index = coefficient of same order.
+    Returns:
+        An `~odrpack.OdrResult` with the fitted coefficients in ``beta``,
+        ordered by ascending polynomial degree.
     """
     LOG.debug("Starting ODR fit.")
 
     # Poly-Fit for starting point ---
-    fit_np = Polynomial.fit(x, y, deg=order).convert()
+    fit_np: Polynomial = Polynomial.fit(x, y, deg=order).convert()
     LOG.debug(f"ODR fit input (from polynomial fit): {fit_np}")
 
     # Actual ODR ---
     xerr, yerr = _check_exact_zero_errors(xerr, yerr)
-    odr = ODR(data=RealData(x=x, y=y, sx=xerr, sy=yerr),
-              model=Model(get_poly_fun(order)),
-              beta0=fit_np.coef)
-    odr_fit = odr.run()
+    odr_fit: OdrResult = odrpack.odr_fit(
+        f=get_polynomial_function(order),
+        xdata=np.asarray(x, dtype=float),
+        ydata=np.asarray(y, dtype=float),
+        beta0=fit_np.coef,
+        weight_x=1.0 / np.asarray(xerr, dtype=float) ** 2,
+        weight_y=1.0 / np.asarray(yerr, dtype=float) ** 2,
+    )
     logging_tools.odr_pprint(LOG.info, odr_fit)
     return odr_fit
 
 
 # 2D-Kick ODR ##################################################################
 
-INPUT_ORDER = "qx0", "qy0", "dqx/dex", "dqy/dey",  "dq(x,y)/de(y,x)"
+INPUT_ORDER = "qx0", "qy0", "dqx/dex", "dqy/dey", "dq(x,y)/de(y,x)"
 
 
-def first_order_detuning_2d(beta: Sequence, x: ArrayLike) -> ArrayLike:
-    """ Calculates the 2D tune array (Qx, Qy)
+def first_order_detuning_2d(x: ArrayLike, beta: Sequence) -> ArrayLike:
+    """
+    Calculates the 2D tune array (Qx, Qy)
         Qx = qx0 + dqx/dex * ex + dqx/dey * ey
         Qy = qy0 + dqy/dex * ex + dqy/dey * ey
 
@@ -92,40 +103,58 @@ def first_order_detuning_2d(beta: Sequence, x: ArrayLike) -> ArrayLike:
     Returns:
         np.array: 2xN [[Qx1, Qx2, ...],[Qy1, Qy2, ...]]
     """
-    return np.array([beta[0] + beta[2] * x[0] + beta[4] * x[1],
-                     beta[1] + beta[4] * x[0] + beta[3] * x[1]])
+    return np.array(
+        [beta[0] + beta[2] * x[0] + beta[4] * x[1], beta[1] + beta[4] * x[0] + beta[3] * x[1]]
+    )
 
 
-def first_order_detuning_2d_jacobian(beta: Sequence, x: ArrayLike) -> ArrayLike:
-    """ Jacobian of the 2D tune array:
-        [[dqx/dex, dqx/dey ],
-         [dqy/dex, dqy/dey ]]
+def first_order_detuning_2d_jac_x(x: ArrayLike, beta: Sequence) -> np.ndarray:
+    """Jacobian of `first_order_detuning_2d` w.r.t. x. Shape (q=2, m=2, n).
 
     Args:
-        beta: length 5 tune coefficients in order `INPUT_ORDER`
-              0: qx0, 1: qy0, 2: xx, 3: yy, 4: xy/yx
-        x: length 2 Sequence, (ex, ey)
+        x: array size 2xN.
+        beta: length 5 tune coefficients in order `INPUT_ORDER`.
 
     Returns:
-        np.array: size 2x2xlen(x) containing the Jacobian of the 2d-fit function.
+        np.array of shape (2, 2, n).
     """
-    return np.dstack([np.array([[beta[2], beta[4]],
-                     [beta[4], beta[3]]])] * len(x[0]))
+    return np.dstack([np.array([[beta[2], beta[4]], [beta[4], beta[3]]])] * len(x[0]))
+
+
+def first_order_detuning_2d_jac_beta(x: ArrayLike, beta: Sequence) -> np.ndarray:
+    """Jacobian of `first_order_detuning_2d` w.r.t. beta. Shape (q=2, npar=5, n).
+
+    Args:
+        x: array size 2xN.
+        beta: length 5 tune coefficients in order `INPUT_ORDER`.
+
+    Returns:
+        np.array of shape (2, 5, n).
+    """
+    n = len(x[0])
+    ones = np.ones(n)
+    zeros = np.zeros(n)
+    return np.array([
+        [ones,  zeros, x[0],  zeros, x[1]],   # dQx/d(beta_i)
+        [zeros, ones,  zeros, x[1],  x[0]],   # dQy/d(beta_i)
+    ])
 
 
 def map_odr_fit_to_planes(odr_fit) -> dict[str, dict[str, FakeOdrOutput]]:
-    """ Maps the calculated odr fit to fake odr fits with `beta` and `sd_beta`
+    """
+    Maps the calculated odr fit to fake odr fits with `beta` and `sd_beta`
     attributes. These would be the results of first-order amplitude detuning
     odr-fits when done independently by tune and kick plane.
 
-    Returns: Dict[str, Dict[str: odr_fit]] of ODR fits, where the inner
-             string gives the kick-plane, the outer the tune-plane..
-
+    Returns:
+        Dict[str, Dict[str: odr_fit]] of ODR fits, where the inner
+        string gives the kick-plane, the outer the tune-plane.
     """
+
     def get_fit(a: int, b: int):
         return FakeOdrOutput(
             beta=[odr_fit.beta[a], odr_fit.beta[b]],
-            sd_beta=[odr_fit.sd_beta[a], odr_fit.sd_beta[b]]
+            sd_beta=[odr_fit.sd_beta[a], odr_fit.sd_beta[b]],
         )
 
     return {
@@ -159,23 +188,33 @@ def do_2d_kicks_odr(x: ArrayLike, y: ArrayLike, xerr: ArrayLike, yerr: ArrayLike
 
     # Curve-Fit for starting point ---
     def curve_fit_fun(v, *args):
-        return first_order_detuning_2d(args, v).ravel()
+        return first_order_detuning_2d(v, args).ravel()
 
-    beta, beta_cov = curve_fit(f=curve_fit_fun, xdata=x, ydata=y.ravel(), p0=[0]*5)
+    beta, beta_cov = curve_fit(f=curve_fit_fun, xdata=x, ydata=y.ravel(), p0=[0] * 5)
 
     res_str = ",\n".join([f"{n:>16} = {b:9.3g}" for n, b in zip(INPUT_ORDER, beta)])
     LOG.info(f"\nDetuning estimate without errors (curve fit):\n{res_str}\n")
 
     # Actual ODR ---
     xerr, yerr = _check_exact_zero_errors(xerr, yerr)
-    odr = ODR(data=RealData(x=x, y=y, sx=xerr, sy=yerr),
-              # model=Model(first_order_detuning_2d),
-              model=Model(first_order_detuning_2d, fjacd=first_order_detuning_2d_jacobian),
-              beta0=beta)
-    odr_fit = odr.run()
+    odr_fit: OdrResult = odrpack.odr_fit(
+        f=first_order_detuning_2d,
+        xdata=np.asarray(x, dtype=float),
+        ydata=np.asarray(y, dtype=float),
+        beta0=beta,
+        weight_x=1.0 / np.asarray(xerr, dtype=float) ** 2,
+        weight_y=1.0 / np.asarray(yerr, dtype=float) ** 2,
+        jac_beta=first_order_detuning_2d_jac_beta,
+        jac_x=first_order_detuning_2d_jac_x,
+    )
     logging_tools.odr_pprint(LOG.debug, odr_fit)
 
-    res_str = ",\n".join([f"{n:>16} = {b:9.3g} +- {e:8.3g}" for n, b, e in zip(INPUT_ORDER, odr_fit.beta, odr_fit.sd_beta)])
+    res_str = ",\n".join(
+        [
+            f"{n:>16} = {b:9.3g} +- {e:8.3g}"
+            for n, b, e in zip(INPUT_ORDER, odr_fit.beta, odr_fit.sd_beta)
+        ]
+    )
     LOG.info(f"\nDetuning estimate with errors (odr):\n{res_str}\n")
     return map_odr_fit_to_planes(odr_fit)
 
@@ -192,13 +231,15 @@ def _filter_nans(*args: ArrayLike) -> list[ArrayLike]:
     return list(a)
 
 
-def _check_exact_zero_errors(xerr: ArrayLike, yerr: ArrayLike) -> tuple[np.ndarray, np.ndarray]:
-    """Check if errors are exact zero and replace with minimum error, if so.
-    Done because ODR crashes on exact zero error-bars.
-
-    Beware that the output will always be np.arrays, even if the input is pd.Series.
+def _check_exact_zero_errors(
+    xerr: pd.Series | np.ndarray, yerr: pd.Series | np.ndarray
+) -> tuple[pd.Series | np.ndarray, pd.Series | np.ndarray]:
     """
-    def check_exact_zero_per_plane(err, plane):
+    Check if errors are exact zero and replace with minimum error, if so.
+    Done because ODR crashes on exact zero error-bars.
+    """
+
+    def check_exact_zero_per_plane(err: pd.Series | np.ndarray, plane: str) -> pd.Series | np.ndarray:
         if (err != 0).all():  # no problem
             return err
 
@@ -206,10 +247,13 @@ def _check_exact_zero_errors(xerr: ArrayLike, yerr: ArrayLike) -> tuple[np.ndarr
         minval = np.where(err == 0, np.inf, err).min()  # assumes all values >=0
 
         if np.isinf(minval):
-            raise ValueError(f"All errors are exactly zero in the {plane} plane."
-                             f" ODR cannot be performed.")
-        LOG.warning(f"Exact zeros in {plane} errors found."
-                    f" Replaced by {minval} (the minimum value) to be able to perform ODR.")
+            raise ValueError(
+                f"All errors are exactly zero in the {plane} plane. ODR cannot be performed."
+            )
+        LOG.warning(
+            f"Exact zeros in {plane} errors found."
+            f" Replaced by {minval} (the minimum value) to be able to perform ODR."
+        )
         return np.where(err == 0, minval, err)
 
     xerr = check_exact_zero_per_plane(xerr, "horizontal")

--- a/omc3/tune_analysis/kick_file_modifiers.py
+++ b/omc3/tune_analysis/kick_file_modifiers.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from scipy import odr
+    import odrpack
 
 LOG = logging_tools.get_logger(__name__)
 
@@ -188,7 +188,7 @@ def add_corrected_natural_tunes(kickac_df: pd.DataFrame) -> pd.DataFrame:
     return kickac_df
 
 
-def add_odr(kickac_df: pd.DataFrame, odr_fit: odr.Output,
+def add_odr(kickac_df: pd.DataFrame, odr_fit: odrpack.OdrResult,
             action_plane: str, tune_plane: str, corrected: bool = False):
     """
     Adds the odr fit of the (un)corrected data to the header of the ``kickac_df``.

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -241,9 +241,8 @@ def odr_pprint(printer, odr_out):
     if hasattr(odr_out, 'info'):
         odr_str += (f'  Residual Variance: {odr_out.res_var:.2e}\n'
                     f'  Inverse Condition #: {odr_out.inv_condnum:.2e}\n'
-                    f'  Reason(s) for Halting:\n')
-        for r in odr_out.stopreason:
-            odr_str += f'    {r}\n'
+                    f'  Reason(s) for Halting:\n'
+                    f'    {odr_out.stopreason}\n')
     printer(odr_str)
     np.set_printoptions(**old_opts)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ test = [
   "omc3[madng]",
 ]
 doc = [
+  "omc3[madng]",  # need pymadng to build its response creation module doc
   "sphinx >= 7.0",
   "sphinx_rtd_theme >= 2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,10 @@ addopts = [
     "--import-mode=importlib",
 ]
 
+filterwarnings = [
+    "ignore:More than 20 figures have been opened:RuntimeWarning:matplotlib",
+]
+
 # Helpful for pytest-debugging (leave commented out on commit):
 # log_cli = true
 # log_cli_level = "DEBUG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ extend-select = [
     "TID",      # Some good import practices
     "TC",       # Enforce importing certain types in a TYPE_CHECKING block
     "PTH",      # Use pathlib instead of os.path
-    "NPY",      # Some numpy-specific things
+    # "NPY",      # Some numpy-specific things
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ extend-select = [
     "TID",      # Some good import practices
     "TC",       # Enforce importing certain types in a TYPE_CHECKING block
     "PTH",      # Use pathlib instead of os.path
-    # "NPY",      # Some numpy-specific things
+    "NPY",      # Some numpy-specific things
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/accuracy/test_global_correction.py
+++ b/tests/accuracy/test_global_correction.py
@@ -30,7 +30,7 @@ from omc3.response_creator import create_response_entrypoint as create_response
 from omc3.scripts.fake_measurement_from_model import ERRORS, VALUES
 from omc3.scripts.fake_measurement_from_model import generate as fake_measurement
 from omc3.utils import logging_tools
-from omc3.utils.stats import LOGGER, rms
+from omc3.utils.stats import rms
 
 LOG = logging_tools.get_logger(__name__)
 # LOG = logging_tools.get_logger('__main__', level_console=logging_tools.MADX)

--- a/tests/unit/test_hole_in_one.py
+++ b/tests/unit/test_hole_in_one.py
@@ -25,9 +25,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from turn_by_turn import TbtData
-from tests.accuracy.test_harpy import _get_model_dataframe
-from tests.unit.test_harpy import create_tbt_data
 
 from omc3.harpy.constants import FILE_AMPS_EXT, FILE_FREQS_EXT, FILE_LIN_EXT
 from omc3.hole_in_one import (
@@ -50,7 +47,9 @@ from omc3.optics_measurements.constants import (
     PHASE_NAME,
     TOTAL_PHASE_NAME,
 )
+from tests.accuracy.test_harpy import _get_model_dataframe
 from tests.conftest import INPUTS, ids_str
+from tests.unit.test_harpy import create_tbt_data
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/test_tune_analysis.py
+++ b/tests/unit/test_tune_analysis.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -12,8 +10,6 @@ from omc3.tune_analysis.bbq_tools import (
 )
 from omc3.tune_analysis.fitting_tools import get_polynomial_function
 
-if TYPE_CHECKING:
-    from numpy.random import Generator
 
 @pytest.mark.basic
 def test_moving_average():
@@ -70,11 +66,10 @@ def _plot_helper(*series):
 
 
 def _get_noisy_sinus():
-    rng: Generator = np.random.default_rng()
     n_samples = 1000
-    sin_data = pd.Series(np.sin(np.linspace(0, 2 * np.pi, n_samples)))
-    data = sin_data + (2 * rng.random(n_samples) - 1)
-    high_int = rng.integers(low=0, high=n_samples, size=100)
-    data[high_int[:50]] += 1.0
-    data[high_int[50:]] -= 1.0
+    sin_data = pd.Series(np.sin(np.linspace(0, 2*np.pi, n_samples)))
+    data = sin_data + (2*np.random.rand(n_samples) - 1)
+    high_int = np.random.randint(low=0, high=n_samples, size=100)
+    data[high_int[:50]] += 1.
+    data[high_int[50:]] -= 1.
     return sin_data, data

--- a/tests/unit/test_tune_analysis.py
+++ b/tests/unit/test_tune_analysis.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 @pytest.mark.basic
 def test_moving_average():
-    np.random.seed(2020)
     sin_data, data = _get_noisy_sinus()
     opt = MinMaxFilterOpt(
         min=-2,

--- a/tests/unit/test_tune_analysis.py
+++ b/tests/unit/test_tune_analysis.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,6 +12,8 @@ from omc3.tune_analysis.bbq_tools import (
 )
 from omc3.tune_analysis.fitting_tools import get_polynomial_function
 
+if TYPE_CHECKING:
+    from numpy.random import Generator
 
 @pytest.mark.basic
 def test_moving_average():
@@ -66,10 +70,11 @@ def _plot_helper(*series):
 
 
 def _get_noisy_sinus():
+    rng: Generator = np.random.default_rng()
     n_samples = 1000
-    sin_data = pd.Series(np.sin(np.linspace(0, 2*np.pi, n_samples)))
-    data = sin_data + (2*np.random.rand(n_samples) - 1)
-    high_int = np.random.randint(low=0, high=n_samples, size=100)
-    data[high_int[:50]] += 1.
-    data[high_int[50:]] -= 1.
+    sin_data = pd.Series(np.sin(np.linspace(0, 2 * np.pi, n_samples)))
+    data = sin_data + (2 * rng.random(n_samples) - 1)
+    high_int = rng.integers(low=0, high=n_samples, size=100)
+    data[high_int[:50]] += 1.0
+    data[high_int[50:]] -= 1.0
     return sin_data, data

--- a/tests/unit/test_tune_analysis.py
+++ b/tests/unit/test_tune_analysis.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.basic
 def test_moving_average():
+    np.random.seed(2020)
     sin_data, data = _get_noisy_sinus()
     opt = MinMaxFilterOpt(
         min=-2,

--- a/tests/unit/test_tune_analysis.py
+++ b/tests/unit/test_tune_analysis.py
@@ -8,7 +8,7 @@ from omc3.tune_analysis.bbq_tools import (
     clean_outliers_moving_average,
     get_moving_average,
 )
-from omc3.tune_analysis.fitting_tools import get_poly_fun
+from omc3.tune_analysis.fitting_tools import get_polynomial_function
 
 
 @pytest.mark.basic
@@ -31,14 +31,14 @@ def test_moving_average():
 @pytest.mark.basic
 def test_get_poly_fun():
     x_arr = np.linspace(0, 100, 101, dtype=int)  # use int for exact compare (==) below
-    p0 = get_poly_fun(0)
-    assert all(p0([1.43], x_arr) == 1.43)
+    p0 = get_polynomial_function(0)
+    assert all(p0(x_arr, [1.43]) == 1.43)
 
-    p1 = get_poly_fun(1)
-    assert all(p1([0, 1], x_arr) == x_arr)
+    p1 = get_polynomial_function(1)
+    assert all(p1(x_arr, [0, 1]) == x_arr)
 
-    p2 = get_poly_fun(2)
-    assert all(p2([0, 2, 3.5], x_arr) == 2*x_arr + 3.5*(x_arr**2))
+    p2 = get_polynomial_function(2)
+    assert all(p2(x_arr, [0, 2, 3.5]) == 2*x_arr + 3.5*(x_arr**2))
 
 
 @pytest.mark.extended


### PR DESCRIPTION
This branch fixes a few of the warnings and deprecations we could see showing up in the test runs.

- Fixes the deprecation of `scipy.odr` in favor of using `odrpack` as they recommend. Already had a previous PR on this, here's the end of it. Mostly adapting order of args, call sites etc.
- Fixes the "dataframe is highly fragmented" `PerformanceWarning` from pandas in the `harpy` code. This is due to modifying the linfiles a lot when building them (lots of column additions, rows additions etc). Fixed with a simple `frame.copy()` call at the right place (as suggested in the warning).
- "Fixes" the warning from `matplotlib` about the number of open figures. Since this does not happen in prod (we don't trigger all code paths in a go) I have just suppressed the warning in the `pytest` configuration. We could put some `plt.close("all")` in the tests but it feels rather ugly and destructive.