### PR TITLE
[Harpy] Parallelisation Strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - The `harpy` internal logic has been reworked:
         - Its own operations cap the BLAS threads at 1 for better efficiency (which frees up logical cores).
         - A parallelisation strategy is deployed over the bunches to make use of the freed cores.
-        - A new `n_jobs` parameter can be provided, which defaults to auto determination of the number of workers.
+        - A new `n_jobs` parameter can be provided, which defaults to auto determination of the number of workers. Should the available RAM not be determinable, the auto determination conservatively falls back to a single worker (although providing `n_jobs` explicitly parallelises anyway).
 
 #### 2026-06-19 - v0.28.2 - _fsoubelet_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OMC3 Changelog
 
+#### 2026-07-?? - v0.29.0 - _fsoubele_
+
+- Changed:
+    - The `harpy` internal logic has been reworked:
+        - Its own operations cap the BLAS threads at 1 for better efficiency (which frees up logical cores).
+        - A parallelisation strategy is deployed over the bunches to make use of the freed cores.
+        - A new `n_jobs` parameter can be provided, which defaults to auto determination of the number of workers.
+
 #### 2026-06-19 - v0.28.2 - _fsoubelet_
 
 - Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OMC3 Changelog
 
-#### 2026-07-?? - v0.29.0 - _fsoubele_
+#### 2026-07-?? - v0.29.0 - _fsoubelet_
 
 - Changed:
     - The `harpy` internal logic has been reworked:

--- a/omc3/__init__.py
+++ b/omc3/__init__.py
@@ -11,7 +11,7 @@ omc3 is a tool package for the optics measurements and corrections group (OMC) a
 __title__ = "omc3"
 __description__ = "An accelerator physics tools package for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/omc3"
-__version__ = "0.28.2"
+__version__ = "0.29.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -197,7 +197,7 @@ def decide_n_workers(
 
     # Compute the number of workers / jobs to dispatch, log it and return
     n_jobs: int = max(1, min(cores_cap, n_bunches, ram_cap))
-    LOGGER.info(
+    LOGGER.debug(
         f"Parallel harpy: n_jobs={n_jobs} (cores_cap={cores_cap}, bunches={n_bunches}, "
         f"ram_cap={ram_cap_str}, peak/bunch~{peak_rss / 1e9:.1f}GB, available~{available_ram_str})"
     )

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -42,8 +42,9 @@ SAFETY_MARGIN = 0.85  # 85% to leave room for other processes etc.
 # this value is safe (leads to fewer workers for parallelisation and no risk of bein OOM).
 _BASELINE_RSS_BYTES = int(1.5e9)  # 1.5GB peak RSS for a bunch in the lowest consuming scenario
 
-# Generous upper bound on the number of frequency lines selected by the narrow
-# (resonance-band) mask; its transient is negligible next to the baseline.
+# Generous upper bound on the number of frequency lines selected by the narrow mask.
+# Its transient is negligible next to the baseline. See comments inside of the
+# estimate_peak_rss_bytes_per_bunch function for details and how this plays a role.
 _NARROW_MASK_BINS = 1 << 14  # equivalent to 2**14
 
 # ----- System information ----- #

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -37,7 +37,7 @@ _BYTES_COMPLEX128 = 16
 
 # Fraction of available RAM the worker pool is allowed
 # to use, with a little bit of margin
-SAFETY_MARGIN = 0.9
+SAFETY_MARGIN = 0.85
 
 # Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
 # Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating
@@ -140,3 +140,66 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
 
     # Return the estimated peak + minimum memory occupancy (data loading etc)
     return _BASELINE_RSS_BYTES + transient
+
+
+def decide_n_jobs(
+    harpy_input: DotDict,
+    n_bunches: int,
+    n_bpms: int,
+    *,
+    requested: int = 0,
+    margin: float = SAFETY_MARGIN,
+) -> int:
+    """
+    Choose the number of worker processes for per-bunch analysis. Each bunch is sent
+    to a worker. This assumes the number of BLAS threads is limited (for `numpy.svd`
+    operations for instance where it maxes out the threads and doesn't do much with
+    it).
+
+    Note
+    ----
+        The `requested` argument mirrors the `n_jobs` for the harpy parameters. Passing
+        `0` selects automatically (all usable cores, RAM permitting); `1` runs serially
+        (which is the old behaviour) and providing an integer value `N` caps the pool at
+        either `N` processes or the automatically determined number (RAM permitting).
+
+        The result is `max(1, min(cores_cap, n_bunches, ram_cap))`, where `ram_cap` is
+        `floor(margin * available_ram / peak_rss_per_bunch)` (or unconstrained when the
+        available RAM could not be determined).
+
+    Args:
+        harpy_input (DotDict): Harpy analysis settings, forwarded to
+            :func:`estimate_peak_rss_bytes_per_bunch` for the per-bunch RSS estimate.
+        n_bunches (int): Number of bunches to process. Caps the pool since each bunch
+            goes to at most one worker.
+        n_bpms (int): Number of BPMs (use the pre-clean count as a safe upper bound),
+            used for the per-bunch RSS estimate.
+        requested (int): the `n_jobs` option passed to ``harpy``. See the note above.
+        margin (float): fraction of available RAM the worker pool may occupy, leaving
+            the remainder as headroom against under-estimating the peak and for other
+            running processes.
+
+    Returns:
+        The number of worker processes to use, always at least 1.
+    """
+    # Determine a few parameters
+    cores_cap: int = requested if requested > 0 else usable_cores()
+    peak_rss: int = estimate_peak_rss_bytes_per_bunch(harpy_input, n_bpms)
+    available_ram = available_ram_bytes()
+
+    # Determine the available RAM to use, including the safety margin
+    # If unknown RAM -> do not let it constrain the choice
+    if available_ram is None:
+        ram_cap: int = n_bunches
+        available_ram_str, ram_cap_str = "unknown", "n/a"
+    else:
+        ram_cap = int(margin * available_ram / peak_rss)
+        available_ram_str, ram_cap_str = f"{available_ram / 1e9:.0f}GB", str(ram_cap)
+
+    # Compute the number of workers / jobs to dispatch, log it and return
+    n_jobs: int = max(1, min(cores_cap, n_bunches, ram_cap))
+    LOGGER.info(
+        f"Parallel harpy: n_jobs={n_jobs} (cores_cap={cores_cap}, bunches={n_bunches}, "
+        f"ram_cap={ram_cap_str}, peak/bunch~{peak_rss / 1e9:.1f}GB, available~{available_ram_str})"
+    )
+    return n_jobs

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -91,7 +91,7 @@ def available_ram_bytes() -> int | None:
     """
     Returns currently available RAM in bytes (memory that can be
     given to processes without swapping), via ``psutil``. Returns
-    or ``None`` if it cannot be determined.
+    ``None`` if it cannot be determined.
     """
     try:
         return psutil.virtual_memory().available

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -171,7 +171,8 @@ def decide_n_workers(
         The `requested` argument mirrors the `n_jobs` for the harpy parameters. Passing
         `0` selects automatically (all usable cores, RAM permitting); `1` runs serially
         (which is the old behaviour) and providing an integer value `N` caps the pool at
-        either `N` processes or the automatically determined number (RAM permitting).
+        either `N` processes or the automatically determined number (RAM permitting) if
+        the latter is smaller.
 
         The result is `max(1, min(cores_cap, n_bunches, ram_cap))`, where `ram_cap` is
         `floor(margin * available_ram / peak_rss_per_bunch)` (or unconstrained when the

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -33,9 +33,9 @@ LOGGER: Logger = logging_tools.get_logger(__name__)
 _BYTES_FLOAT64 = 8
 _BYTES_COMPLEX128 = 16
 
-# Fraction of available RAM the worker pool is allowed
-# to use, with a little bit of margin
-SAFETY_MARGIN = 0.85
+# Fraction of available RAM the worker pool is allowed to use,
+# with a little bit of margin. Could be tweaked.
+SAFETY_MARGIN = 0.85  # 85% to leave room for other processes etc.
 
 # Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
 # Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -207,6 +207,14 @@ def decide_n_workers(
         ram_cap = int(margin * available_ram / peak_rss)
         available_ram_str, ram_cap_str = f"{available_ram / 1e9:.0f}GB", str(ram_cap)
 
+        # In case the estimated peak RSS is higher than available RAM, we warn the user
+        if peak_rss > available_ram:
+            LOGGER.warning(
+                f"The estimated peak RSS (memory usage) of a bunch is {peak_rss / 1e9:.1f}GB. "
+                f"The available detected RAM is {available_ram_str}. "
+                "This might lead to slowdowns or crashes!"
+            )
+
     # Compute the number of workers / jobs to dispatch, log it and return
     n_jobs: int = max(1, min(cores_cap, n_bunches, ram_cap))
     LOGGER.info(

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -1,0 +1,68 @@
+"""
+Parallel
+--------
+
+Private helpers for harpy's per-bunch parallel orchestration:
+
+- Resource estimation (peak resident memory per bunch, available RAM, usable cores),
+- Worker count strategy,
+- BLAS thread-capping utilities.
+
+The functions are kept free of side effects (aside from reading ``/proc/meminfo``) so
+the sizing logic can be unit-tested in isolation. The actual dispatch / orchestration
+lives in :func:`omc3.harpy.handler.analyse_bunches`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from threadpoolctl import threadpool_limits
+
+from omc3.utils import logging_tools
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from generic_parser import DotDict
+
+LOGGER: Logger = logging_tools.get_logger(__name__)
+
+# ----- Some constants ----- #
+
+_BYTES_FLOAT64 = 8
+_BYTES_COMPLEX128 = 16
+
+# Fraction of available RAM the worker pool is allowed
+# to use, with a little bit of margin
+SAFETY_MARGIN = 0.9
+
+# Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
+# Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating
+# is safe (fewer workers, no OOM), so this doubles as the whole footprint of the narrow-mask path.
+_BASELINE_RSS_BYTES = int(1.5e9)
+
+# Generous upper bound on the number of frequency lines selected by the narrow
+# (resonance-band) mask; its transient is negligible next to the baseline.
+_NARROW_MASK_BINS = 1 << 14  # equivalent to 2**14
+
+# ----- System information ----- #
+
+def usable_cores() -> int:
+    """
+    Returns the number of cores actually available to this process.
+
+    Attempts to use approaches which honour the CPU affinity mask (taskset,
+    cgroup cpuset, HPC bindings etc). First via ``os.process_cpu_count`` (which
+    is Python 3.13+) then with ``os.sched_getaffinity`` (which is Linux only, and
+    that is fine in the CCC). Falls back to ``os.cpu_count()`` but that is the
+    total number of CPUs on the machine. Defaults to 1.
+    """
+    if hasattr(os, "process_cpu_count"):  # Python 3.13+: honours affinity + PYTHON_CPU_COUNT
+        return os.process_cpu_count() or 1
+    try:
+        return len(os.sched_getaffinity(0))  # Linux only, honours affinity mask
+    except AttributeError:  # macOS/Windows
+        return os.cpu_count() or 1

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -113,8 +113,8 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     via `np.dot(u, s_vt_freq[:, mask])`, plus its `np.abs` copy).
 
     Its width is the number of selected frequency lines: the full `2 ** turn_bits`
-    when `full_spectra` are written (default in the CCC) or cleaning is disabled
-    (all-ones mask), and a negligible narrow band otherwise.
+    when `full_spectra` are written (default from the BB GUI in the CCC) or cleaning
+    is disabled (all-ones mask), and a negligible narrow band otherwise.
 
     It scales with ``turn_bits`` and ``n_bpms``, not with the number of turns (the
     SVD reduces to ``sing_val`` rows before the zero-padded FFT).

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -172,12 +172,14 @@ def decide_n_workers(
         `0` selects automatically (all usable cores, RAM permitting); `1` runs serially
         (which is the old behaviour) and providing an integer value `N` uses up to `N`
         workers, still bounded by the same safety limits. In other words `N` can only
-        throttle the pool *below* the automatic choice, never oversubscribe it.
+        throttle the pool *below* the automatic choice, never oversubscribe it. Requesting
+        `N` explicitly is also what lifts the fallback described below.
 
         The result is `max(1, min(cores_cap, n_bunches, ram_cap))`, where `cores_cap` is
         `usable_cores()` when automatic or `min(N, usable_cores())` when `N` is requested,
-        and `ram_cap` is `floor(margin * available_ram / peak_rss_per_bunch)` (or
-        unconstrained when the available RAM could not be determined).
+        and `ram_cap` is `floor(margin * available_ram / peak_rss_per_bunch)` (or `1` when
+        the available RAM could not be determined and no explicit `N` was requested, as we
+        do not guess a pool size we cannot verify).
 
     Args:
         harpy_input (DotDict): Harpy analysis settings, forwarded to
@@ -201,11 +203,27 @@ def decide_n_workers(
     peak_rss: int = estimate_peak_rss_bytes_per_bunch(harpy_input, n_bpms)
     available_ram: int | None = available_ram_bytes()
 
-    # Determine the available RAM to use, including the safety margin
-    # If unknown RAM -> do not let it constrain the choice
+    # Determine the available RAM to use, including the safety margin.
+    # If unknown RAM -> we cannot size the pool. An OOM-killed worker takes the whole pool
+    # down with it, so the safe failure mode is to stay serial when deciding automatically.
+    # However, an explicitly provided 'n_jobs' is trusted, as the user knows their machine
+    # better than a detection which just failed.
     if available_ram is None:
-        ram_cap: int = n_bunches
-        available_ram_str, ram_cap_str = "unknown", "n/a"
+        available_ram_str = "unknown"
+        if requested > 0:
+            ram_cap: int = n_bunches  # do not constrain, the user asked for it
+            ram_cap_str = "n/a (explicit n_jobs)"
+            LOGGER.warning(
+                "Could not determine the available RAM on this machine; proceeding with "
+                f"the explicitly requested n_jobs={requested}."
+            )
+        else:
+            ram_cap = 1
+            ram_cap_str = "1 (unknown RAM)"
+            LOGGER.warning(
+                "Could not determine the available RAM on this machine, falling back to a "
+                "single worker. Provide n_jobs=N explicitly to parallelise anyway."
+            )
     else:
         ram_cap = int(margin * available_ram / peak_rss)
         available_ram_str, ram_cap_str = f"{available_ram / 1e9:.0f}GB", str(ram_cap)

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -52,7 +52,7 @@ _NARROW_MASK_BINS = 1 << 14  # equivalent to 2**14
 
 def usable_cores() -> int:
     """
-    Tries to return the number of cores actually available to this process.
+    Tries to return the number of logical cores actually available to this process.
 
     Prefers approaches that honour the CPU affinity mask (taskset, cgroup cpuset,
     HPC pinning, ...) so a pinned process does not oversubscribe. Tries, in order:
@@ -64,18 +64,26 @@ def usable_cores() -> int:
 
     Always returns at least 1.
     """
+    LOGGER.debug("Determining available logical CPU cores, attempting to honour CPU affinity.")
     if hasattr(os, "process_cpu_count"):  # Python 3.13+, honours affinity + PYTHON_CPU_COUNT
         return os.process_cpu_count() or 1
 
+    # fmt: off
     try:
         return len(os.sched_getaffinity(0))  # Linux only, honours affinity |  # ty:ignore[unresolved-attribute]
     except AttributeError:  # macOS / Windows: no sched_getaffinity
         pass
+    # fmt: on
 
     try:  # macOS has no affinity concept -> AttributeError
         return len(psutil.Process().cpu_affinity()) or 1  # works on Windows
     except (AttributeError, NotImplementedError, OSError):
         pass
+
+    LOGGER.debug(
+        "Defaulting to number of logical cores, with no affinity. "
+        "This can lead to overloading if the machine is shared with many other processes."
+    )
     return os.cpu_count() or 1
 
 
@@ -96,12 +104,12 @@ def available_ram_bytes() -> int | None:
 
 def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     """
-    Analytic estimate of the peak resident set sizememory of a single
+    Analytic estimate of the peak resident set size memory of a single
     ``run_per_bunch`` call, in bytes. This is the number of bytes we estimate
-    one worker will peak at.
+    one worker will peak at for a given bunch.
 
     The dominant transient for this is the coefficient array built when calling
-    :func:`omc3.harpy.frequency.windowed_padded_rfft` (which runs allocates memory
+    :func:`omc3.harpy.frequency.windowed_padded_rfft` (which allocates memory
     via `np.dot(u, s_vt_freq[:, mask])`, plus its `np.abs` copy).
 
     Its width is the number of selected frequency lines: the full `2 ** turn_bits`
@@ -197,7 +205,7 @@ def decide_n_workers(
 
     # Compute the number of workers / jobs to dispatch, log it and return
     n_jobs: int = max(1, min(cores_cap, n_bunches, ram_cap))
-    LOGGER.debug(
+    LOGGER.info(
         f"Parallel harpy: n_jobs={n_jobs} (cores_cap={cores_cap}, bunches={n_bunches}, "
         f"ram_cap={ram_cap_str}, peak/bunch~{peak_rss / 1e9:.1f}GB, available~{available_ram_str})"
     )

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -2,15 +2,14 @@
 Parallel
 --------
 
-Private helpers for harpy's per-bunch parallel orchestration:
+Private helper module for harpy's per-bunch parallel orchestration:
 
 - Resource estimation (peak resident memory per bunch, available RAM, usable cores),
 - Dispatched workers count strategy.
 
-The functions are kept free of side effects (aside from querying ``psutil`` for host RAM
-and cores) so the sizing logic can be unit-tested in isolation. The actual dispatch /
-orchestration (and the BLAS thread-capping around it) lives in
-:func:`omc3.harpy.handler.analyse_bunches`.
+The functions are kept free of side effects, aside from querying ``psutil`` for host RAM
+and cores. The actual dispatch / orchestration (and the BLAS thread-capping around it) lives
+in :func:`omc3.harpy.handler.analyse_bunches_parallel`.
 """
 
 from __future__ import annotations

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -170,13 +170,14 @@ def decide_n_workers(
     ----
         The `requested` argument mirrors the `n_jobs` for the harpy parameters. Passing
         `0` selects automatically (all usable cores, RAM permitting); `1` runs serially
-        (which is the old behaviour) and providing an integer value `N` caps the pool at
-        either `N` processes or the automatically determined number (RAM permitting) if
-        the latter is smaller.
+        (which is the old behaviour) and providing an integer value `N` uses up to `N`
+        workers, still bounded by the same safety limits. In other words `N` can only
+        throttle the pool *below* the automatic choice, never oversubscribe it.
 
-        The result is `max(1, min(cores_cap, n_bunches, ram_cap))`, where `ram_cap` is
-        `floor(margin * available_ram / peak_rss_per_bunch)` (or unconstrained when the
-        available RAM could not be determined).
+        The result is `max(1, min(cores_cap, n_bunches, ram_cap))`, where `cores_cap` is
+        `usable_cores()` when automatic or `min(N, usable_cores())` when `N` is requested,
+        and `ram_cap` is `floor(margin * available_ram / peak_rss_per_bunch)` (or
+        unconstrained when the available RAM could not be determined).
 
     Args:
         harpy_input (DotDict): Harpy analysis settings, forwarded to
@@ -193,8 +194,10 @@ def decide_n_workers(
     Returns:
         The number of worker processes to use, always at least 1.
     """
-    # Determine a few parameters
-    cores_cap: int = requested if requested > 0 else usable_cores()
+    # Determine a few parameters. A requested N only ever caps *below* the usable cores:
+    # workers are CPU-bound (BLAS capped to 1 thread), so more workers than cores just
+    # oversubscribes with no gain. Hence N can be throttled down but never oversubscribe.
+    cores_cap: int = min(requested, usable_cores()) if requested > 0 else usable_cores()
     peak_rss: int = estimate_peak_rss_bytes_per_bunch(harpy_input, n_bpms)
     available_ram: int | None = available_ram_bytes()
 

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -78,3 +78,15 @@ def usable_cores() -> int:
     except (AttributeError, NotImplementedError, OSError):
         pass
     return os.cpu_count() or 1
+
+
+def available_ram_bytes() -> int | None:
+    """
+    Returns currently available RAM in bytes (memory that can be
+    given to processes without swapping), via ``psutil``. Returns
+    or ``None`` if it cannot be determined.
+    """
+    try:
+        return psutil.virtual_memory().available
+    except (OSError, RuntimeError, ValueError):
+        return None

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -39,8 +39,8 @@ SAFETY_MARGIN = 0.85
 
 # Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
 # Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating
-# is safe (fewer workers, no OOM), so this doubles as the whole footprint of the narrow-mask path.
-_BASELINE_RSS_BYTES = int(1.5e9)
+# this value is safe (leads to fewer workers for parallelisation and no risk of bein OOM).
+_BASELINE_RSS_BYTES = int(1.5e9)  # 1.5GB peak RSS for a bunch in the lowest consuming scenario
 
 # Generous upper bound on the number of frequency lines selected by the narrow
 # (resonance-band) mask; its transient is negligible next to the baseline.

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -90,3 +90,53 @@ def available_ram_bytes() -> int | None:
         return psutil.virtual_memory().available
     except (OSError, RuntimeError, ValueError):
         return None
+
+
+# ----- Orchestration preparation ----- #
+
+
+def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
+    """
+    Analytic estimate of the peak resident set sizememory of a single
+    ``run_per_bunch`` call, in bytes. This is the number of bytes we estimate
+    one worker will peak at.
+
+    The dominant transient for this is the coefficient array built when calling
+    :func:`omc3.harpy.frequency.windowed_padded_rfft` (which runs allocates memory
+    via `np.dot(u, s_vt_freq[:, mask])`, plus its `np.abs` copy).
+
+    Its width is the number of selected frequency lines: the full `2 ** turn_bits`
+    when `full_spectra` are written (default in the CCC) or cleaning is disabled
+    (all-ones mask), and a negligible narrow band otherwise.
+
+    It scales with ``turn_bits`` and ``n_bpms``, not with the number of turns (the
+    SVD reduces to ``sing_val`` rows before the zero-padded FFT).
+
+    Args:
+        harpy_input (DotDict): Harpy analysis settings from which to query ``turn_bits``,
+            ``to_write`` and ``clean``.
+        n_bpms (int): number of BPMs (use the pre-clean count as a safe upper bound).
+
+    Returns:
+        Estimated peak resident set size (RSS) memory in bytes.
+    """
+    # Neglect the measurement array length (6600 for ACD, 40 000 for ADT) vs zero padding
+    padded: int = 1 << harpy_input.turn_bits  # equivalent to 2 ** turn_bits, frequency bins
+
+    # Determine if we have the extra memory usage from full-spectra
+    full: bool = ("full_spectra" in harpy_input.to_write) or (not harpy_input.clean)
+
+    # Witdh, in frequency bins, of the coefficient array dominating the memory peak,
+    # i.e. how many rfft bins survive get_freq_mask() into the `coefs` array.
+    # - full: the whole half spectrum (2**turn_bits) is materialised, when full_spectra is required.
+    # - otherwise: get_freq_mask() keeps only narrow ± tolerance bands around the tunes / resonances,
+    #              a few thousand bins. We have set _NARROW_MASK_BINS to safely over-estimate that.
+    n_mask: int = padded if full else _NARROW_MASK_BINS
+
+    # At the FFT peak we have two arrays of shape (n_bpms, n_mask) simultaneously:
+    # - coefs = np.dot(u, s_vt_freq[:, mask]), a complex128 array
+    # - np.abs(coefs), its float64 copy
+    transient: int = n_bpms * n_mask * (_BYTES_COMPLEX128 + _BYTES_FLOAT64)
+
+    # Return the estimated peak + minimum memory occupancy (data loading etc)
+    return _BASELINE_RSS_BYTES + transient

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -184,7 +184,7 @@ def decide_n_workers(
     # Determine a few parameters
     cores_cap: int = requested if requested > 0 else usable_cores()
     peak_rss: int = estimate_peak_rss_bytes_per_bunch(harpy_input, n_bpms)
-    available_ram = available_ram_bytes()
+    available_ram: int | None = available_ram_bytes()
 
     # Determine the available RAM to use, including the safety margin
     # If unknown RAM -> do not let it constrain the choice

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -1,6 +1,6 @@
 """
-Parallel
---------
+Harpy Parallel Helpers
+----------------------
 
 Private helper module for harpy's per-bunch parallel orchestration:
 

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -5,12 +5,12 @@ Parallel
 Private helpers for harpy's per-bunch parallel orchestration:
 
 - Resource estimation (peak resident memory per bunch, available RAM, usable cores),
-- Worker count strategy,
-- BLAS thread-capping utilities.
+- Dispatched workers count strategy.
 
 The functions are kept free of side effects (aside from querying ``psutil`` for host RAM
 and cores) so the sizing logic can be unit-tested in isolation. The actual dispatch /
-orchestration lives in :func:`omc3.harpy.handler.analyse_bunches`.
+orchestration (and the BLAS thread-capping around it) lives in
+:func:`omc3.harpy.handler.analyse_bunches`.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ import os
 from typing import TYPE_CHECKING
 
 import psutil
-from threadpoolctl import threadpool_limits
 
 from omc3.utils import logging_tools
 
@@ -142,7 +141,7 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     return _BASELINE_RSS_BYTES + transient
 
 
-def decide_n_jobs(
+def decide_n_workers(
     harpy_input: DotDict,
     n_bunches: int,
     n_bpms: int,

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -116,8 +116,11 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     when `full_spectra` are written (default from the BB GUI in the CCC) or cleaning
     is disabled (all-ones mask), and a negligible narrow band otherwise.
 
-    It scales with ``turn_bits`` and ``n_bpms``, not with the number of turns (the
-    SVD reduces to ``sing_val`` rows before the zero-padded FFT).
+    It scales with ``turn_bits`` and ``n_bpms``, not with the number of turns in the
+    measurement, for two reasons. First, the rfft zero-pads its input to a fixed length
+    set by `2 ** (turn_bits + 1)`, so the measurement's turn count is overshadowed by the
+    padding. Second, the SVD reduces the data to ``sing_val`` rows before that FFT, so the
+    turns never enter the dominant ``(n_bpms, n_mask)`` array at all.
 
     Args:
         harpy_input (DotDict): Harpy analysis settings from which to query ``turn_bits``,

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -8,17 +8,17 @@ Private helpers for harpy's per-bunch parallel orchestration:
 - Worker count strategy,
 - BLAS thread-capping utilities.
 
-The functions are kept free of side effects (aside from reading ``/proc/meminfo``) so
-the sizing logic can be unit-tested in isolation. The actual dispatch / orchestration
-lives in :func:`omc3.harpy.handler.analyse_bunches`.
+The functions are kept free of side effects (aside from querying ``psutil`` for host RAM
+and cores) so the sizing logic can be unit-tested in isolation. The actual dispatch /
+orchestration lives in :func:`omc3.harpy.handler.analyse_bunches`.
 """
 
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+import psutil
 from threadpoolctl import threadpool_limits
 
 from omc3.utils import logging_tools
@@ -50,19 +50,31 @@ _NARROW_MASK_BINS = 1 << 14  # equivalent to 2**14
 
 # ----- System information ----- #
 
+
 def usable_cores() -> int:
     """
-    Returns the number of cores actually available to this process.
+    Tries to return the number of cores actually available to this process.
 
-    Attempts to use approaches which honour the CPU affinity mask (taskset,
-    cgroup cpuset, HPC bindings etc). First via ``os.process_cpu_count`` (which
-    is Python 3.13+) then with ``os.sched_getaffinity`` (which is Linux only, and
-    that is fine in the CCC). Falls back to ``os.cpu_count()`` but that is the
-    total number of CPUs on the machine. Defaults to 1.
+    Prefers approaches that honour the CPU affinity mask (taskset, cgroup cpuset,
+    HPC pinning, ...) so a pinned process does not oversubscribe. Tries, in order:
+
+    - ``os.process_cpu_count`` (Python 3.13+, honours affinity and ``PYTHON_CPU_COUNT``),
+    - ``os.sched_getaffinity`` (Linux only, honours affinity),
+    - ``psutil.Process().cpu_affinity`` (Windows/Linux only, honours affinity),
+    - ``os.cpu_count`` (total logical CPUs, ignores affinity).
+
+    Always returns at least 1.
     """
-    if hasattr(os, "process_cpu_count"):  # Python 3.13+: honours affinity + PYTHON_CPU_COUNT
+    if hasattr(os, "process_cpu_count"):  # Python 3.13+, honours affinity + PYTHON_CPU_COUNT
         return os.process_cpu_count() or 1
+
     try:
-        return len(os.sched_getaffinity(0))  # Linux only, honours affinity mask
-    except AttributeError:  # macOS/Windows
-        return os.cpu_count() or 1
+        return len(os.sched_getaffinity(0))  # Linux only, honours affinity
+    except AttributeError:  # macOS / Windows: no sched_getaffinity
+        pass
+
+    try:  # macOS has no affinity concept -> AttributeError
+        return len(psutil.Process().cpu_affinity()) or 1  # works on Windows
+    except (AttributeError, NotImplementedError, OSError):
+        pass
+    return os.cpu_count() or 1

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -33,9 +33,9 @@ LOGGER: Logger = logging_tools.get_logger(__name__)
 _BYTES_FLOAT64 = 8
 _BYTES_COMPLEX128 = 16
 
-# Fraction of available RAM the worker pool is allowed to use,
-# with a little bit of margin. Could be tweaked.
-SAFETY_MARGIN = 0.85  # 85% to leave room for other processes etc.
+# Default fraction of available RAM that the worker pool is allowed to use.
+# This is meant to leave a little bit of margin. Can be tweaked at function call.
+ALLOWED_RAM_PORTION = 0.85  # 85% to leave room for other processes etc.
 
 # Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
 # Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating
@@ -158,7 +158,7 @@ def decide_n_workers(
     n_bpms: int,
     *,
     requested: int = 0,
-    margin: float = SAFETY_MARGIN,
+    margin: float = ALLOWED_RAM_PORTION,
 ) -> int:
     """
     Choose the number of worker processes for per-bunch analysis. Each bunch is sent

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -133,7 +133,7 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     # Neglect the measurement array length (6600 for ACD, 40 000 for ADT) vs zero padding
     padded: int = 1 << harpy_input.turn_bits  # equivalent to 2 ** turn_bits, frequency bins
 
-    # Determine if we have the extra memory usage from full-spectra
+    # Determine if we have the extra memory usage from full-spectra / no cleaning
     full: bool = ("full_spectra" in harpy_input.to_write) or (not harpy_input.clean)
 
     # Witdh, in frequency bins, of the coefficient array dominating the memory peak,

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -39,7 +39,7 @@ SAFETY_MARGIN = 0.85  # 85% to leave room for other processes etc.
 
 # Empirically measured floor on the optics1 server (64-core, 536 BPMs, lin-only path):
 # Python + NumPy + libraries + one bunch of data + the SVD working set. Overestimating
-# this value is safe (leads to fewer workers for parallelisation and no risk of bein OOM).
+# this value is safe (leads to fewer workers for parallelisation and no risk of being OOM).
 _BASELINE_RSS_BYTES = int(1.5e9)  # 1.5GB peak RSS for a bunch in the lowest consuming scenario
 
 # Generous upper bound on the number of frequency lines selected by the narrow mask.
@@ -136,7 +136,7 @@ def estimate_peak_rss_bytes_per_bunch(harpy_input: DotDict, n_bpms: int) -> int:
     # Determine if we have the extra memory usage from full-spectra / no cleaning
     full: bool = ("full_spectra" in harpy_input.to_write) or (not harpy_input.clean)
 
-    # Witdh, in frequency bins, of the coefficient array dominating the memory peak,
+    # Width, in frequency bins, of the coefficient array dominating the memory peak,
     # i.e. how many rfft bins survive get_freq_mask() into the `coefs` array.
     # - full: the whole half spectrum (2**turn_bits) is materialised, when full_spectra is required.
     # - otherwise: get_freq_mask() keeps only narrow ± tolerance bands around the tunes / resonances,

--- a/omc3/harpy/_parallel.py
+++ b/omc3/harpy/_parallel.py
@@ -68,7 +68,7 @@ def usable_cores() -> int:
         return os.process_cpu_count() or 1
 
     try:
-        return len(os.sched_getaffinity(0))  # Linux only, honours affinity
+        return len(os.sched_getaffinity(0))  # Linux only, honours affinity |  # ty:ignore[unresolved-attribute]
     except AttributeError:  # macOS / Windows: no sched_getaffinity
         pass
 

--- a/omc3/harpy/frequency.py
+++ b/omc3/harpy/frequency.py
@@ -265,7 +265,7 @@ def _calculate_natural_tunes(
         A DataFrame containing the natural tune frequencies, amplitudes, and phases for each BPM.
         The columns are named according to the plane (e.g., 'NATTUNEX', 'NATAMPX', 'NATMUX').
     """
-    # Get the relavant fractional tune
+    # Get the relevant fractional tune
     freq = nattunes["XY".index(plane)] % 1
 
     # Find the natural tune, amplitude and phase

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -79,7 +79,7 @@ def analyse_bunches_parallel(
 
     Each bunch is analysed independently, so the work is spread across a process pool
     whose size is chosen automatically (RAM- and core-aware, see
-    :func:`omc3.harpy._parallel.decide_n_jobs`) unless ``harpy_input.n_jobs`` overrides
+    :func:`omc3.harpy._parallel.decide_n_workers`) unless ``harpy_input.n_jobs`` overrides
     it (``1`` = serial). BLAS is capped to a single thread in both the serial and the
     parallel path, so the results do not depend on the chosen ``n_jobs``.
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -193,7 +193,7 @@ def run_per_bunch(
             else {
                 "X": clean.svd_decomposition(bpm_datas["X"], harpy_input.sing_val),
                 "Y": clean.svd_decomposition(bpm_datas["Y"], harpy_input.sing_val),
-            },
+            },  # ty:ignore[invalid-argument-type]
         )
     )
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -73,7 +73,7 @@ PLANE_TO_NUM: dict[str, int] = {**P2N, "Z": 3}
 
 def analyse_bunches_parallel(
     bunch_tasks: list[tuple[TbtData, str]], harpy_input: DotDict
-) -> list[dict[str, tfs.TfsDataFrame]]:
+) -> list[dict[str, TfsDataFrame]]:
     """
     Run :func:`run_per_bunch` over all bunches, in parallel when beneficial.
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -5,7 +5,7 @@ Handler
 This module contains high-level functions to manage the functionality of ``harpy``.
 
 Various tools are provided to handle the cleaning, frequency analysis and resonance search
-for a single-bunch `TbtData` input. Additionally, a running function exists to everything
+for a single-bunch `TbtData` input. Additionally, a running function exists to handle everything
 for a single bunch, and a high-level overseer function orchestrates the parallelisation of
 different bunches workloads across workers.
 """
@@ -68,6 +68,8 @@ def run_per_bunch(
 ) -> dict[str, tfs.TfsDataFrame]:
     """
     Cleans data, analyses frequencies and searches for resonances.
+    Potentially also writes output data to disk if requested in the
+    harpy parameters.
 
     Args:
         tbt_data: single bunch `TbtData`.

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -95,6 +95,8 @@ def analyse_bunches_parallel(
         return []
 
     # Get the parameters we need here to orchestrate
+    LOGGER.info("Determining parallelisation strategy based on inputs, bunches, CPU cores and RAM.")
+    n_bunches: int = len(bunch_tasks)
     n_bpms: int = max(tbt_data.matrices[0][PLANES[0]].index.size for tbt_data, _ in bunch_tasks)
     n_jobs: int = _parallel.decide_n_workers(
         harpy_input, len(bunch_tasks), n_bpms, requested=harpy_input.n_jobs
@@ -102,11 +104,13 @@ def analyse_bunches_parallel(
 
     # If we are running sequentially (old behaviour)
     if n_jobs == 1:
+        LOGGER.info(f"Performing harmonic analysis sequentially on {n_bunches} bunches.")
         return [
             _run_per_bunch_blas_capped(tbt_data, harpy_input, name) for tbt_data, name in bunch_tasks
         ]
 
     # If we are parallelising across bunches, start a pool and dispatch futures
+    LOGGER.info(f"Starting {n_jobs} concurrent workers.")
     with ProcessPoolExecutor(max_workers=n_jobs) as pool:
         futures: list[Future[dict[str, TfsDataFrame]]] = [
             pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -2,24 +2,29 @@
 Handler
 -------
 
-This module contains high-level functions to manage most functionality of ``harpy``.
-Tools are provided to handle the cleaning, frequency analysis and resonance search for a
-single-bunch `TbtData`.
+This module contains high-level functions to manage the functionality of ``harpy``.
+
+Various tools are provided to handle the cleaning, frequency analysis and resonance search
+for a single-bunch `TbtData` input. Additionally, a running function exists to everything
+for a single bunch, and a high-level overseer function orchestrates the parallelisation of
+different bunches workloads across workers.
 """
 
 from __future__ import annotations
 
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
 import tfs
+from threadpoolctl import threadpool_limits
 
 from omc3.definitions import formats
 from omc3.definitions.constants import PLANE_TO_NUM as P2N
 from omc3.definitions.constants import PLANES
-from omc3.harpy import clean, frequency, kicker
+from omc3.harpy import _parallel, clean, frequency, kicker
 from omc3.harpy.constants import (
     COL_AMP,
     COL_BPM_RES,
@@ -145,6 +150,9 @@ def run_per_bunch(
         if "lin" in harpy_input.to_write:
             _write_lin_tfs(output_file_path, plane, lins[plane])
     return lins
+
+
+# ----- Various helpers ----- #
 
 
 def _get_cut_tbt_matrix(tbt_data: TbtData, turn_indices: list[int], plane: str) -> pd.DataFrame:

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -53,14 +53,64 @@ from omc3.utils import logging_tools
 from omc3.utils.contexts import timeit
 
 if TYPE_CHECKING:
+    from concurrent.futures._base import Future
     from datetime import date
+    from logging import Logger
 
     from generic_parser import DotDict
+    from tfs.frame import TfsDataFrame
     from turn_by_turn import TbtData
 
-LOGGER = logging_tools.get_logger(__name__)
-ALL_PLANES = (*PLANES, "Z")
-PLANE_TO_NUM = {**P2N, "Z": 3}
+LOGGER: Logger = logging_tools.get_logger(__name__)
+
+# ----- Some constants ----- #
+
+ALL_PLANES: tuple[str, str, Literal["Z"]] = (*PLANES, "Z")
+PLANE_TO_NUM: dict[str, int] = {**P2N, "Z": 3}
+
+# ----- Orchestration and Calculation ----- #
+
+
+def analyse_bunches_parallel(
+    bunch_tasks: list[tuple[TbtData, str]], harpy_input: DotDict
+) -> list[dict[str, tfs.TfsDataFrame]]:
+    """
+    Run :func:`run_per_bunch` over all bunches, in parallel when beneficial.
+
+    Each bunch is analysed independently, so the work is spread across a process pool
+    whose size is chosen automatically (RAM- and core-aware, see
+    :func:`omc3.harpy._parallel.decide_n_jobs`) unless ``harpy_input.n_jobs`` overrides
+    it (``1`` = serial). BLAS is capped to a single thread in both the serial and the
+    parallel path, so the results do not depend on the chosen ``n_jobs``.
+
+    Args:
+        bunch_tasks: list of ``(single-bunch TbtData, output filename)`` pairs.
+        harpy_input: analysis settings.
+
+    Returns:
+        One ``{plane: TfsDataFrame}`` dictionary per bunch, in the input order.
+    """
+    if not bunch_tasks:
+        return []
+
+    n_bpms: int = max(tbt_data.matrices[0][PLANES[0]].index.size for tbt_data, _ in bunch_tasks)
+    n_jobs: int = _parallel.decide_n_workers(
+        harpy_input, len(bunch_tasks), n_bpms, requested=harpy_input.n_jobs
+    )
+
+    with threadpool_limits(limits=1, user_api="blas"):
+        if n_jobs == 1:
+            return [
+                _run_per_bunch_blas_capped(tbt_data, harpy_input, name) for tbt_data, name in bunch_tasks
+            ]
+
+        with ProcessPoolExecutor(max_workers=n_jobs) as pool:
+            futures: list[Future[dict[str, TfsDataFrame]]] = [
+                pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)
+                for tbt_data, name in bunch_tasks
+            ]
+            # Iterate in submission order so the returned list matches the input order.
+            return [future.result() for future in futures]
 
 
 def run_per_bunch(

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -110,7 +110,7 @@ def analyse_bunches_parallel(
         ]
 
     # If we are parallelising across bunches, start a pool and dispatch futures
-    LOGGER.info(f"Starting {n_jobs} concurrent workers.")
+    LOGGER.info(f"Dispatching {n_bunches} to {n_jobs} concurrent workers.")
     with ProcessPoolExecutor(max_workers=n_jobs) as pool:
         futures: list[Future[dict[str, TfsDataFrame]]] = [
             pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -84,8 +84,8 @@ def analyse_bunches_parallel(
     parallel path, so the results do not depend on the chosen ``n_jobs``.
 
     Args:
-        bunch_tasks: list of ``(single-bunch TbtData, output filename)`` pairs.
-        harpy_input: analysis settings.
+        bunch_tasks: A list of ``(single-bunch TbtData, output filename)`` pairs.
+        harpy_input (DotDict): The harpy analysis settings.
 
     Returns:
         One ``{plane: TfsDataFrame}`` dictionary per bunch, in the input order.
@@ -98,19 +98,60 @@ def analyse_bunches_parallel(
         harpy_input, len(bunch_tasks), n_bpms, requested=harpy_input.n_jobs
     )
 
-    with threadpool_limits(limits=1, user_api="blas"):
-        if n_jobs == 1:
-            return [
-                _run_per_bunch_blas_capped(tbt_data, harpy_input, name) for tbt_data, name in bunch_tasks
-            ]
+    if n_jobs == 1:
+        return [
+            _run_per_bunch_blas_capped(tbt_data, harpy_input, name) for tbt_data, name in bunch_tasks
+        ]
 
-        with ProcessPoolExecutor(max_workers=n_jobs) as pool:
-            futures: list[Future[dict[str, TfsDataFrame]]] = [
-                pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)
-                for tbt_data, name in bunch_tasks
-            ]
-            # Iterate in submission order so the returned list matches the input order.
-            return [future.result() for future in futures]
+    with ProcessPoolExecutor(max_workers=n_jobs) as pool:
+        futures: list[Future[dict[str, TfsDataFrame]]] = [
+            pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)
+            for tbt_data, name in bunch_tasks
+        ]
+        # Iterate in submission order so the returned list matches the input order.
+        return [future.result() for future in futures]
+
+
+def _run_per_bunch_blas_capped(
+    tbt_data: TbtData, harpy_input: DotDict, output_filename: str
+) -> dict[str, tfs.TfsDataFrame]:
+    """
+    The unit of work dispatched serially or to a pool worker: analyse one bunch with
+    BLAS capped to a single thread.
+
+    This is done because the numpy operations that dominate a bunch's analysis (the SVD
+    in cleaning and the dot-products / FFTs in the frequency analysis) each fan out across
+    a multithreaded BLAS backend by default. However this is a very poor use of threads as
+    it oversubscribes the machine and scales poorly. Forcing single-threaded BLAS is both
+    faster and frees up logical cores that we can use to parallelise across bunches.
+
+    This is only true for the specific operations called within harpy's analysis, so we
+    create this wrapper to cap the BLAS threads at one (1) for the duration of the wrapped
+    `run_per_bunch` function ONLY.
+
+    Note
+    ----
+        The thread capping lives *inside* this function, and not around the pool dispatch in
+        `analyse_bunches_parallel`, because *it has to*. The ``threadpool_limits`` context
+        manager only changes the BLAS library loaded in the *current* process. Since pool
+        workers are separate processes from the main one, using a context manager in the parent
+        (which does no BLAS work, only submits futures) would not reach them.
+
+        Because pools use ``forkserver`` (Linux, 3.14+) or ``spawn`` (macOS/Windows), our workers
+        start as fresh interpreters that re-import NumPy with BLAS defaulting to all cores rather
+        than inheriting the parent's state. Where ``fork`` is the default (Linux, <=3.13) we don't
+        want to rely on an inheritance leak.
+
+        For this reason the cap must execute in the worker, i.e. inside the callable it runs. This
+        means either implementing the cap inside of the `run_per_bunch` function directly (but then
+        one can't run it uncapped in tests or for whatever reason) or creating this little wrapper
+        which is dispatched to the workers and ensures the capping.
+
+        The wrapper is kept at module level so it stays picklable for those non-``fork`` start
+        methods, should there remain any.
+    """
+    with threadpool_limits(limits=1, user_api="blas"):
+        return run_per_bunch(tbt_data, harpy_input, output_filename)
 
 
 def run_per_bunch(

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -90,19 +90,23 @@ def analyse_bunches_parallel(
     Returns:
         One ``{plane: TfsDataFrame}`` dictionary per bunch, in the input order.
     """
+    # Early exit if we're provided nothing somehow
     if not bunch_tasks:
         return []
 
+    # Get the parameters we need here to orchestrate
     n_bpms: int = max(tbt_data.matrices[0][PLANES[0]].index.size for tbt_data, _ in bunch_tasks)
     n_jobs: int = _parallel.decide_n_workers(
         harpy_input, len(bunch_tasks), n_bpms, requested=harpy_input.n_jobs
     )
 
+    # If we are running sequentially (old behaviour)
     if n_jobs == 1:
         return [
             _run_per_bunch_blas_capped(tbt_data, harpy_input, name) for tbt_data, name in bunch_tasks
         ]
 
+    # If we are parallelising across bunches, start a pool and dispatch futures
     with ProcessPoolExecutor(max_workers=n_jobs) as pool:
         futures: list[Future[dict[str, TfsDataFrame]]] = [
             pool.submit(_run_per_bunch_blas_capped, tbt_data, harpy_input, name)
@@ -150,6 +154,8 @@ def _run_per_bunch_blas_capped(
         The wrapper is kept at module level so it stays picklable for those non-``fork`` start
         methods, should there remain any.
     """
+    # Context manager so the cap is released after exiting, although we dispatch
+    # this to different processes and those are terminated after exiting
     with threadpool_limits(limits=1, user_api="blas"):
         return run_per_bunch(tbt_data, harpy_input, output_filename)
 

--- a/omc3/harpy/handler.py
+++ b/omc3/harpy/handler.py
@@ -139,7 +139,10 @@ def run_per_bunch(
                 order_resonances=harpy_input.resonances,
             )
         )
-        lins[plane] = lins[plane].copy()  # defragment after joins / col assignments etc from previous operations
+
+        # Defragment after joins / col assignments within find_resonances
+        lins[plane] = lins[plane].copy()
+
         lins[plane] = _add_calculated_phase_errors(lins[plane])
         lins[plane] = _sync_phase(lins[plane], plane)
         lins[plane] = _rescale_amps_to_main_line_and_compute_noise(lins[plane], plane)
@@ -248,7 +251,9 @@ def _sync_phase(lin_frame: pd.DataFrame, plane: str) -> pd.DataFrame:
     return lin_frame
 
 
-def _compute_headers(df: pd.DataFrame, date: None | date | pd.Timestamp = None) -> dict[str, str | float]:
+def _compute_headers(
+    df: pd.DataFrame, date: None | date | pd.Timestamp = None
+) -> dict[str, str | float]:
     headers = {}
     for plane in ALL_PLANES:
         for prefix in ("", "NAT"):

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -117,8 +117,9 @@ def hole_in_one_entrypoint(opt: DotDict, rest: list[str]) -> None:
 
         Flags: **--bunch_ids**
       - **n_jobs** *(int)*: Number of worker processes for the per-bunch frequency analysis.
-        0 (default) chooses automatically: min(usable cores, number of bunches, RAM budget).
-        1 runs serially. A positive N caps the pool at N processes (still clamped to what fits in RAM).
+        0 (default) chooses automatically: min(usable cores, number of bunches, RAM budget), and
+        falls back to serial if the available RAM cannot be determined. 1 runs serially. A positive
+        N caps the pool at N processes (still clamped to what fits in RAM, when that can be determined).
 
         Flags: **--n_jobs**
         Default: ``0``
@@ -740,8 +741,9 @@ def harpy_params() -> EntryPointParameters:
         default=HARPY_DEFAULTS["n_jobs"],
         help="Number of worker processes for the per-bunch frequency analysis. "
         "0 (default) chooses automatically: min(usable cores, number of bunches, "
-        "RAM budget). 1 runs serially. A positive N caps the pool at N processes "
-        "(still clamped to what fits in RAM).",
+        "RAM budget), and falls back to serial if the available RAM cannot be "
+        "determined. 1 runs serially. A positive N caps the pool at N processes "
+        "(still clamped to what fits in RAM, when that can be determined).",
     )
     # fmt: on
     return params

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -423,8 +423,7 @@ def _run_harpy(harpy_options: DotDict) -> list[Path]:
                 tbt_data, harpy_options, file
             )
         ]
-        lins = handler.analyse_bunches_parallel(bunch_tasks, harpy_options)
-    return lins
+        return handler.analyse_bunches_parallel(bunch_tasks, harpy_options)
 
 
 def _parse_tbt_data(files: Iterable[Path | str | tbt.TbtData], tbt_datatype: str

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -115,6 +115,12 @@ def hole_in_one_entrypoint(opt: DotDict, rest: list[str]) -> None:
         are processed.
 
         Flags: **--bunch_ids**
+      - **n_jobs** *(int)*: Number of worker processes for the per-bunch frequency analysis.
+        0 (default) chooses automatically: min(usable cores, number of bunches, RAM budget).
+        1 runs serially. A positive N caps the pool at N processes (still clamped to what fits in RAM).
+
+        Flags: **--n_jobs**
+        Default: ``0``
       - **unit** *(str)*: A unit of TbT BPM orbit data. All cuts and output are in 'm'.
 
         Flags: **--unit**
@@ -726,6 +732,15 @@ def harpy_params() -> EntryPointParameters:
         default=HARPY_DEFAULTS["resonances"],
         help="Maximum magnet order of resonance lines to calculate.",
     )
+    params.add_parameter(
+        name="n_jobs",
+        type=int,
+        default=HARPY_DEFAULTS["n_jobs"],
+        help="Number of worker processes for the per-bunch frequency analysis. "
+        "0 (default) chooses automatically: min(usable cores, number of bunches, "
+        "RAM budget). 1 runs serially. A positive N caps the pool at N processes "
+        "(still clamped to what fits in RAM).",
+    )
     # fmt: on
     return params
 
@@ -867,6 +882,7 @@ HARPY_DEFAULTS = {
     "to_write": ["lin", "bpm_summary"],
     "tbt_datatype": "lhc",
     "resonances": 4,
+    "n_jobs": 0,
 }
 
 OPTICS_DEFAULTS = {

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -407,17 +407,15 @@ def _run_harpy(harpy_options: DotDict) -> list[Path]:
     """Run frequency analysis on turn-by-turn data."""
     iotools.create_dirs(harpy_options.outputdir)
     with timeit(lambda spanned: LOGGER.info(f"Total time for Harpy: {spanned}")):
-        lins = []
         tbt_datas = _parse_tbt_data(harpy_options.files, harpy_options.tbt_datatype)
-        for tbt_data, file in tbt_datas:
-            lins.extend(
-                [
-                    handler.run_per_bunch(bunch_data, harpy_options, name_for_bunch)
-                    for bunch_data, name_for_bunch in _add_suffix_and_iter_bunches(
-                        tbt_data, harpy_options, file
-                    )
-                ]
+        bunch_tasks = [
+            (bunch_data, name_for_bunch)
+            for tbt_data, file in tbt_datas
+            for bunch_data, name_for_bunch in _add_suffix_and_iter_bunches(
+                tbt_data, harpy_options, file
             )
+        ]
+        lins = handler.analyse_bunches_parallel(bunch_tasks, harpy_options)
     return lins
 
 

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -510,6 +510,10 @@ def _harpy_entrypoint(params: list[str]) -> tuple[DotDict, list[str]]:
         raise AttributeError(
             "The magnet order for resonance lines calculation should be between 2 and 8 (inclusive)."
         )
+    if options.n_jobs < 0:
+        raise AttributeError(
+            "n_jobs must be >= 0 (0 = automatic, 1 = serial, N = N worker processes)."
+        )
     options.outputdir = Path(options.outputdir)
     return options, rest
 

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -384,7 +384,9 @@ def _get_suboptions(
 
 
 def _write_config_file(
-    harpy_opt: dict[str, Any], optics_opt: dict[str, Any], accelerator_opt: dict[str, Any]
+    harpy_opt: dict[str, Any] | None,
+    optics_opt: dict[str, Any] | None,
+    accelerator_opt: dict[str, Any] | None,
 ) -> None:
     """Write the parsed options into a config file for later use."""
     all_options: dict[str, Any] = {}

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -479,7 +479,7 @@ def _add_suffix_and_iter_bunches(
         )
 
 
-def _measure_optics(lins: list[Path], optics_opt: DotDict) -> None:
+def _measure_optics(lins: list[dict[str, TfsDataFrame]], optics_opt: DotDict) -> None:
     """Measure lattice optics from frequency spectra or files."""
     if len(lins) == 0:
         lins = optics_opt.files

--- a/omc3/hole_in_one.py
+++ b/omc3/hole_in_one.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
     from generic_parser import DotDict
+    from tfs import TfsDataFrame
 
 LOGGER = logging_tools.get_logger(__name__)
 
@@ -411,7 +412,7 @@ def _write_config_file(
     save_options_to_config(out_dir / file_name, all_options)
 
 
-def _run_harpy(harpy_options: DotDict) -> list[Path]:
+def _run_harpy(harpy_options: DotDict) -> list[dict[str, TfsDataFrame]]:
     """Run frequency analysis on turn-by-turn data."""
     iotools.create_dirs(harpy_options.outputdir)
     with timeit(lambda spanned: LOGGER.info(f"Total time for Harpy: {spanned}")):

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -183,7 +183,7 @@ def _get_resonance_frequencies(resonances, q):
     freqs = np.mod(resonances @ q, 1)
     freqs = np.where(freqs > .5, 1 - freqs, freqs)
 
-    freqs = freqs.astype(np.float64)  # in case of all zeros, this is int and causes crash with float-nan
+    freqs = freqs.astype(np.float64, copy=False)  # in case of all zeros, this is int and causes crash with float-nan
     freqs[~use_idx] = np.nan
     return freqs
 

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -183,7 +183,7 @@ def _get_resonance_frequencies(resonances, q):
     freqs = np.mod(resonances @ q, 1)
     freqs = np.where(freqs > .5, 1 - freqs, freqs)
 
-    freqs.dtype = np.float64  # in case of all zeros, this is int and causes crash with float-nan
+    freqs = freqs.astype(np.float64)  # in case of all zeros, this is int and causes crash with float-nan
     freqs[~use_idx] = np.nan
     return freqs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ dependencies = [
   "tables >= 3.10.1",
   "requests >= 2.27",
   "odrpack >= 0.4.0",
+  "psutil >= 7.0",
+  "threadpoolctl >= 3.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -8,12 +9,14 @@ import tfs
 import turn_by_turn as tbt
 from generic_parser import DotDict
 from pandas.testing import assert_frame_equal
-from tfs.frame import TfsDataFrame
 from tfs.testing import assert_dict_equal
 
 from omc3.harpy import _parallel
 from omc3.hole_in_one import _add_suffix_and_iter_bunches, hole_in_one_entrypoint
 from tests.accuracy.test_harpy import _get_model_dataframe
+
+if TYPE_CHECKING:
+    from tfs.frame import TfsDataFrame
 
 
 @pytest.mark.basic

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -174,7 +174,13 @@ def test_harpy_ram_clamp_forces_serial(tmp_path, monkeypatch):
 # Helper ---
 
 
-def _run_harpy_multibunch(dirpath: Path, model: pd.DataFrame, bunch_ids, n_jobs: int) -> Path:
+def _run_harpy_multibunch(
+    dirpath: Path,
+    model: pd.DataFrame,
+    bunch_ids,
+    n_jobs: int,
+    to_write: Sequence[str] = ("lin",),
+) -> Path:
     """Write a multi-bunch tbt file and run harpy on it with the given ``n_jobs``."""
     tbt_file = dirpath / "test_file.sdds"
     tbt.write(tbt_file, create_tbt_data(model=model, bunch_ids=bunch_ids, n_turns=512))
@@ -184,7 +190,7 @@ def _run_harpy_multibunch(dirpath: Path, model: pd.DataFrame, bunch_ids, n_jobs:
         autotunes="transverse",
         outputdir=str(dirpath),
         files=[tbt_file],
-        to_write=["lin"],
+        to_write=list(to_write),
         turn_bits=10,
         output_bits=8,
         unit="m",

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -8,6 +8,7 @@ import tfs
 import turn_by_turn as tbt
 from generic_parser import DotDict
 from pandas.testing import assert_frame_equal
+from tfs.frame import TfsDataFrame
 from tfs.testing import assert_dict_equal
 
 from omc3.harpy import _parallel
@@ -143,20 +144,27 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs, to_write):
     parallel_dir.mkdir()
 
     # Run it the old way, serial calculation per bunch
-    serial_file = _run_harpy_multibunch(serial_dir, model, bunch_ids, n_jobs=1)
+    serial_file = _run_harpy_multibunch(serial_dir, model, bunch_ids, n_jobs=1, to_write=to_write)
 
     # Run it the "new" way, parallelising over bunches
-    parallel_file = _run_harpy_multibunch(parallel_dir, model, bunch_ids, n_jobs=n_jobs)
+    parallel_file = _run_harpy_multibunch(parallel_dir, model, bunch_ids, n_jobs=n_jobs, to_write=to_write)
 
+    # Check lin files always, and spectra files (.amps/.freqs) when full spectra were written
+    extensions: list[str] = [".lin"]
+    if "full_spectra" in to_write:
+        extensions += [".amps", ".freqs"]
+
+    # Now we compare results for each bunch
     for bunch in bunch_ids:
-        for plane in "xy":
-            serial = tfs.read(f"{serial_file}_bunchID{bunch}.lin{plane}")
-            parallel = tfs.read(f"{parallel_file}_bunchID{bunch}.lin{plane}")
-            assert_frame_equal(serial, parallel)
-            # Exclude TIME header, which is the (wall-clock) timestamp of each run
-            serial_headers = {k: v for k, v in serial.headers.items() if k != "TIME"}
-            parallel_headers = {k: v for k, v in parallel.headers.items() if k != "TIME"}
-            assert_dict_equal(serial_headers, parallel_headers)
+        for plane in "xy":  # there's output per plane
+            for ext in extensions:  # and we check all relevant output files (potentially incl. spectra)
+                serial: TfsDataFrame = tfs.read(f"{serial_file}_bunchID{bunch}{ext}{plane}")
+                parallel: TfsDataFrame = tfs.read(f"{parallel_file}_bunchID{bunch}{ext}{plane}")
+                assert_frame_equal(serial, parallel)
+                # Exclude TIME header, which is the (wall-clock) timestamp of each run
+                serial_headers = {k: v for k, v in serial.headers.items() if k != "TIME"}
+                parallel_headers = {k: v for k, v in parallel.headers.items() if k != "TIME"}
+                assert_dict_equal(serial_headers, parallel_headers)
 
 
 @pytest.mark.basic

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -8,7 +8,6 @@ import tfs
 import turn_by_turn as tbt
 from generic_parser import DotDict
 from pandas.testing import assert_frame_equal
-from tfs.testing import assert_tfs_frame_equal
 
 from omc3.harpy import _parallel
 from omc3.hole_in_one import _add_suffix_and_iter_bunches, hole_in_one_entrypoint
@@ -122,6 +121,28 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
                     tfs.read(file_path)
                 else:
                     assert not file_path.is_file()
+
+
+# Helper ---
+
+
+def _run_harpy_multibunch(dirpath: Path, model: pd.DataFrame, bunch_ids, n_jobs: int) -> Path:
+    """Write a multi-bunch tbt file and run harpy on it with the given ``n_jobs``."""
+    tbt_file = dirpath / "test_file.sdds"
+    tbt.write(tbt_file, create_tbt_data(model=model, bunch_ids=bunch_ids, n_turns=512))
+    hole_in_one_entrypoint(
+        harpy=True,
+        clean=True,
+        autotunes="transverse",
+        outputdir=str(dirpath),
+        files=[tbt_file],
+        to_write=["lin"],
+        turn_bits=10,
+        output_bits=8,
+        unit="m",
+        n_jobs=n_jobs,
+    )
+    return tbt_file
 
 
 def create_tbt_data(

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -126,10 +126,13 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
 
 @pytest.mark.basic
 @pytest.mark.parametrize("n_jobs", (0, 2))  # keep njobs not too high for CI
-def test_harpy_parallel_matches_serial(tmp_path, n_jobs):
+@pytest.mark.parametrize("to_write", (["lin"], ["lin", "full_spectra"]))
+def test_harpy_parallel_matches_serial(tmp_path, n_jobs, to_write):
     """
-    The auto (n_jobs=0) and forced-pool (n_jobs=2) paths must produce lin files
+    The auto (n_jobs=0) and forced-pool (n_jobs=2) paths must produce output files
     identical to the serial (n_jobs=1) run: only the orchestration changes, not the maths.
+    The ``full_spectra`` case (default from the GUI in the CCC) writes out additional files
+    as``.amps``/``.freqs`` which we will check too.
     """
     model = _get_model_dataframe()
     bunch_ids = [1, 5, 15]

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -136,7 +136,7 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs, to_write):
     The auto (n_jobs=0) and forced-pool (n_jobs=2) paths must produce output files
     identical to the serial (n_jobs=1) run: only the orchestration changes, not the maths.
     The ``full_spectra`` case (default from the GUI in the CCC) writes out additional files
-    as``.amps``/``.freqs`` which we will check too.
+    as ``.amps``/``.freqs`` which we will check too.
     """
     model = _get_model_dataframe()
     bunch_ids = [1, 5, 15]

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -150,7 +150,9 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs, to_write):
     serial_file = _run_harpy_multibunch(serial_dir, model, bunch_ids, n_jobs=1, to_write=to_write)
 
     # Run it the "new" way, parallelising over bunches
-    parallel_file = _run_harpy_multibunch(parallel_dir, model, bunch_ids, n_jobs=n_jobs, to_write=to_write)
+    parallel_file = _run_harpy_multibunch(
+        parallel_dir, model, bunch_ids, n_jobs=n_jobs, to_write=to_write
+    )
 
     # Check lin files always, and spectra files (.amps/.freqs) when full spectra were written
     extensions: list[str] = [".lin"]
@@ -160,7 +162,9 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs, to_write):
     # Now we compare results for each bunch
     for bunch in bunch_ids:
         for plane in "xy":  # there's output per plane
-            for ext in extensions:  # and we check all relevant output files (potentially incl. spectra)
+            for (
+                ext
+            ) in extensions:  # and we check all relevant output files (potentially incl. spectra)
                 serial: TfsDataFrame = tfs.read(f"{serial_file}_bunchID{bunch}{ext}{plane}")
                 parallel: TfsDataFrame = tfs.read(f"{parallel_file}_bunchID{bunch}{ext}{plane}")
                 assert_frame_equal(serial, parallel)
@@ -192,6 +196,22 @@ def test_analyse_no_tasks_returns_empty():
     an empty list, without computing a strategy or starting a pool.
     """
     assert handler.analyse_bunches_parallel([], DotDict(n_jobs=0)) == []
+
+
+@pytest.mark.basic
+def test_harpy_negative_n_jobs_is_rejected(tmp_path):
+    """
+    A negative --n_jobs is rejected up front by the harpy entrypoint validation,
+    before any file is read (so the input path need not exist).
+    """
+    with pytest.raises(AttributeError, match="n_jobs must be >= 0"):
+        hole_in_one_entrypoint(
+            harpy=True,
+            autotunes="transverse",
+            outputdir=str(tmp_path),
+            files=["does_not_need_to_exist.sdds"],
+            n_jobs=-1,
+        )
 
 
 # Helper ---

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -125,7 +125,7 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
 
 
 @pytest.mark.basic
-@pytest.mark.parametrize("n_jobs", (0, 2))
+@pytest.mark.parametrize("n_jobs", (0, 2))  # keep njobs not too high for CI
 def test_harpy_parallel_matches_serial(tmp_path, n_jobs):
     """
     The auto (n_jobs=0) and forced-pool (n_jobs=2) paths must produce lin files
@@ -139,7 +139,10 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs):
     parallel_dir = tmp_path / "parallel"
     parallel_dir.mkdir()
 
+    # Run it the old way, serial calculation per bunch
     serial_file = _run_harpy_multibunch(serial_dir, model, bunch_ids, n_jobs=1)
+
+    # Run it the "new" way, parallelising over bunches
     parallel_file = _run_harpy_multibunch(parallel_dir, model, bunch_ids, n_jobs=n_jobs)
 
     for bunch in bunch_ids:

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -11,7 +11,7 @@ from generic_parser import DotDict
 from pandas.testing import assert_frame_equal
 from tfs.testing import assert_dict_equal
 
-from omc3.harpy import _parallel
+from omc3.harpy import _parallel, handler
 from omc3.hole_in_one import _add_suffix_and_iter_bunches, hole_in_one_entrypoint
 from tests.accuracy.test_harpy import _get_model_dataframe
 
@@ -183,6 +183,15 @@ def test_harpy_ram_clamp_forces_serial(tmp_path, monkeypatch):
     for bunch in bunch_ids:
         for plane in "xy":
             assert Path(f"{tbt_file}_bunchID{bunch}.lin{plane}").is_file()
+
+
+@pytest.mark.basic
+def test_analyse_no_tasks_returns_empty():
+    """
+    With no bunches to process, the orchestrator should return early with
+    an empty list, without computing a strategy or starting a pool.
+    """
+    assert handler.analyse_bunches_parallel([], DotDict(n_jobs=0)) == []
 
 
 # Helper ---

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -8,6 +8,7 @@ import tfs
 import turn_by_turn as tbt
 from generic_parser import DotDict
 from pandas.testing import assert_frame_equal
+from tfs.testing import assert_dict_equal
 
 from omc3.harpy import _parallel
 from omc3.hole_in_one import _add_suffix_and_iter_bunches, hole_in_one_entrypoint
@@ -121,6 +122,51 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
                     tfs.read(file_path)
                 else:
                     assert not file_path.is_file()
+
+
+@pytest.mark.basic
+@pytest.mark.parametrize("n_jobs", (0, 2))
+def test_harpy_parallel_matches_serial(tmp_path, n_jobs):
+    """
+    The auto (n_jobs=0) and forced-pool (n_jobs=2) paths must produce lin files
+    identical to the serial (n_jobs=1) run: only the orchestration changes, not the maths.
+    """
+    model = _get_model_dataframe()
+    bunch_ids = [1, 5, 15]
+
+    serial_dir = tmp_path / "serial"
+    serial_dir.mkdir()
+    parallel_dir = tmp_path / "parallel"
+    parallel_dir.mkdir()
+
+    serial_file = _run_harpy_multibunch(serial_dir, model, bunch_ids, n_jobs=1)
+    parallel_file = _run_harpy_multibunch(parallel_dir, model, bunch_ids, n_jobs=n_jobs)
+
+    for bunch in bunch_ids:
+        for plane in "xy":
+            serial = tfs.read(f"{serial_file}_bunchID{bunch}.lin{plane}")
+            parallel = tfs.read(f"{parallel_file}_bunchID{bunch}.lin{plane}")
+            assert_frame_equal(serial, parallel)
+            # TIME is the (wall-clock) timestamp of each run, so exclude it; the rest
+            # of the headers (tunes, units) must match.
+            serial_headers = {k: v for k, v in serial.headers.items() if k != "TIME"}
+            parallel_headers = {k: v for k, v in parallel.headers.items() if k != "TIME"}
+            assert_dict_equal(serial_headers, parallel_headers)
+
+
+@pytest.mark.basic
+def test_harpy_ram_clamp_forces_serial(tmp_path, monkeypatch):
+    """
+    A tiny available-RAM reading must clamp the automatic pool down to a single
+    worker, and the run must still complete and produce the expected lin files.
+    """
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(1e6))  # 1 MB RAM
+    model = _get_model_dataframe()
+    bunch_ids = [1, 5, 15]
+    tbt_file = _run_harpy_multibunch(tmp_path, model, bunch_ids, n_jobs=0)
+    for bunch in bunch_ids:
+        for plane in "xy":
+            assert Path(f"{tbt_file}_bunchID{bunch}.lin{plane}").is_file()
 
 
 # Helper ---

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -7,7 +7,10 @@ import pytest
 import tfs
 import turn_by_turn as tbt
 from generic_parser import DotDict
+from pandas.testing import assert_frame_equal
+from tfs.testing import assert_tfs_frame_equal
 
+from omc3.harpy import _parallel
 from omc3.hole_in_one import _add_suffix_and_iter_bunches, hole_in_one_entrypoint
 from tests.accuracy.test_harpy import _get_model_dataframe
 
@@ -15,7 +18,7 @@ from tests.accuracy.test_harpy import _get_model_dataframe
 @pytest.mark.basic
 @pytest.mark.parametrize("suffix", ("_my_suffix", None))
 def test_input_suffix_and_single_bunch(suffix):
-    """ Tests the function :func:`omc3.hole_in_one._add_suffix_and_loop_over_bunches`
+    """Tests the function :func:`omc3.hole_in_one._add_suffix_and_loop_over_bunches`
     by checking that the suffix is attached to single-bunch files."""
     input_name = "input_file.sdds"
     options = DotDict(
@@ -42,7 +45,7 @@ def test_input_suffix_and_single_bunch(suffix):
 @pytest.mark.parametrize("suffix", ("_my_suffix", None))
 @pytest.mark.parametrize("bunches", (None, (1, 15)))
 def test_input_suffix_and_multibunch(suffix, bunches):
-    """ Tests the function :func:`omc3.hole_in_one._add_suffix_and_loop_over_bunches`
+    """Tests the function :func:`omc3.hole_in_one._add_suffix_and_loop_over_bunches`
     by checking that the suffixes are attached to multi-bunch files and they are
     split up into single-bunch files correctly."""
     input_name = "input_file.sdds"
@@ -57,8 +60,10 @@ def test_input_suffix_and_multibunch(suffix, bunches):
     )
     n_data = 0
     bunch_ids = bunches or tbt_data.bunch_ids
-    matrices =  [tbt_data.matrices[tbt_data.bunch_ids.index(id_)] for id_ in bunch_ids]
-    for (data, filename_with_suffix), bunch_id, matrix in zip(_add_suffix_and_iter_bunches(tbt_data, options, input_name), bunch_ids, matrices):
+    matrices = [tbt_data.matrices[tbt_data.bunch_ids.index(id_)] for id_ in bunch_ids]
+    for (data, filename_with_suffix), bunch_id, matrix in zip(
+        _add_suffix_and_iter_bunches(tbt_data, options, input_name), bunch_ids, matrices
+    ):
         bunch_str = f"_bunchID{bunch_id}"
         suffix_str = suffix or ""
         assert filename_with_suffix == f"{input_name}{bunch_str}{suffix_str}"
@@ -78,7 +83,7 @@ def test_input_suffix_and_multibunch(suffix, bunches):
 @pytest.mark.parametrize("suffix", ("_my_suffix", None))
 @pytest.mark.parametrize("bunches", (None, (1, 15)))
 def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
-    """ Runs harpy and checks that the right files are created.
+    """Runs harpy and checks that the right files are created.
 
     Only with bunchID as we have enough tests in the accuracy tests,
     that implicitly check that the single-bunch files are created.
@@ -91,18 +96,19 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
     tbt.write(tbt_file, create_tbt_data(model=model, bunch_ids=all_bunches))
 
     # Run harpy ---
-    hole_in_one_entrypoint(harpy=True,
-                           clean=False,
-                           autotunes="transverse",
-                           outputdir=str(tmp_path),
-                           files=[tbt_file],
-                           to_write=["lin", "spectra"],
-                           turn_bits=4,  # make it fast
-                           output_bits=4,
-                           unit="m",
-                           suffix=suffix,
-                           bunch_ids=None if bunches is None else list(bunches),
-                           )
+    hole_in_one_entrypoint(
+        harpy=True,
+        clean=False,
+        autotunes="transverse",
+        outputdir=str(tmp_path),
+        files=[tbt_file],
+        to_write=["lin", "spectra"],
+        turn_bits=4,  # make it fast
+        output_bits=4,
+        unit="m",
+        suffix=suffix,
+        bunch_ids=None if bunches is None else list(bunches),
+    )
 
     # Check that the right files are created ---
     exts = [".lin", ".freqs", ".amps"]
@@ -118,9 +124,9 @@ def test_harpy_with_suffix_and_bunchid(tmp_path, suffix, bunches):
                     assert not file_path.is_file()
 
 
-# Helper ---
-
-def create_tbt_data(model: pd.DataFrame, bunch_ids: Sequence[int] = (0, ), n_turns: int = 10) -> tbt.TbtData:
+def create_tbt_data(
+    model: pd.DataFrame, bunch_ids: Sequence[int] = (0,), n_turns: int = 10
+) -> tbt.TbtData:
     """Create simple turn-by-turn data based on the given model.
 
     Args:
@@ -131,8 +137,12 @@ def create_tbt_data(model: pd.DataFrame, bunch_ids: Sequence[int] = (0, ), n_tur
     Returns:
         tbt.TbtData: Created TbtData
     """
+    # fmt: off
     ints = np.arange(n_turns) - n_turns / 2
     data_x = model.loc[:, "AMPX"].to_numpy()[:, None] * np.cos(2 * np.pi * (model.loc[:, "MUX"].to_numpy()[:, None] + model.loc[:, "TUNEX"].to_numpy()[:, None] * ints[None, :]))
     data_y = model.loc[:, "AMPY"].to_numpy()[:, None] * np.cos(2 * np.pi * (model.loc[:, "MUY"].to_numpy()[:, None] + model.loc[:, "TUNEY"].to_numpy()[:, None] * ints[None, :]))
     matrix = tbt.TransverseData(X=pd.DataFrame(data=data_x, index=model.index), Y=pd.DataFrame(data=data_y, index=model.index))
-    return tbt.TbtData(matrices=[matrix] * len(bunch_ids), bunch_ids=list(bunch_ids), nturns=n_turns)
+    # fmt: on
+    return tbt.TbtData(
+        matrices=[matrix] * len(bunch_ids), bunch_ids=list(bunch_ids), nturns=n_turns
+    )

--- a/tests/unit/test_harpy.py
+++ b/tests/unit/test_harpy.py
@@ -150,8 +150,7 @@ def test_harpy_parallel_matches_serial(tmp_path, n_jobs):
             serial = tfs.read(f"{serial_file}_bunchID{bunch}.lin{plane}")
             parallel = tfs.read(f"{parallel_file}_bunchID{bunch}.lin{plane}")
             assert_frame_equal(serial, parallel)
-            # TIME is the (wall-clock) timestamp of each run, so exclude it; the rest
-            # of the headers (tunes, units) must match.
+            # Exclude TIME header, which is the (wall-clock) timestamp of each run
             serial_headers = {k: v for k, v in serial.headers.items() if k != "TIME"}
             parallel_headers = {k: v for k, v in parallel.headers.items() if k != "TIME"}
             assert_dict_equal(serial_headers, parallel_headers)

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -107,6 +107,14 @@ def test_decide_n_jobs_requested_still_ram_clamped(monkeypatch):
 
 
 @pytest.mark.basic
+def test_decide_n_jobs_requested_clamped_to_cores(monkeypatch):
+    """A requested N above the usable cores is throttled down: we never oversubscribe cores."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores only
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(1e12))  # 1000GB of RAM!
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=200) == 8
+
+
+@pytest.mark.basic
 def test_decide_n_jobs_ram_unknown_falls_back_to_cores_and_bunches(monkeypatch):
     """Ensure with no RAM info we fall back to min between n_cores and n_bunches."""
     monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -2,6 +2,7 @@
 Unit tests for the harpy parallel orchestration strategy in omc3.harpy._parallel.
 """
 
+import logging
 import os
 from types import SimpleNamespace
 
@@ -180,12 +181,49 @@ def test_decide_n_jobs_requested_clamped_to_cores(monkeypatch):
 
 
 @pytest.mark.basic
-def test_decide_n_jobs_ram_unknown_falls_back_to_cores_and_bunches(monkeypatch):
-    """Ensure with no RAM info we fall back to min between n_cores and n_bunches."""
+def test_decide_n_jobs_ram_unknown_falls_back_to_serial(monkeypatch):
+    """
+    With no RAM info we cannot size the pool safely, so deciding automatically
+    conservatively falls back to a single worker (an OOM-killed worker would take
+    the whole pool down with it, so 'slow' is a better failure mode than 'dead').
+    """
     monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores
     monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: None)  # Unavailable RAM info
-    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=0) == 8  # n_cores
-    assert _parallel.decide_n_workers(_min_harpy_input(), 3, 536, requested=0) == 3  # n_bunches
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=0) == 1
+    assert _parallel.decide_n_workers(_min_harpy_input(), 3, 536, requested=0) == 1
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_ram_unknown_honours_explicit_request(monkeypatch):
+    """
+    An explicitly requested --n_jobs lifts the fallback above: the user knows their
+    machine better than a detection which just failed. The cores and bunches caps
+    still apply, though.
+    """
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: None)  # Unavailable RAM info
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=4) == 4  # requested
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=200) == 8  # n_cores
+    assert _parallel.decide_n_workers(_min_harpy_input(), 3, 536, requested=64) == 3  # n_bunches
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_ram_unknown_warns(monkeypatch, caplog):
+    """
+    Both unknown-RAM paths warn: the automatic one so that an unexpected serial run
+    can be diagnosed, and the explicit one so the user knows we did not validate it.
+    """
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: None)  # Unavailable RAM info
+
+    with caplog.at_level(logging.WARNING):
+        _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=0)
+    assert "falling back to a single worker" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=4)
+    assert "explicitly requested n_jobs=4" in caplog.text
 
 
 @pytest.mark.basic

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -2,6 +2,9 @@
 Unit tests for the harpy parallel orchestration strategy in omc3.harpy._parallel.
 """
 
+import os
+from types import SimpleNamespace
+
 import pytest
 from generic_parser import DotDict
 
@@ -130,3 +133,48 @@ def test_decide_n_jobs_never_below_one(monkeypatch):
     monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: 1)  # 1 byte!
     assert _parallel.decide_n_workers(_min_harpy_input(), 0, 536, requested=0) == 1
     assert _parallel.decide_n_workers(_min_harpy_input(), 10, 536, requested=0) == 1
+
+
+# ----- Detection of Usable Cores ----- #
+
+# Our coverage CI runs on Python 3.14+, where usable_cores() returns early inside of
+# os.process_cpu_count(). These tests remove the attribute to force (and cover) each
+# fallback: os.sched_getaffinity -> psutil affinity -> os.cpu_count.
+
+
+@pytest.mark.basic
+def test_usable_cores_via_sched_getaffinity(monkeypatch):
+    """
+    Without os.process_cpu_count(), the Linux os.sched_getaffinity path is used.
+    """
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
+    assert _parallel.usable_cores() == 3
+
+
+@pytest.mark.basic
+def test_usable_cores_via_psutil_affinity(monkeypatch):
+    """
+    Without process_cpu_count() and sched_getaffinity(), psutil's affinity is used.
+    """
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
+    monkeypatch.setattr(
+        _parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=lambda: [0, 1, 2, 3])
+    )
+    assert _parallel.usable_cores() == 4
+
+
+@pytest.mark.basic
+def test_usable_cores_falls_back_to_cpu_count(monkeypatch):
+    """
+    When no affinity source is available, fall back to os.cpu_count().
+    """
+    def _raise():
+        raise NotImplementedError
+
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
+    monkeypatch.setattr(_parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=_raise))
+    monkeypatch.setattr(os, "cpu_count", lambda: 7)  # patch as well as we can't predict the CI machine
+    assert _parallel.usable_cores() == 7

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -56,3 +56,69 @@ def test_no_clean_triggers_full_transient():
     narrow: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(clean=True, to_write=["lin"]), 536)
     no_clean: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(clean=False, to_write=["lin"]), 536)
     assert no_clean > 5 * narrow
+
+
+# ----- Determination of Number of Parallel Workers ----- #
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_core_bound(monkeypatch):
+    """So much RAM the number of cores limits us."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores only
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(1e12))  # 1000GB of RAM!
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=0) == 8
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_bunch_bound(monkeypatch):
+    """So few bunches we should just dispatch one worker for each."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 64)  # 64 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(1e12))  # 1000GB of RAM!
+    assert _parallel.decide_n_workers(_min_harpy_input(), 3, 536, requested=0) == 3
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_ram_bound(monkeypatch):
+    """Available RAM would have us out of memory so it determines the number of workers."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 64)  # 64 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(100e9))  # 100 GB RAM
+    harpy_input: DotDict = _min_harpy_input(to_write=["lin", "full_spectra"])  # ~15 GB/worker
+    peak: int = _parallel.estimate_peak_rss_bytes_per_bunch(harpy_input, 536)
+    n_workers: int = _parallel.decide_n_workers(harpy_input, 64, 536, requested=0)
+    assert n_workers == int(_parallel.SAFETY_MARGIN * 100e9 / peak)
+    assert n_workers < 10  # RAM-bound, well below the 64 cores / number of bunches (we properly throttle)
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_requested_serial(monkeypatch):
+    """Ensure the provided --n_jobs is used if RAM permits it."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 64)  # 64 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(1e12))  # 1000GB of RAM!
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=1) == 1
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_requested_still_ram_clamped(monkeypatch):
+    """Ensure the provided --n_jobs is bypassed if RAM limits it."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 64)  # 64 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: int(30e9))  # 30 GB of RAM
+    harpy_input = _min_harpy_input(to_write=["lin", "full_spectra"])  # ~15 GB/worker -> ~1 fits with safety margin
+    assert _parallel.decide_n_workers(harpy_input, 100, 536, requested=16) == 1
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_ram_unknown_falls_back_to_cores_and_bunches(monkeypatch):
+    """Ensure with no RAM info we fall back to min between n_cores and n_bunches."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 8)  # 8 cores
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: None)  # Unavailable RAM info
+    assert _parallel.decide_n_workers(_min_harpy_input(), 100, 536, requested=0) == 8  # n_cores
+    assert _parallel.decide_n_workers(_min_harpy_input(), 3, 536, requested=0) == 3  # n_bunches
+
+
+@pytest.mark.basic
+def test_decide_n_jobs_never_below_one(monkeypatch):
+    """Ensure with a very limited system we still attribute 1 worker."""
+    monkeypatch.setattr(_parallel, "usable_cores", lambda: 1)  # 1 core!
+    monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: 1)  # 1 byte!
+    assert _parallel.decide_n_workers(_min_harpy_input(), 0, 536, requested=0) == 1
+    assert _parallel.decide_n_workers(_min_harpy_input(), 10, 536, requested=0) == 1

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -150,7 +150,7 @@ def test_decide_n_jobs_ram_bound(monkeypatch):
     harpy_input: DotDict = _min_harpy_input(to_write=["lin", "full_spectra"])  # ~15 GB/worker
     peak: int = _parallel.estimate_peak_rss_bytes_per_bunch(harpy_input, 536)
     n_workers: int = _parallel.decide_n_workers(harpy_input, 64, 536, requested=0)
-    assert n_workers == int(_parallel.SAFETY_MARGIN * 100e9 / peak)
+    assert n_workers == int(_parallel.ALLOWED_RAM_PORTION * 100e9 / peak)
     assert n_workers < 10  # RAM-bound, well below the 64 cores / number of bunches (we properly throttle)
 
 

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -178,3 +178,19 @@ def test_usable_cores_falls_back_to_cpu_count(monkeypatch):
     monkeypatch.setattr(_parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=_raise))
     monkeypatch.setattr(os, "cpu_count", lambda: 7)  # patch as well as we can't predict the CI machine
     assert _parallel.usable_cores() == 7
+
+
+# ----- Detection of Available RAM ----- #
+
+
+@pytest.mark.basic
+def test_available_ram_bytes_returns_none_on_error(monkeypatch):
+    """
+    If psutil cannot read memory, check that available_ram_bytes()
+    reports None (and RAM remains unconstrained).
+    """
+    def _raise():
+        raise OSError
+
+    monkeypatch.setattr(_parallel.psutil, "virtual_memory", _raise)
+    assert _parallel.available_ram_bytes() is None

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -16,6 +16,68 @@ def _min_harpy_input(turn_bits=20, to_write=("lin",), clean=True) -> DotDict:
     return DotDict(turn_bits=turn_bits, to_write=list(to_write), clean=clean)
 
 
+
+# ----- Detection of Available RAM ----- #
+
+
+@pytest.mark.basic
+def test_available_ram_bytes_returns_none_on_error(monkeypatch):
+    """
+    If psutil cannot read memory, check that available_ram_bytes()
+    reports None (and RAM remains unconstrained).
+    """
+    def _raise():
+        raise OSError
+
+    monkeypatch.setattr(_parallel.psutil, "virtual_memory", _raise)
+    assert _parallel.available_ram_bytes() is None
+
+
+# ----- Detection of Usable Cores ----- #
+
+# Our coverage CI runs on Python 3.14+, where usable_cores() returns early inside of
+# os.process_cpu_count(). These tests remove the attribute to force (and cover) each
+# fallback: os.sched_getaffinity -> psutil affinity -> os.cpu_count.
+
+
+@pytest.mark.basic
+def test_usable_cores_via_sched_getaffinity(monkeypatch):
+    """
+    Without os.process_cpu_count(), the Linux os.sched_getaffinity path is used.
+    """
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
+    assert _parallel.usable_cores() == 3
+
+
+@pytest.mark.basic
+def test_usable_cores_via_psutil_affinity(monkeypatch):
+    """
+    Without process_cpu_count() and sched_getaffinity(), psutil's affinity is used.
+    """
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
+    monkeypatch.setattr(
+        _parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=lambda: [0, 1, 2, 3])
+    )
+    assert _parallel.usable_cores() == 4
+
+
+@pytest.mark.basic
+def test_usable_cores_falls_back_to_cpu_count(monkeypatch):
+    """
+    When no affinity source is available, fall back to os.cpu_count().
+    """
+    def _raise():
+        raise NotImplementedError
+
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
+    monkeypatch.setattr(_parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=_raise))
+    monkeypatch.setattr(os, "cpu_count", lambda: 7)  # patch as well as we can't predict the CI machine
+    assert _parallel.usable_cores() == 7
+
+
 # ----- Estimation of Peak RSS per Bunch ----- #
 
 
@@ -133,64 +195,3 @@ def test_decide_n_jobs_never_below_one(monkeypatch):
     monkeypatch.setattr(_parallel, "available_ram_bytes", lambda: 1)  # 1 byte!
     assert _parallel.decide_n_workers(_min_harpy_input(), 0, 536, requested=0) == 1
     assert _parallel.decide_n_workers(_min_harpy_input(), 10, 536, requested=0) == 1
-
-
-# ----- Detection of Usable Cores ----- #
-
-# Our coverage CI runs on Python 3.14+, where usable_cores() returns early inside of
-# os.process_cpu_count(). These tests remove the attribute to force (and cover) each
-# fallback: os.sched_getaffinity -> psutil affinity -> os.cpu_count.
-
-
-@pytest.mark.basic
-def test_usable_cores_via_sched_getaffinity(monkeypatch):
-    """
-    Without os.process_cpu_count(), the Linux os.sched_getaffinity path is used.
-    """
-    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
-    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
-    assert _parallel.usable_cores() == 3
-
-
-@pytest.mark.basic
-def test_usable_cores_via_psutil_affinity(monkeypatch):
-    """
-    Without process_cpu_count() and sched_getaffinity(), psutil's affinity is used.
-    """
-    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
-    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
-    monkeypatch.setattr(
-        _parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=lambda: [0, 1, 2, 3])
-    )
-    assert _parallel.usable_cores() == 4
-
-
-@pytest.mark.basic
-def test_usable_cores_falls_back_to_cpu_count(monkeypatch):
-    """
-    When no affinity source is available, fall back to os.cpu_count().
-    """
-    def _raise():
-        raise NotImplementedError
-
-    monkeypatch.delattr(os, "process_cpu_count", raising=False)  # simulate lower Python
-    monkeypatch.delattr(os, "sched_getaffinity", raising=False)  # simulate non-Linux
-    monkeypatch.setattr(_parallel.psutil, "Process", lambda: SimpleNamespace(cpu_affinity=_raise))
-    monkeypatch.setattr(os, "cpu_count", lambda: 7)  # patch as well as we can't predict the CI machine
-    assert _parallel.usable_cores() == 7
-
-
-# ----- Detection of Available RAM ----- #
-
-
-@pytest.mark.basic
-def test_available_ram_bytes_returns_none_on_error(monkeypatch):
-    """
-    If psutil cannot read memory, check that available_ram_bytes()
-    reports None (and RAM remains unconstrained).
-    """
-    def _raise():
-        raise OSError
-
-    monkeypatch.setattr(_parallel.psutil, "virtual_memory", _raise)
-    assert _parallel.available_ram_bytes() is None

--- a/tests/unit/test_harpy_parallel.py
+++ b/tests/unit/test_harpy_parallel.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for the harpy parallel orchestration strategy in omc3.harpy._parallel.
+"""
+
+import pytest
+from generic_parser import DotDict
+
+from omc3.harpy import _parallel
+
+
+def _min_harpy_input(turn_bits=20, to_write=("lin",), clean=True) -> DotDict:
+    """Just the ones we query from harpy input."""
+    return DotDict(turn_bits=turn_bits, to_write=list(to_write), clean=clean)
+
+
+# ----- Estimation of Peak RSS per Bunch ----- #
+
+
+@pytest.mark.basic
+def test_peak_rss_scales_linearly_with_bpms():
+    base: int = _parallel._BASELINE_RSS_BYTES
+    hin: DotDict = _min_harpy_input(to_write=["lin", "full_spectra"])
+    p500: int = _parallel.estimate_peak_rss_bytes_per_bunch(hin, 500)
+    p1000: int = _parallel.estimate_peak_rss_bytes_per_bunch(hin, 1000)
+    p2000: int = _parallel.estimate_peak_rss_bytes_per_bunch(hin, 2000)
+    # The transient (everything above the constant baseline) scales with n_bpms.
+    assert (p1000 - base) == 2 * (p500 - base)
+    assert (p2000 - base) == 4 * (p500 - base)
+
+
+@pytest.mark.basic
+def test_peak_rss_doubles_with_turn_bits():
+    """Increasing turn_bits by 1 should double the peak RSS since it's used as a power of 2."""
+    base: int = _parallel._BASELINE_RSS_BYTES
+    p20: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(20, ["lin", "full_spectra"]), 536)
+    p21: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(21, ["lin", "full_spectra"]), 536)
+    p22: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(22, ["lin", "full_spectra"]), 536)
+    assert (p21 - base) == 2 * (p20 - base)
+    assert (p22 - base) == 2 * (p21 - base)
+
+
+@pytest.mark.basic
+def test_full_spectra_much_heavier_than_lin_only():
+    """
+    When providing full_spectra (as in the CCC) the estimated peak RSS should drastically increase.
+    See inside the estimate_peak_rss_bytes_per_bunch docstring and comments for why.
+    """
+    lin: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(to_write=["lin"]), 536)
+    full: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(to_write=["lin", "full_spectra"]), 536)
+    assert full > 5 * lin
+
+
+@pytest.mark.basic
+def test_no_clean_triggers_full_transient():
+    """Similarly, no cleaning should also drastically up the estimate."""
+    narrow: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(clean=True, to_write=["lin"]), 536)
+    no_clean: int = _parallel.estimate_peak_rss_bytes_per_bunch(_min_harpy_input(clean=False, to_write=["lin"]), 536)
+    assert no_clean > 5 * narrow


### PR DESCRIPTION
This PR introduces a parallelisation strategy for the `harpy` harmonic analysis.
Let me preface this by saying: no code that does any of the calculations has been touched.

This is a long PR text, I'll try to split it.

## Context

Currently, when performing harmonic analysis for the bunches in a file, `harpy` runs the analysis serially, bunch after bunch. We have a wall time of ~25-30s for analysing a bunch so this scales roughly as `n_bunches * 30 seconds`.

The operations within `harpy` (SVD, some big dot products, FFTs) dispatch hungrily across all available threads via `BLAS`.

As it turns out for our operations this is not a great idea, and benchmarks show that limiting `BLAS` to a single thread gives similar results (slightly faster for SVD, slightly slower for dot product, all within 5-10% in any case). This is an opportunity to free up the threads and parallelise differently.

## What is changed

The parallelisation strategy is changed. Instead of running bunch after bunch and letting `BLAS` eat up all threads unproductively, the following is done:
- The `harpy` workload of single bunches sets a hard cap for `BLAS` to one (1) thread,
- The bunches are now parallelised across workers.

## Implementation

1. Most of the new code is in a new `omc3.harpy._parallel` module, with heuristics to determine the number of workers to dispatch to. This is done based on estimated peak RSS for a given bunch (from the TbT data and from the `harpy` options), the detected number of available logical cores and RAM, and user input (more on that later).

2. The main function in `harpy` now calls this heuristic first then dispatches work. It performs the same thing as the current behaviour if `n_jobs=1`, and starts a `ProcessPoolExecutor` to parallelise across bunches if `n_jobs>1`.

3. A CLI flag `--n_jobs` is provided to give the user (and GUI) control over this strategy. Providing `0` (the default) leads to automatic determination as described above. Giving `1` leads to serial processing, which is the current behaviour. Providing `N>0` uses uses up to N workers, still bounded by the automatic safety limits (available cores, number of bunches, and RAM budget): an explicit `N` can only throttle the pool below the automatic choice, but never oversubscribe it.

Some little things:

- Version and CHANGELOG are bumped in preparation for a feature release. Would be nice to have #579 in as well, and maybe some further improvements in the calculation parts of `harpy` I am reserving for another PR.
- `threadpoolctl` is added to the dependencies (was already a transitive dependency),
- `psutil` is added to the dependencies.

### Performance Gains

The theoretical gains, assuming we are not limited by the resources of the machine, is a factor of `n_bunches` at most. In practice there is some overhead due to the dispatch of jobs but it is small, especially compared to the workload's runtime.

Previously: a file with `n_bunches` would analyse them one by one.
Now: a file with `n_bunches` will start all analyses simultaneously and be done in ~ the same time it takes to complete a single bunch's analysis.

## Tests

I have added unit tests for both the parallelisation heuristics, and for comparing serial results vs parallel workers results on the same inputs. The latter is done for linfiles but also the `.amps[xy]` and `.freqs[xy]` files from the `full_spectra` output (as full_spectra is our default in the GUI).

## Field Tests

I have tested this in the CCC starting workloads from the GUI. Reproducing previous analyses leads to the exact same results, down to the optics analysis downstream.

See below for GUI + harpy parallelisation considerations when we are dealing with multiple files.

### Wider parallelisation with GUI

There are two layers to the interplay here. This is assuming the default GUI setting of `Run Per-File Tasks in Parallel`.

When selecting multiple files in the BPM panel and starting the `Analyse spectra` command, the GUI issues a `python -m omc3.hole_in_one --harpy [...]` command for each file, instantly. This is done via `ssh` submission to the relevant optics server. What happens next is:

- _Currently_: All started processes (from GUI, one per file) start ~at once, and for each file the bunches are done sequentially. With a wall time of ~30s for analysing a bunch each file takes at minimum 30s x `n_bunches`. Considering `BLAS` maxes out the threads on the server, with a lot of files (or the newer 5 bunches / beam measurements) this can lead to throttling and additional slowdown on top of the `30s x n_bunches`.
- _This PR_: All started processes (from GUI, one per file) start ~at once, and each analyses the resources then parallelises across bunches within detected limits (available cores, RAM etc). If the resources are high enough then *all* bunches run in parallel and we are reduced to the min wall time of `~30s` for a given bunch's analysis.

The general outcomes:

- For a single file the gain is nice, since we always fall down to base wall time with our optics server resources: from `n_bunches x ~30s` -> `~30s`.
- For many files the gain can be even more, since the old behaviour can throttle the server and in that case we might see a better speed-up.
- *Importantly*, when analysing the kick files as they come in we can assume on would always analyse just one file at a time and be done in `~30s` every time. This lets analysis stay on top of the measurements considering we can only get a kick every minute (currently, especially with the 5 bunches the analysis falls behind measurements quite quickly).

### Benchmarks from the CCC

The python edge environment is currently on this branch. I have reproduced some analyses from earlier in the year and compared the prod version's performance (current `omc3`) to the edge version (this branch).

All results down to the optics analysis are perfectly identical. Below are some screenshots of the performance gains, for the 5 bunches measurements.

|                     | Current omc3 | This Branch omc3 |
| ------------------- | ------------ | ---------------- |
| Optics Server Usage |<img width="1410" height="812" alt="prod_usage" src="https://github.com/user-attachments/assets/06e7ea21-39a6-4236-8916-b0208c99512e" /> | <img width="1410" height="812" alt="edge_usage" src="https://github.com/user-attachments/assets/f2163947-a193-4da6-a10e-ddd46a909487" /> |
| Performance Logs    | <img width="1533" height="402" alt="prod_logs" src="https://github.com/user-attachments/assets/1bc39813-34ad-43c8-8a30-29a31bda6666" /> | <img width="1559" height="446" alt="edge_logs" src="https://github.com/user-attachments/assets/96a79485-5ab8-4e83-a163-e3745b914e34" /> |
| Total Wall Time     | 120 seconds | 31 seconds |

**Verdict**: we now finish all much faster and close to the min wall time for one bunch analysis, and we utilise much less of the machine resources, which means we have room for a lot more parallelisation (more files, more bunches).

Notice also that the new `harpy` is a little more talkative in the logs :)

Results of the analyses are the exact same, see the final optics for instance:

<img width="2560" height="1440" alt="results_comparison" src="https://github.com/user-attachments/assets/40c7e448-8aa6-4fdb-92db-fadef2dd5789" />

For more benchmark details see the OMC logbook entries of today, `2026-07-03`.

