### PR TITLE
More Ruff 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # This runs ruff check by default, our pyproject.toml has the config
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4.1.0
         with:
           version: "latest"
           src: "omc3/"

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -288,10 +288,12 @@ def analyse_with_bbq_corrections(opt: DotDict) -> tuple[TfsDataFrame, TfsDataFra
     return kick_df, bbq_df
 
 
-def get_kick_and_bbq_df(kick: Path | str, bbq_in: Path | str,
-                        beam: int = None,
-                        filter_opt: FilterOpts = None,
-                        ) -> tuple[TfsDataFrame, TfsDataFrame]:
+def get_kick_and_bbq_df(
+    kick: Path | str,
+    bbq_in: Path | str,
+    beam: int | None = None,
+    filter_opt: FilterOpts | None = None,
+) -> tuple[TfsDataFrame, TfsDataFrame]:
     """Load the input data."""
     bbq_df = None
     if bbq_in is not None and bbq_in == INPUT_PREVIOUS:

--- a/omc3/amplitude_detuning_analysis.py
+++ b/omc3/amplitude_detuning_analysis.py
@@ -508,10 +508,10 @@ def _get_bbq_data(beam: int, input_: Path | str | int, kick_df: TfsDataFrame) ->
                 t_start - t_delta, t_end + t_delta, keys=timber_keys, names=dict(zip(timber_keys, bbq_cols))
             )
         else:  # input_ is a file name or path
-            LOG.debug(f"Getting bbq data from file '{str(input_):s}'")
+            LOG.debug(f"Getting bbq data from file '{input_!s:s}'")
             data = read_timed_dataframe(input_)
             if not len(data.index):
-                raise ValueError(f"No entries in {str(input_):s}.") from e
+                raise ValueError(f"No entries in {input_!s:s}.") from e
 
     else:  # input_ is a number, assumed to be a fill number
         LOG.debug(f"Getting timber data from fill '{input_:d}'")

--- a/omc3/check_corrections.py
+++ b/omc3/check_corrections.py
@@ -459,7 +459,7 @@ def _get_corrections(
         if len(do_not_exist):
             raise OSError(
                 f"Some correction files do not exist for scenario {name}:"
-                f" {str(do_not_exist)}"
+                f" {do_not_exist!s}"
             )
 
     return corr_dict
@@ -537,7 +537,7 @@ def _create_model_and_write_diff_to_measurements(
         corr_model_path, correction_files, accel_inst
     )  # writes out twiss file!
     corr_model_elements = _maybe_add_coupling_to_model(corr_model_elements, measurement)
-    LOG.debug(f"Matched model created in {str(corr_model_path.absolute())}.")
+    LOG.debug(f"Matched model created in {corr_model_path.absolute()!s}.")
 
     # Get diff to nominal model
     diff_columns = (

--- a/omc3/check_corrections.py
+++ b/omc3/check_corrections.py
@@ -438,7 +438,7 @@ def _check_opt_add_dicts(opt: DotDict) -> DotDict:
 
 
 def _get_corrections(
-    corrections: Sequence[Path], file_pattern: str = None
+    corrections: Sequence[Path], file_pattern: str | None = None
 ) -> dict[str, Sequence[Path]]:
     """Sort the given correction files:
     If given by individual files, they all go into one bucket,
@@ -614,7 +614,7 @@ def _create_check_columns(
     colmap_meas: ColumnsAndLabels,
     colmap_model: ColumnsAndLabels,
     attribute: str,
-    rms_mask: dict = None,
+    rms_mask: dict | None = None,
 ) -> None:
     """Creates the columns in the measurements, that allow for checking the corrections.
     These are:

--- a/omc3/correction/arc_by_arc.py
+++ b/omc3/correction/arc_by_arc.py
@@ -131,7 +131,7 @@ def identify_closest_arc_bpm_to_ip(bpms: Sequence[str], ip: int, side: Literal["
     TODO: Use a regex instead, filtering the list by [LR]IP and choose the lowest via sort.
     This would assure that also BPMW etc. could be used. (jdilly, 2025)
     """
-    beam = list(bpms)[0][-1]
+    beam = next(iter(bpms))[-1]
 
     indices = range(1, 15)
     for ii in indices:

--- a/omc3/correction/handler.py
+++ b/omc3/correction/handler.py
@@ -225,7 +225,7 @@ def get_measurement_data(
         keys: Sequence[str],
         meas_dir: Path,
         beta_filename: str,
-        w_dict: dict[str, float] = None,
+        w_dict: dict[str, float] | None = None,
 ) -> tuple[list[str], dict[str, tfs.TfsDataFrame]]:
     """ Loads all measurements defined by `keys` into a dictionary. """
     measurement = {}

--- a/omc3/correction/handler.py
+++ b/omc3/correction/handler.py
@@ -423,7 +423,7 @@ def write_knob(knob_path: Path, delta: pd.DataFrame) -> None:
         delta (pd.DataFrame): DataFrame containing a DELTA column and
                               the corrector names as index.
     """
-    a = datetime.datetime.fromtimestamp(time.time())
+    a = datetime.datetime.fromtimestamp(time.time(), tz=datetime.UTC)
     delta_out = -delta.loc[:, [DELTA]]
     delta_out.headers["PATH"] = str(knob_path.parent)
     delta_out.headers["DATE"] = str(a.ctime())

--- a/omc3/correction/model_appenders.py
+++ b/omc3/correction/model_appenders.py
@@ -41,7 +41,7 @@ LOG = logging_tools.get_logger(__name__)
 def add_differences_to_model_to_measurements(
     model: pd.DataFrame,
     measurement: dict[str, pd.DataFrame],
-    keys: Sequence[str] = None,
+    keys: Sequence[str] | None = None,
 ) -> dict[str, pd.DataFrame]:
     """
     Provided with DataFrames from a model and a measurement, and a number of keys to be found in both,

--- a/omc3/correction/model_diff.py
+++ b/omc3/correction/model_diff.py
@@ -30,9 +30,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-def diff_twiss_parameters(model_a: tfs.TfsDataFrame,
-                          model_b: tfs.TfsDataFrame,
-                          parameters: Sequence[str] = None) -> tfs.TfsDataFrame:
+def diff_twiss_parameters(
+    model_a: tfs.TfsDataFrame,
+    model_b: tfs.TfsDataFrame,
+    parameters: Sequence[str] | None = None,
+) -> tfs.TfsDataFrame:
     """Create a TfsDataFrame containing the difference of the given parameters between
     model_a and model_b."""
     # preparation ---

--- a/omc3/correction/response_io.py
+++ b/omc3/correction/response_io.py
@@ -28,7 +28,7 @@ COMPLEVEL: int = 9  # goes from 0-9, 9 is highest compression, None deactivates 
 # Fullresponse -----------------------------------------------------------------
 
 
-def read_fullresponse(path: Path, optics_parameters: Sequence[str] = None) -> dict[str, pd.DataFrame]:
+def read_fullresponse(path: Path, optics_parameters: Sequence[str] | None = None) -> dict[str, pd.DataFrame]:
     """Load the response matrices from disk.
     Beware: As empty DataFrames are skipped on write,
     default for not found entries are empty DataFrames.
@@ -66,7 +66,7 @@ def write_fullresponse(path: Path, fullresponse: dict[str, pd.DataFrame]):
 # Varmap -----------------------------------------------------------------------
 
 
-def read_varmap(path: Path, k_values: Sequence[str] = None) -> dict[str, dict[str, pd.Series]]:
+def read_varmap(path: Path, k_values: Sequence[str] | None = None) -> dict[str, dict[str, pd.Series]]:
     """Load the variable mapping file from disk.
     Beware: As empty DataFrames are skipped on write,
     default for not found entries are empty Series.

--- a/omc3/correction/response_io.py
+++ b/omc3/correction/response_io.py
@@ -34,8 +34,8 @@ def read_fullresponse(path: Path, optics_parameters: Sequence[str] = None) -> di
     default for not found entries are empty DataFrames.
     """
     if not path.exists():
-        raise OSError(f"Fullresponse file {str(path)} does not exist.")
-    LOG.info(f"Loading response matrices from file '{str(path)}'")
+        raise OSError(f"Fullresponse file {path!s} does not exist.")
+    LOG.info(f"Loading response matrices from file '{path!s}'")
 
     # If encountering issues, remove the context manager and debug
     with ignore_natural_name_warning(), pd.HDFStore(path, mode="r") as store:
@@ -53,9 +53,9 @@ def write_fullresponse(path: Path, fullresponse: dict[str, pd.DataFrame]):
     """Write the full response matrices to disk.
     Beware: Empty Dataframes are skipped! (HDF creates gigantic files otherwise)
     """
-    LOG.info(f"Saving response matrices into file '{str(path)}'")
+    LOG.info(f"Saving response matrices into file '{path!s}'")
     if path.exists():
-        LOG.warning(f"Fullresponse file {str(path)} already exist and will be overwritten.")
+        LOG.warning(f"Fullresponse file {path!s} already exist and will be overwritten.")
 
     # If encountering issues, remove the context manager and debug
     with ignore_natural_name_warning(), pd.HDFStore(path, mode="w", complib=COMPLIB, complevel=COMPLEVEL) as store:
@@ -72,8 +72,8 @@ def read_varmap(path: Path, k_values: Sequence[str] = None) -> dict[str, dict[st
     default for not found entries are empty Series.
     """
     if not path.exists():
-        raise OSError(f"Varmap file {str(path)} does not exist.")
-    LOG.info(f"Loading varmap from file '{str(path)}'")
+        raise OSError(f"Varmap file {path!s} does not exist.")
+    LOG.info(f"Loading varmap from file '{path!s}'")
 
     # If encountering issues, remove the context manager and debug
     with ignore_natural_name_warning(), pd.HDFStore(path, mode="r") as store:
@@ -92,7 +92,7 @@ def write_varmap(path: Path, varmap: dict[str, dict[str, pd.Series]]):
     """Write the  variable mapping file to disk.
     Beware: Empty Dataframes are skipped! (HDF creates gigantic files otherwise)
     """
-    LOG.info(f"Saving varmap into file '{str(path)}'")
+    LOG.info(f"Saving varmap into file '{path!s}'")
 
     # If encountering issues, remove the context manager and debug
     with ignore_natural_name_warning(), pd.HDFStore(path, mode="w", complib=COMPLIB, complevel=COMPLEVEL) as store:

--- a/omc3/correction/response_madng.py
+++ b/omc3/correction/response_madng.py
@@ -199,10 +199,10 @@ def create_fullresponse(
         try:
             # Compute derivatives with twiss
             response_dict = _compute_response_with_derivatives(mad, variables, accel_inst)
-        except RuntimeError as e:
+        except RuntimeError:
             LOGGER.error("Error while computing response with MAD-NG derivatives.")
             _log_madng_output(log_path)
-            raise e
+            raise
         _log_madng_output(log_path)
 
     return response_dict

--- a/omc3/correction/response_madng.py
+++ b/omc3/correction/response_madng.py
@@ -152,10 +152,10 @@ def _load_sequence(mad: MAD, accel_inst: Accelerator):
         )
 
     # Load into MAD-NG
-    mad.send(f'MADX:load("{str(madx_seq_path.absolute())}")')
+    mad.send(f'MADX:load("{madx_seq_path.absolute()!s}")')
     if mad.MADX[seq_name] == 0:
         raise ValueError(
-            f"Sequence '{seq_name}' not found in MAD file '{str(madx_seq_path.absolute())}'"
+            f"Sequence '{seq_name}' not found in MAD file '{madx_seq_path.absolute()!s}'"
         )
     mad.send(f"loaded_sequence = MADX.{seq_name}")
     mad.loaded_sequence.dir = accel_inst.beam_direction

--- a/omc3/correction/response_madx.py
+++ b/omc3/correction/response_madx.py
@@ -84,7 +84,7 @@ def create_fullresponse(
         variables = accel_inst.get_variables(classes=variable_categories)
         if len(variables) == 0:
             raise ValueError("No variables found! Make sure your categories are valid!")
-        num_proc = num_proc if len(variables) > num_proc else len(variables)
+        num_proc = min(len(variables), num_proc)
         process_pool = multiprocessing.Pool(processes=num_proc)
 
         incr_dict = _generate_madx_jobs(accel_inst, variables, delta_k, num_proc, temp_dir)

--- a/omc3/correction/response_madx.py
+++ b/omc3/correction/response_madx.py
@@ -27,7 +27,7 @@ import tfs
 from numpy.exceptions import ComplexWarning
 from optics_functions.coupling import coupling_via_cmatrix
 
-import omc3.madx_wrapper as madx_wrapper
+from omc3 import madx_wrapper
 from omc3.correction.constants import INCR, ORBIT_DPP
 from omc3.model.accelerators.accelerator import AccElementTypes, Accelerator
 from omc3.model.model_creators.manager import CreatorType, get_model_creator_class

--- a/omc3/correction/response_twiss.py
+++ b/omc3/correction/response_twiss.py
@@ -380,16 +380,16 @@ class TwissResponse:
             q_map = {"X": tw.Q1, "Y": tw.Q2}
             disp_resp = dict.fromkeys([f"{p}_{t}" for p in sign_map for t in sign_map[p]])
 
-            for plane in sign_map:
+            for plane, value in sign_map.items():
                 q = q_map[plane]
                 col_beta = f"{BETA}{plane}"
-                el_types = sign_map[plane].keys()
+                el_types = value.keys()
                 els_per_type = [els_in[el_type] for el_type in el_types]
 
                 coeff = np.sqrt(tw.loc[el_out, col_beta].to_numpy()) / (2 * np.sin(np.pi * q))
 
                 for el_in, el_type in zip(els_per_type, el_types):
-                    coeff_sign = sign_map[plane][el_type]
+                    coeff_sign = value[el_type]
                     out_str = f"{plane}_{el_type}"
 
                     if len(el_in):
@@ -436,16 +436,16 @@ class TwissResponse:
             q_map = {"X": tw.Q1, "Y": tw.Q2}
             disp_resp = dict.fromkeys([f"{p:s}_{t:s}" for p in sign_map for t in sign_map[p]])
 
-            for plane in sign_map:
+            for plane, value in sign_map.items():
                 q = q_map[plane]
                 col_beta = f"{BETA}{plane}"
-                el_types = sign_map[plane].keys()
+                el_types = value.keys()
                 els_per_type = [els_in[el_type] for el_type in el_types]
 
                 coeff = 1 / (2 * np.sin(np.pi * q))
                 coeff_corr = 1 / (4 * np.sin(2 * np.pi * q))
                 for el_in, el_type in zip(els_per_type, el_types):
-                    coeff_sign = sign_map[plane][el_type]
+                    coeff_sign = value[el_type]
                     out_str = f"{plane:s}_{el_type:s}"
 
                     if len(el_in):

--- a/omc3/correction/sequence_evaluation.py
+++ b/omc3/correction/sequence_evaluation.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import tfs
 
-import omc3.madx_wrapper as madx_wrapper
+from omc3 import madx_wrapper
 from omc3.correction.response_io import write_varmap
 from omc3.model.model_creators.manager import CreatorType, get_model_creator_class
 from omc3.utils import logging_tools

--- a/omc3/correction/sequence_evaluation.py
+++ b/omc3/correction/sequence_evaluation.py
@@ -67,7 +67,7 @@ def evaluate_for_variables(
         if len(variables) == 0:
             raise ValueError("No variables found! Make sure your categories are valid!")
 
-        num_proc = num_proc if len(variables) > num_proc else len(variables)
+        num_proc = min(len(variables), num_proc)
         process_pool = multiprocessing.Pool(processes=num_proc)
 
         k_values = _get_orders(order)

--- a/omc3/correction/sequence_evaluation.py
+++ b/omc3/correction/sequence_evaluation.py
@@ -96,7 +96,7 @@ def _generate_madx_jobs(
     def _do_macro(var):
         return (
             f"exec, create_table(table.{var:s});\n"
-            f"write, table=table.{var:s}, file='{str(_get_tablefile(temp_dir, var)):s}';\n"
+            f"write, table=table.{var:s}, file='{_get_tablefile(temp_dir, var)!s:s}';\n"
         )
 
     LOG.debug("Generating MADX jobfiles.")
@@ -312,7 +312,7 @@ def check_varmap_file(accel_inst: Accelerator, vars_categories):
         Path(accel_inst.model_dir) / f"varmap_{'_'.join(sorted(set(vars_categories)))}.{EXT}"
     )
     if not varmap_path.exists():
-        LOG.info(f"Variable mapping '{str(varmap_path):s}' not found. Evaluating it via madx.")
+        LOG.info(f"Variable mapping '{varmap_path!s:s}' not found. Evaluating it via madx.")
         mapping = evaluate_for_variables(accel_inst, vars_categories)
         write_varmap(varmap_path, mapping)
 

--- a/omc3/kmod_importer.py
+++ b/omc3/kmod_importer.py
@@ -276,7 +276,7 @@ def _sort_paths_by_ip(
         beam_dir = path / f"{BEAM_DIR}{beam}"
         lsa_results = beam_dir / f"{LSA_FILE_NAME}{EXT}"
         df = tfs.read(lsa_results, index=NAME)
-        ip = [ip.upper() for ip in IPS if ip.upper() in df.index][0]
+        ip = next(ip.upper() for ip in IPS if ip.upper() in df.index)
         sorted_paths[ip].append(path)
     return sorted_paths
 

--- a/omc3/kmod_importer.py
+++ b/omc3/kmod_importer.py
@@ -287,8 +287,8 @@ def _sort_paths_by_ip(
 def calculate_all_lumi_imbalances(
     averaged_results: dict[str, dict[int, tfs.TfsDataFrame]],
     df_model: tfs.TfsDataFrame,
-    output_dir: Path | str = None,
-    ) -> None:
+    output_dir: Path | str | None = None,
+) -> None:
     """Calculates the luminosity imbalance between two IPs.
 
     Args:

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -390,7 +390,7 @@ def extract(ldb, knobs: Sequence[str], time: datetime) -> dict[str, float]:
                 LOGGER.debug(f"{knob} not found in StateTracker")
                 continue
 
-            timestamps, values = knobvalue[knobkey]
+            _timestamps, values = knobvalue[knobkey]
             if len(values) == 0:
                 LOGGER.debug(f"No value for {knob} found")
                 continue

--- a/omc3/knob_extractor.py
+++ b/omc3/knob_extractor.py
@@ -488,8 +488,7 @@ def _write_knobsfile(output: Path | str, collected_knobs: tfs.TfsDataFrame):
         outfile.write(f"!! --- extracted knobs for time {collected_knobs.headers[Head.time]}\n\n")
         for category, knobs_df in category_knobs.items():
             outfile.write(f"!! --- {category:10} --------------------\n")
-            for knob, knob_entry in knobs_df.iterrows():
-                outfile.write(f"{get_madx_command(knob_entry)}\n")
+            outfile.writelines(f"{get_madx_command(knob_entry)}\n" for knob, knob_entry in knobs_df.iterrows())
             outfile.write("\n")
         outfile.write("\n")
 

--- a/omc3/machine_data_extraction/data_classes.py
+++ b/omc3/machine_data_extraction/data_classes.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-import dateutil.tz as tz
 import tfs
+from dateutil import tz
 
 from omc3.machine_data_extraction.utils import knob_to_output_name, timestamp_to_utciso
 from omc3.utils.misc import StrEnum

--- a/omc3/machine_data_extraction/lsa_beamprocesses.py
+++ b/omc3/machine_data_extraction/lsa_beamprocesses.py
@@ -71,7 +71,7 @@ def get_active_beamprocess_at_time(
         raise ValueError(
             f"No active BeamProcess found for group '{bp_group}' at time {time.isoformat()}."
         )
-    LOGGER.debug(f"Active BeamProcess at time '{time.isoformat()}': {str(beamprocess)}")
+    LOGGER.debug(f"Active BeamProcess at time '{time.isoformat()}': {beamprocess!s}")
     return BeamProcessInfo.from_java_beamprocess(beamprocess)
 
 
@@ -122,7 +122,7 @@ def get_beamprocess_with_fill_at_time(
     try:
         start_time = _find_beamprocess_start(fill_info.beamprocesses, time, bp_info.name)
     except ValueError as e:
-        raise ValueError(f"In fill {fill_info.no} the {str(e)}") from e
+        raise ValueError(f"In fill {fill_info.no} the {e!s}") from e
     LOGGER.debug(
         f"Beamprocess {bp_info.name} in fill {fill_info.no} started at time {start_time.isoformat()}."
     )

--- a/omc3/machine_data_extraction/lsa_beamprocesses.py
+++ b/omc3/machine_data_extraction/lsa_beamprocesses.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
-import dateutil.tz as tz
 import numpy as np
+from dateutil import tz
 
 from omc3.machine_data_extraction.data_classes import BeamProcessInfo, FillInfo
 from omc3.machine_data_extraction.nxcals_knobs import NXCALSResult, get_raw_vars

--- a/omc3/machine_data_extraction/lsa_optics.py
+++ b/omc3/machine_data_extraction/lsa_optics.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-import dateutil.tz as tz
+from dateutil import tz
 
 from omc3.machine_data_extraction.data_classes import OpticsInfo
 from omc3.utils import logging_tools

--- a/omc3/model/accelerators/accelerator.py
+++ b/omc3/model/accelerators/accelerator.py
@@ -365,7 +365,6 @@ class AcceleratorDefinitionError(Exception):
     should have been overwritten.
     """
 
-    pass
 
 
 # Helper ----

--- a/omc3/model/accelerators/accelerator.py
+++ b/omc3/model/accelerators/accelerator.py
@@ -35,10 +35,13 @@ from omc3.utils import logging_tools
 from omc3.utils.iotools import PathOrStr, find_file
 
 if TYPE_CHECKING:
+    from logging import Logger
+    from typing import ClassVar
+
     import numpy as np
 
-LOG = logging_tools.get_logger(__name__)
-CURRENT_DIR = Path(__file__).parent
+LOG: Logger = logging_tools.get_logger(__name__)
+CURRENT_DIR: Path = Path(__file__).parent
 
 
 class AccExcitationMode:  # TODO: use enum! (jdilly, 2025)
@@ -65,7 +68,7 @@ class Accelerator:
     NAME: str
     LOCAL_REPO_NAME: str | None = None
     # RE_DICT needs to use MAD-X compatible regex patterns (jdilly, 2021)
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"^B.*",
         AccElementTypes.MAGNETS: r".*",
         AccElementTypes.ARC_BPMS: r"^B.*",

--- a/omc3/model/accelerators/accelerator.py
+++ b/omc3/model/accelerators/accelerator.py
@@ -204,10 +204,10 @@ class Accelerator:
         driven_filenames = {"acd": model_dir / TWISS_AC_DAT, "adt": model_dir / TWISS_ADT_DAT}
         if driven_filenames["acd"].is_file() and driven_filenames["adt"].is_file():
             raise AcceleratorDefinitionError("ADT as well as ACD models provided. Choose only one.")
-        for key in driven_filenames:
-            if driven_filenames[key].is_file():
+        for key, filename in driven_filenames.items():
+            if filename.is_file():
                 self.excitation = DRIVEN_EXCITATIONS[key]
-                self.model_driven = tfs.read(driven_filenames[key], index=NAME)
+                self.model_driven = tfs.read(filename, index=NAME)
 
         if self.excitation != AccExcitationMode.FREE:
             self.drv_tunes = [self.model_driven.headers["Q1"], self.model_driven.headers["Q2"]]

--- a/omc3/model/accelerators/esrf.py
+++ b/omc3/model/accelerators/esrf.py
@@ -54,17 +54,22 @@ Model Creation Keyword Args:
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import AccElementTypes, Accelerator
 
+if TYPE_CHECKING:
+    from typing import ClassVar
 
 class Esrf(Accelerator):
     NAME = "esrf"
-    RE_DICT = {AccElementTypes.BPMS: r"BPM",
-               AccElementTypes.MAGNETS: r".*",
-               AccElementTypes.ARC_BPMS: r"BPM\.(\d*[02468]\.[1-5]|\d*[13579]\.[3-7])",
-               }  # bpms 1-5 in even cells and bpms 3-7 in odd cells.
+    RE_DICT: ClassVar[dict[str, str]] = {
+        AccElementTypes.BPMS: r"BPM",
+        AccElementTypes.MAGNETS: r".*",
+        AccElementTypes.ARC_BPMS: r"BPM\.(\d*[02468]\.[1-5]|\d*[13579]\.[3-7])",
+    }  # bpms 1-5 in even cells and bpms 3-7 in odd cells.
 
     def __init__(self, *args, **kwargs):
         parser = EntryPoint(self.get_parameters(), strict=True)

--- a/omc3/model/accelerators/generic.py
+++ b/omc3/model/accelerators/generic.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import AccElementTypes, Accelerator
 
+if TYPE_CHECKING:
+    from typing import ClassVar
 
 class Generic(Accelerator):
     NAME = "generic"
-    RE_DICT = {AccElementTypes.BPMS: r"^B.*",
-               AccElementTypes.MAGNETS: r".*",
-               AccElementTypes.ARC_BPMS: r"^B.*",
-               }
+    RE_DICT: ClassVar[dict[str, str]] = {
+        AccElementTypes.BPMS: r"^B.*",
+        AccElementTypes.MAGNETS: r".*",
+        AccElementTypes.ARC_BPMS: r"^B.*",
+    }
 
     def __init__(self, *args, **kwargs):
         parser = EntryPoint(self.get_parameters(), strict=True)

--- a/omc3/model/accelerators/iota.py
+++ b/omc3/model/accelerators/iota.py
@@ -63,18 +63,23 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import AccElementTypes, Accelerator
 
-LOGGER = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from logging import Logger
+    from typing import ClassVar
+
+LOGGER: Logger = logging.getLogger(__name__)
 CURRENT_DIR: Path = Path(__file__).parent
 
 
 class Iota(Accelerator):
     NAME = "iota"
-    RE_DICT = {AccElementTypes.BPMS: r"^IBPM.*",
+    RE_DICT: ClassVar[dict[str, str]] = {AccElementTypes.BPMS: r"^IBPM.*",
                AccElementTypes.MAGNETS: r"^Q.*",
                AccElementTypes.ARC_BPMS: r"^IBPM.*"}
 

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -100,11 +100,12 @@ from omc3.utils.knob_list_manipulations import get_vars_by_classes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
+    from logging import Logger
+    from typing import ClassVar
 
-
-LOGGER = logging_tools.get_logger(__name__)
-CURRENT_DIR = Path(__file__).parent
-LHC_DIR = CURRENT_DIR / "lhc"
+LOGGER: Logger = logging_tools.get_logger(__name__)
+CURRENT_DIR: Path = Path(__file__).parent
+LHC_DIR: Path = CURRENT_DIR / "lhc"
 
 
 class Lhc(Accelerator):
@@ -114,7 +115,7 @@ class Lhc(Accelerator):
 
     NAME: str = "lhc"
     LOCAL_REPO_NAME: str = "acc-models-lhc"
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"BPM.*",
         AccElementTypes.MAGNETS: r"^M.*",
         AccElementTypes.ARC_BPMS: r"BPM.*\.0*(1[5-9]|[2-9]\d|[1-9]\d{2,})[RL]",

--- a/omc3/model/accelerators/lhc.py
+++ b/omc3/model/accelerators/lhc.py
@@ -256,7 +256,7 @@ class Lhc(Accelerator):
         # Check if no filtering but only sorting was required
         if (frm is None) and (to is None) and (len(sorted_vars) != len(variables)):
             unknown_vars = sorted(var for var in variables if var not in sorted_vars)
-            LOGGER.debug(f"The following variables do not have a location: {str(unknown_vars)}")
+            LOGGER.debug(f"The following variables do not have a location: {unknown_vars!s}")
             sorted_vars = sorted_vars + unknown_vars
         return sorted_vars
 

--- a/omc3/model/accelerators/ps.py
+++ b/omc3/model/accelerators/ps.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from generic_parser import EntryPoint
 
@@ -64,8 +65,12 @@ from omc3.model.accelerators.psbase import PsBase
 from omc3.model.constants import PLANE_TO_HV
 from omc3.utils.parsertools import require_param
 
-LOGGER = logging.getLogger(__name__)
-CURRENT_DIR = Path(__file__).parent
+if TYPE_CHECKING:
+    from logging import Logger
+    from typing import ClassVar
+
+LOGGER: Logger = logging.getLogger(__name__)
+CURRENT_DIR: Path = Path(__file__).parent
 
 # tune matching methods
 # check `ps/base.madx`
@@ -81,7 +86,7 @@ class Ps(PsBase):
 
     NAME: str = "ps"
     LOCAL_REPO_NAME: str = "acc-models-ps"
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"PR\.BPM",
         AccElementTypes.MAGNETS: r".*",
         AccElementTypes.ARC_BPMS: r"PR\.BPM",

--- a/omc3/model/accelerators/psbooster.py
+++ b/omc3/model/accelerators/psbooster.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from generic_parser import EntryPoint
 
@@ -75,15 +76,19 @@ from omc3.model.accelerators.accelerator import (
 from omc3.model.accelerators.psbase import PsBase
 from omc3.model.constants import PLANE_TO_HV
 
-LOGGER = logging.getLogger(__name__)
-CURRENT_DIR = Path(__file__).parent
+if TYPE_CHECKING:
+    from logging import Logger
+    from typing import ClassVar
+
+LOGGER: Logger = logging.getLogger(__name__)
+CURRENT_DIR: Path = Path(__file__).parent
 
 
 class Psbooster(PsBase):
     """Parent Class for Psbooster-types."""
     NAME: str = "psbooster"
     LOCAL_REPO_NAME: str = "acc-models-psb"
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"BR\d\.BPM[^T]",
         AccElementTypes.MAGNETS: r".*",
         AccElementTypes.ARC_BPMS: r"BR\d\.BPM[^T]",

--- a/omc3/model/accelerators/skekb.py
+++ b/omc3/model/accelerators/skekb.py
@@ -64,6 +64,8 @@ Model Creation Keyword Args:
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from generic_parser import EntryPoint
 
 from omc3.model.accelerators.accelerator import (
@@ -73,14 +75,18 @@ from omc3.model.accelerators.accelerator import (
 )
 from omc3.utils import logging_tools
 
-LOGGER = logging_tools.get_logger(__name__)
+if TYPE_CHECKING:
+    from logging import Logger
+    from typing import ClassVar
+
+LOGGER: Logger = logging_tools.get_logger(__name__)
 
 
 class SKekB(Accelerator):
     """KEK's SuperKEKB accelerator."""
     NAME = "skekb"
     RINGS = ("ler", "her")
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"^M*",
         AccElementTypes.MAGNETS: r".*",
         AccElementTypes.ARC_BPMS: r"^M*",

--- a/omc3/model/accelerators/sps.py
+++ b/omc3/model/accelerators/sps.py
@@ -18,6 +18,7 @@ from omc3.utils.knob_list_manipulations import get_vars_by_classes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import ClassVar
 
     from generic_parser import DotDict
 
@@ -27,7 +28,7 @@ class Sps(Accelerator):
     """ SPS accelerator. """
     NAME: str = "sps"
     LOCAL_REPO_NAME: str = "acc-models-sps"
-    RE_DICT: dict[str, str] = {
+    RE_DICT: ClassVar[dict[str, str]] = {
         AccElementTypes.BPMS: r"^BP.*",
         AccElementTypes.MAGNETS: r".*",  # has a variety of names...
         AccElementTypes.ARC_BPMS: r"^BP.*",

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -499,9 +499,9 @@ class SegmentCreator(ModelCreator, ABC):
             madx_script += "\n".join(
                 [
                     f'call, file="{corrections_path}";',
-                    (f"exec, twiss_segment(forward_SbSSEQ, "
+                    ("exec, twiss_segment(forward_SbSSEQ, "
                     f'"{twiss_forward_corr_path}", biniSbSParams);'),
-                    (f"exec, twiss_segment(backward_SbSSEQ, "
+                    ("exec, twiss_segment(backward_SbSSEQ, "
                     f'"{twiss_backward_corr_path}", bendSbSParams);'),
                     "",
                 ]

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -65,7 +65,7 @@ class ModelCreator(ABC):
     jobfile: str = JOB_MODEL_MADX_NOMINAL  # lowercase as it might be changed in subclasses __init__
     save_sequence_filename: str = "saved_madx.seq"
 
-    def __init__(self, accel: Accelerator, logfile: Path = None, acc_models_path: Path = None):
+    def __init__(self, accel: Accelerator, logfile: Path | None = None, acc_models_path: Path | None = None):
         """
         Initialise the Model Creator.
 

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -499,10 +499,10 @@ class SegmentCreator(ModelCreator, ABC):
             madx_script += "\n".join(
                 [
                     f'call, file="{corrections_path}";',
-                    f"exec, twiss_segment(forward_SbSSEQ, "
-                    f'"{twiss_forward_corr_path}", biniSbSParams);',
-                    f"exec, twiss_segment(backward_SbSSEQ, "
-                    f'"{twiss_backward_corr_path}", bendSbSParams);',
+                    (f"exec, twiss_segment(forward_SbSSEQ, "
+                    f'"{twiss_forward_corr_path}", biniSbSParams);'),
+                    (f"exec, twiss_segment(backward_SbSSEQ, "
+                    f'"{twiss_backward_corr_path}", bendSbSParams);'),
                     "",
                 ]
             )

--- a/omc3/model/model_creators/abstract_model_creator.py
+++ b/omc3/model/model_creators/abstract_model_creator.py
@@ -94,7 +94,6 @@ class ModelCreator(ABC):
             opt: The remaining options (i.e. those not yet consumed by the model creator)
 
         """
-        pass
 
     def full_run(self):
         """Does the full run: preparation, running madx, post_run."""
@@ -134,7 +133,6 @@ class ModelCreator(ABC):
         """
         Returns the ``MAD-X`` script used to create the model (directory).
         """
-        pass
 
     @abstractmethod
     def get_base_madx_script(self) -> str:
@@ -142,7 +140,6 @@ class ModelCreator(ABC):
         Returns the ``MAD-X`` script used to set-up the basic accelerator in MAD-X, without actually creating the twiss-output,
         as some modifications to the accelerator may come afterwards (depending on which model-creator is calling this).
         """
-        pass
 
     @property
     def sequence_name(self) -> str:

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -20,9 +20,12 @@ from omc3.utils.iotools import PathOrStr, save_config
 from omc3.utils.parsertools import print_help, require_param
 
 if TYPE_CHECKING:
+    from logging import Logger
+
     from omc3.model.model_creators.abstract_model_creator import ModelCreator
 
-LOGGER = logging_tools.get_logger(__name__)
+
+LOGGER: Logger = logging_tools.get_logger(__name__)
 
 
 def _get_params():

--- a/omc3/model_creator.py
+++ b/omc3/model_creator.py
@@ -140,7 +140,6 @@ def create_instance_and_model(opt, accel_opt) -> Accelerator | None:
             print_help(accel_class.get_parameters())
         except Exception as e:  # noqa: BLE001 (ugly that we catch all exceptions here...)
             LOGGER.debug(f"An error occurred: {e}")
-            pass
 
         print("---- Model Creator | Usage ----\n")
         print_help(model_manager._get_params())

--- a/omc3/optics_measurements/dpp.py
+++ b/omc3/optics_measurements/dpp.py
@@ -70,7 +70,7 @@ def _values_in_range(range_to_use: list[int], dpp_values: Sequence[float]) -> li
 
 
 def _find_range_with_element(ranges: list[list[int]], element: int) -> list[int]:
-    return [dpp_range for dpp_range in ranges if element in dpp_range][0]
+    return next(dpp_range for dpp_range in ranges if element in dpp_range)
 
 
 def _compute_ranges(dpps: Sequence[float], tolerance: float) -> list[list[int]]:

--- a/omc3/optics_measurements/measure_optics.py
+++ b/omc3/optics_measurements/measure_optics.py
@@ -149,7 +149,7 @@ def chromatic_beating(input_files: InputFiles, measure_input: DotDict, tune_dict
         for dpp_val in dpps:
             dpp_meas_input = deepcopy(measure_input)
             dpp_meas_input["analyse_dpp"] = dpp_val
-            phase_res, out_dfs = phase.calculate(dpp_meas_input, input_files, tune_dict, plane)
+            phase_res, _out_dfs = phase.calculate(dpp_meas_input, input_files, tune_dict, plane)
             beta_df, _ = beta_from_phase.calculate(dpp_meas_input, tune_dict, phase_res[phase.COMPENSATED], {}, plane)
             betas.append(beta_df)
         output_df = chromatic.calculate_w_and_phi(betas, dpps, input_files, measure_input, plane)

--- a/omc3/optics_measurements/measure_optics.py
+++ b/omc3/optics_measurements/measure_optics.py
@@ -162,7 +162,7 @@ def _get_header(meas_input: DotDict, tune_dict: tune.TuneDict) -> dict[str, Any]
         "Measure_optics:version": VERSION,
         "Command": f"{sys.executable} {' '.join(sys.argv)}",
         "CWD": Path.cwd().absolute(),
-        "Date": datetime.datetime.today().strftime("%d. %B %Y, %H:%M:%S"),
+        "Date": datetime.datetime.now(tz=datetime.UTC).strftime("%d. %B %Y, %H:%M:%S"),
         MODEL_DIRECTORY: meas_input.accelerator.model_dir,
         "Compensation": meas_input.compensation,
         "Q1": tune_dict["X"]["QF"],

--- a/omc3/optics_measurements/rdt.py
+++ b/omc3/optics_measurements/rdt.py
@@ -318,7 +318,7 @@ def _process_rdt(
     )
 
     # Get amplitude and phase of the line from linx/liny file
-    line_amp, line_phase, line_amp_e, line_phase_e = complex_secondary_lines(  # TODO use the errors
+    line_amp, line_phase, _line_amp_e, _line_phase_e = complex_secondary_lines(  # TODO use the errors
         df.loc[:, MEASUREMENT].to_numpy()[:, np.newaxis] * meas_input.accelerator.beam_direction,
         df.loc[:, f"{ERR}{MEASUREMENT}"].to_numpy()[:, np.newaxis],
         comp_coeffs1,

--- a/omc3/plotting/optics_measurements/utils.py
+++ b/omc3/plotting/optics_measurements/utils.py
@@ -66,7 +66,7 @@ class FigureCollector:
 
     def add_data_for_id(self, figure_id: str, label: str, data: DataSet,
                         x_label: str, y_label: str,
-                        path: Path = None, axes_id: str = '',
+                        path: Path | None = None, axes_id: str = '',
                         axes_ids: Iterable[str] = ('',)) -> None:
         """Add the data at the appropriate figure container."""
         try:

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -369,8 +369,15 @@ def plot_odr(ax: Axes, odr_fit: odrpack.OdrResult, xmax: float, label: str = '',
     return color
 
 
-def _plot_detuning(ax: Axes, data: AmpDetData, label: str, color=None,
-                   limits: dict[str, float] = None, odr_fit: odrpack.OdrResult=None, odr_label: str =""):
+def _plot_detuning(
+    ax: Axes,
+    data: AmpDetData,
+    label: str,
+    color=None,
+    limits: dict[str, float] | None = None,
+    odr_fit: odrpack.OdrResult | None = None,
+    odr_label: str ="",
+):
     """Plot the detuning and the ODR into axes."""
     x_lim = _get_default(limits, 'x_lim', [0, max(data.action+data.action_err)])
     offset = 0
@@ -624,8 +631,12 @@ def plot_cube(ax: Axes, x: ArrayLike, y: ArrayLike, f_low: callable, f_upp: call
 
 
 def _format_axes_3d(
-        ax: Axes, limits: dict[str, float], ax_labels: Sequence[str],
-        acd: bool, odr_labels: Sequence[dict[str, str]] = None):
+    ax: Axes,
+    limits: dict[str, float],
+    ax_labels: Sequence[str],
+    acd: bool,
+    odr_labels: Sequence[dict[str, str]] | None = None,
+):
     # labels
     ax.set_xlabel(ax_labels[0], labelpad=15)
     ax.set_ylabel(ax_labels[1], labelpad=15)

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -717,7 +717,7 @@ def _get_scaled_odr_label(odr_fit, order, action_unit, acd_correction, magnitude
 def _get_scaled_labels(val, std, scale):
     scaled_vas, scaled_std = val*scale, std*scale
     if abs(scaled_std) > 1 or scaled_std == 0:
-        return f'{int(round(scaled_vas)):d}', f'{int(round(scaled_std)):d}'
+        return f"{round(scaled_vas):d}", f"{round(scaled_std):d}"
     return significant_digits(scaled_vas, scaled_std)
 
 

--- a/omc3/plotting/plot_amplitude_detuning.py
+++ b/omc3/plotting/plot_amplitude_detuning.py
@@ -286,7 +286,7 @@ def _plot_2d(tune_plane: str, opt: DotDict) -> dict[str, Figure]:
                                                     corrected=corrected
                                                     )
                 except KeyError as e:
-                    LOG.debug(f"Entries not found in dataframe: {str(e)}")
+                    LOG.debug(f"Entries not found in dataframe: {e!s}")
                     continue  # should only happen when there is no 'corrected' columns
 
                 # Read data from kick_df headers ---

--- a/omc3/plotting/plot_checked_corrections.py
+++ b/omc3/plotting/plot_checked_corrections.py
@@ -424,7 +424,7 @@ def _create_correction_plots_per_filename(
     return figs
 
 
-def save_plots(output_dir: Path, figure_dict: dict[str, Figure], input_dir: Path = None):
+def save_plots(output_dir: Path, figure_dict: dict[str, Figure], input_dir: Path | None = None):
     """ Save the plots. """
     for figname, fig in figure_dict.items():
         outdir = output_dir

--- a/omc3/plotting/plot_checked_corrections.py
+++ b/omc3/plotting/plot_checked_corrections.py
@@ -509,7 +509,7 @@ def show_plots(figure_dict: dict[str, Figure]):
                     continue
 
                 if not correction_name:
-                    name_y = "_".join([rdt, complement_column.text_label, complement_column.expected_column])
+                    name_y = f"{rdt}_{complement_column.text_label}_{complement_column.expected_column}"
                 else:
                     name_y = "_".join(name_x.split("_")[:-1] + [complement_column.text_label,])
 

--- a/omc3/plotting/plot_checked_corrections.py
+++ b/omc3/plotting/plot_checked_corrections.py
@@ -271,7 +271,7 @@ def plot_checked_corrections(opt: DotDict):
         for correction in opt.corrections:
             correction_dirs[correction] = opt.input_dir / correction
 
-    measurements: Path = opt.meas_dir or list(correction_dirs.values())[0]
+    measurements: Path = opt.meas_dir or next(iter(correction_dirs.values()))
 
     files = _get_corrected_measurement_names(correction_dirs.values())
     ip_positions = _get_ip_positions(opt.ip_positions, opt.x_axis, opt.ip_search_pattern)

--- a/omc3/plotting/plot_tfs.py
+++ b/omc3/plotting/plot_tfs.py
@@ -400,12 +400,14 @@ def sort_data(opt):
     return collector
 
 
-def get_id(filename_parts, column, file_label, column_label, same_axes, same_figure, prefix, plane='', planes=[]):
+def get_id(filename_parts, column, file_label, column_label, same_axes, same_figure, prefix, plane='', planes = None):
     """
     Get the right IDs for the current sorting way.
     This is where the actual sorting happens, by mapping the right IDs according to the chosen
     options.
     """
+    if planes is None:
+        planes = []  # avoid default mutable argument in function
     planes = "".join(planes)
 
     file_last = filename_parts[-1].replace(EXT, "").strip("_")

--- a/omc3/plotting/spectrum/stem.py
+++ b/omc3/plotting/spectrum/stem.py
@@ -62,11 +62,11 @@ def _plot_stems(fig_cont: FigureContainer) -> None:
             # plot
             try:
                 # Matplotlib < v3.8
-                markers, stems, base = ax.stem(data[plane][FREQS], data[plane][AMPS], basefmt='none', label=label,
+                markers, stems, _base = ax.stem(data[plane][FREQS], data[plane][AMPS], basefmt='none', label=label,
                                                use_line_collection=True)
             except TypeError:
                 # Matplotlib >= v3.8
-                markers, stems, base = ax.stem(data[plane][FREQS], data[plane][AMPS], basefmt='none', label=label)
+                markers, stems, _base = ax.stem(data[plane][FREQS], data[plane][AMPS], basefmt='none', label=label)
 
             # Set appropriate colours
             color = get_cycled_color(idx_data)

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -318,7 +318,7 @@ def get_data_for_bpm(data: dict, bpm: str, rescale: bool) -> dict:
                 data_series[plane][AMPS] = rescale_amp(data_series[plane][AMPS])
 
             if any(data_series[plane][AMPS].isna()):
-                raise Exception("NAN FOUND")  # ruff: ignore[TRY002]
+                raise ValueError("NAN FOUND")
     return data_series
 
 

--- a/omc3/plotting/spectrum/utils.py
+++ b/omc3/plotting/spectrum/utils.py
@@ -318,7 +318,7 @@ def get_data_for_bpm(data: dict, bpm: str, rescale: bool) -> dict:
                 data_series[plane][AMPS] = rescale_amp(data_series[plane][AMPS])
 
             if any(data_series[plane][AMPS].isna()):
-                raise Exception("NAN FOUND")
+                raise Exception("NAN FOUND")  # ruff: ignore[TRY002]
     return data_series
 
 

--- a/omc3/plotting/utils/annotations.py
+++ b/omc3/plotting/utils/annotations.py
@@ -65,7 +65,7 @@ def set_yaxis_label(param: str, plane: str, ax=None, delta: bool = False, chromc
         raise ValueError(f"Label '{param}' not found.")
 
     if delta:
-        if param.startswith("beta") or param.startswith("norm"):
+        if param.startswith(("beta", "norm")):
             label = fr'$\Delta({label[1:-1]})$'
         else:
             label = fr'$\Delta {label[1:]}'

--- a/omc3/plotting/utils/lines.py
+++ b/omc3/plotting/utils/lines.py
@@ -6,11 +6,16 @@ Line-plotting related functionality.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.transforms as mtrans
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.markers import MarkerStyle
 from matplotlib.patches import PathPatch
+
+if TYPE_CHECKING:
+    from typing import ClassVar
 
 VERTICAL_LINES_TEXT_LOCATIONS = {
     "bottom": {"y": -0.01, "va": "top", "ha": "center"},
@@ -25,7 +30,7 @@ class MarkerList:
     """Create a list of predefined markers."""
 
     # markers = ["s", "o", ">", "D", "v", "*", "h", "^", "p", "X", "<", "P"]  # matplotlib 2.++
-    markers = ["s", "o", ">", "D", "v", "*", "h", "^", "p", "<"]
+    markers: ClassVar[list[str]] = ["s", "o", ">", "D", "v", "*", "h", "^", "p", "<"]
 
     def __init__(self):
         self.idx = 0

--- a/omc3/plotting/utils/lines.py
+++ b/omc3/plotting/utils/lines.py
@@ -90,8 +90,8 @@ def plot_vertical_lines_fast(ax, x, y=(0, 1), **kwargs):
 def plot_vertical_line(
     ax,
     axvline_args: dict,
-    text: str = None,
-    text_loc: str = None,
+    text: str | None = None,
+    text_loc: str | None = None,
     label_size: float = rcParams["font.size"],
 ):
     """

--- a/omc3/plotting/utils/style.py
+++ b/omc3/plotting/utils/style.py
@@ -28,8 +28,10 @@ def omc3_styles():
     return {p.with_suffix('').name: p for p in STYLES_DIR.glob('*.mplstyle')}
 
 
-def set_style(styles: Path | str | Sequence[Path | str] = 'standard',
-              manual: dict[str, Any] = None):
+def set_style(
+    styles: Path | str | Sequence[Path | str] = 'standard',
+    manual: dict[str, Any] | None = None,
+):
     """
     Sets the style for all following plots.
 

--- a/omc3/plotting/utils/windows.py
+++ b/omc3/plotting/utils/windows.py
@@ -100,7 +100,7 @@ class PlotWidget(QWidget):
 
 class TabWidget(QTabWidget):
 
-    def __init__(self, title: str = None):
+    def __init__(self, title: str | None = None):
         """A simple tab widget, that in addition
         to QTabWidget keeps track of the tabs via dictionary
         and can have a title.
@@ -120,7 +120,7 @@ class TabWidget(QTabWidget):
 
 class SimpleTabWindow:
 
-    def __init__(self, title: str = "Simple Tab Window", size: tuple[int, int] = None):
+    def __init__(self, title: str = "Simple Tab Window", size: tuple[int, int] | None = None):
         """A simple GUI window, i.e. a standalone graphical application,
         which contains a single Tab-Widget, allowing the user to add tabs to it.
 
@@ -156,7 +156,7 @@ class SimpleTabWindow:
 
 class VerticalTabWindow(SimpleTabWindow):
 
-    def __init__(self, title: str = "Vertical Tab Window", size: tuple[int, int] = None):
+    def __init__(self, title: str = "Vertical Tab Window", size: tuple[int, int] | None = None):
         """A Window in which the tabs are aligned vertically on the left-hand side.
         This window assumes that you may want to have tabs within tabs,
         so the convenience function `add_to_tab` is implemented, which allows
@@ -183,7 +183,7 @@ class VerticalTabWindow(SimpleTabWindow):
         self.app.exec()
 
 
-def create_pyplot_window_from_fig(fig: Figure, title: str = None):
+def create_pyplot_window_from_fig(fig: Figure, title: str | None = None):
     """Create a window from the given figure, which is managed by pyplot.
     This is similar to how figures behave when created with `pyplot.figure()`,
     but you can crate the figure instance first and the manager later.

--- a/omc3/plotting/utils/windows.py
+++ b/omc3/plotting/utils/windows.py
@@ -38,7 +38,7 @@ LOG = logging_tools.get_logger(__name__)
 try:
     from qtpy.QtWidgets import QApplication, QMainWindow, QTabWidget, QVBoxLayout, QWidget
 except ImportError as e:
-    LOG.debug(f"Could not import QtPy: {str(e)}")
+    LOG.debug(f"Could not import QtPy: {e!s}")
     QMainWindow, QApplication, QVBoxLayout  = None, None, None
     FigureCanvas, NavigationToolbar = None, None  # for mock in pytest
     QWidget, QTabWidget = object, object

--- a/omc3/sbs_propagation.py
+++ b/omc3/sbs_propagation.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import shutil
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -171,7 +172,7 @@ def _maybe_create_nominal_model(accel: Accelerator, fetcher_opts: DotDict):
         creator.prepare_options(fetcher_opts)
     except AcceleratorDefinitionError:
         if fetcher_opts.list_choices:
-            exit()
+            sys.exit()
         raise
 
     # Run the actual model creation
@@ -232,7 +233,7 @@ def create_segment(
         segment_creator.prepare_options(fetcher_opts)
     except AcceleratorDefinitionError:
         if fetcher_opts.list_choices:
-            exit()
+            sys.exit()
         raise
 
     segment_creator.full_run()

--- a/omc3/sbs_propagation.py
+++ b/omc3/sbs_propagation.py
@@ -274,7 +274,7 @@ def extend_segment(segment: Segment, model: pd.DataFrame, measurement: OpticsMea
     return new_segment
 
 
-def get_differences(propagables: list[Propagable], segment_name: str = "", output_dir: Path = None) -> SegmentDiffs:
+def get_differences(propagables: list[Propagable], segment_name: str = "", output_dir: Path | None = None) -> SegmentDiffs:
     """Calculate the differences of the propagated model and the measurement and write
     them out into files (if ``output`` had been given).
 

--- a/omc3/scripts/bad_bpms_summary.py
+++ b/omc3/scripts/bad_bpms_summary.py
@@ -55,6 +55,8 @@ their given number of appearances after 'harpy' and 'isolation forest'.
 """
 from __future__ import annotations
 
+import functools
+import operator
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
@@ -389,7 +391,7 @@ def evaluate(df: tfs.TfsDataFrame) -> tfs.TfsDataFrame:
                     df.groupby([NAME, ACCEL, SOURCE, PLANE], as_index=False)
                     .agg(
                         COUNT=(NAME, 'size'),  # Count the number of rows in each group
-                        REASONS=(REASONS, lambda x: list(set(sum(x, []))))  # Flatten and combine the lists
+                        REASONS=(REASONS, lambda x: list(set(functools.reduce(operator.iadd, x, []))))  # Flatten + combine lists (avoid sum which is quadratic)
                     )
                 )
 

--- a/omc3/scripts/create_logbook_entry.py
+++ b/omc3/scripts/create_logbook_entry.py
@@ -154,7 +154,7 @@ def _get_rbac_token() -> str:
     except CONNECTION_ERRORS as e:
         LOGGER.debug(
             f"Getting RBAC token from location failed. "
-            f"{e.__class__.__name__}: {str(e)}"
+            f"{e.__class__.__name__}: {e!s}"
         )
     else:
         LOGGER.info(f"Logged in to RBAC via location as user {rbac.user}.")
@@ -165,7 +165,7 @@ def _get_rbac_token() -> str:
     except CONNECTION_ERRORS as e:
         LOGGER.debug(
             f"Getting RBAC token via Kerberos failed. "
-            f"{e.__class__.__name__}: {str(e)}"
+            f"{e.__class__.__name__}: {e!s}"
         )
     else:
         LOGGER.info(f"Logged in to RBAC via Kerberos as user {rbac.user}.")

--- a/omc3/scripts/create_logbook_entry.py
+++ b/omc3/scripts/create_logbook_entry.py
@@ -187,7 +187,7 @@ def _get_rbac_token() -> str:
 
 
 def _get_attachments(files: Iterable[Path | str],
-                     filenames: Iterable[str] = None,
+                     filenames: Iterable[str] | None = None,
                      pdf2png: bool = False) -> list[AttachmentBuilderType]:
     """ Read the file-attachments and assign their names. """
     if files is None:

--- a/omc3/scripts/linfile_clean.py
+++ b/omc3/scripts/linfile_clean.py
@@ -208,8 +208,8 @@ def _restore_file(file):
 
 def clean_columns(files: Sequence[Path | str],
                   columns: Sequence[str],
-                  limit: float = None,   # default set in _check_limits
-                  keep: Sequence[str] = None,  # default set below
+                  limit: float | None = None,   # default set in _check_limits
+                  keep: Sequence[str] | None = None,  # default set below
                   backup: bool = True):
     """ Clean the columns in the given files."""
     for file in files:

--- a/omc3/scripts/resync_bpms.py
+++ b/omc3/scripts/resync_bpms.py
@@ -99,9 +99,11 @@ from omc3.utils import logging_tools
 from omc3.utils.iotools import PathOrStr
 
 if TYPE_CHECKING:
+    from logging import Logger
+
     from pandas import Series
 
-LOGGER = logging_tools.get_logger(__name__)
+LOGGER: Logger = logging_tools.get_logger(__name__)
 
 # ----- Some very specific constants -----
 
@@ -112,7 +114,7 @@ RINGS: Final[set[Literal["LER", "HER"]]] = {"LER", "HER"}
 PHASE_FILE: Final[str] = (
     f"{TOTAL_PHASE_NAME}" + "{plane}" + f"{EXT}"
 )  # to be formatted by 'plane'
-DEFAULT_DATATYPE: Final[Literal["lhc"]] = "lhc"
+DEFAULT_DATATYPE: Final = "lhc"
 
 
 # ----- Entrypoint parsing ----- #

--- a/omc3/scripts/resync_bpms.py
+++ b/omc3/scripts/resync_bpms.py
@@ -169,7 +169,7 @@ def _get_params() -> dict:
                 "".join(p)
                 for r in range(1, len(PLANES) + 1)
                 for p in permutations(PLANES, r)
-            ], #
+            ],
             "default": PLANES[0],
             "help": "Planes to process in the given order.",
         },

--- a/omc3/segment_by_segment/propagables/abstract.py
+++ b/omc3/segment_by_segment/propagables/abstract.py
@@ -249,7 +249,7 @@ class Propagable(ABC):
     # These need to be present in all propagables, but as usually a single `compute_xxx`
     # function can handle the different cases, the calling functions are implemented here.
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def measured_forward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Interpolation of measured deviations to forward propagated model."""
         return self._compute_measured(
@@ -258,7 +258,7 @@ class Propagable(ABC):
             forward=True
         )
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def measured_backward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Interpolation of measured deviations to backward propagated model."""
         return self._compute_measured(
@@ -267,7 +267,7 @@ class Propagable(ABC):
             forward=False
         )
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def expected_forward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Interpolation of measured deviations to corrected forward propagated model."""
         return self._compute_measured(
@@ -276,7 +276,7 @@ class Propagable(ABC):
             forward=True
         )
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def expected_backward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Interpolation of measured deviations to corrected backward propagated model."""
         return self._compute_measured(
@@ -285,7 +285,7 @@ class Propagable(ABC):
             forward=False
         )
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def correction_forward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Deviations between forward propagated models with and without correction."""
         return self._compute_correction(
@@ -295,7 +295,7 @@ class Propagable(ABC):
             forward=True,
         )
 
-    @cache
+    @cache  # ruff: ignore [B019] | warning: cache prevents GC of instance & can lead to memory leaks
     def correction_backward(self, plane: str) -> tuple[pd.Series, pd.Series]:
         """Deviations between backward propagated models with and without correction."""
         return self._compute_correction(

--- a/omc3/segment_by_segment/propagables/alpha.py
+++ b/omc3/segment_by_segment/propagables/alpha.py
@@ -46,8 +46,8 @@ class AlphaPhase(Propagable):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the alpha phase is in the measurement data. """
         try:
-            meas.beta_phase_x
-            meas.beta_phase_y
+            _x = meas.beta_phase_x  # just testing presence via access | why not test alfx?
+            _y = meas.beta_phase_y  # just testing presence via access | why not test alfy?
         except FileNotFoundError:
             return False
         return True

--- a/omc3/segment_by_segment/propagables/beta.py
+++ b/omc3/segment_by_segment/propagables/beta.py
@@ -46,8 +46,8 @@ class BetaPhase(Propagable):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the beta phase is in the measurement data. """
         try:
-            meas.beta_phase_x
-            meas.beta_phase_y
+            _x = meas.beta_phase_x  # just testing presence via access
+            _y = meas.beta_phase_y  # just testing presence via access
         except FileNotFoundError:
             return False
         return True

--- a/omc3/segment_by_segment/propagables/coupling.py
+++ b/omc3/segment_by_segment/propagables/coupling.py
@@ -28,6 +28,7 @@ from omc3.utils import logging_tools
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import ClassVar
 
     from tfs import TfsDataFrame
 
@@ -48,7 +49,7 @@ class Coupling(Propagable):
 
     columns: PropagableColumns = PropagableColumns("")  # measured columns don't have prefix
     MODEL_COLUMN_PREFIX: str  # needs to be defined per RDT
-    error_propagation_funcs: dict[str, Callable]  # Need to be defined per RDT
+    error_propagation_funcs: dict[str, Callable]  # To be defined per RDT
 
     @Propagable.segment_models.setter
     def segment_models(self, segment_models: SegmentModels):
@@ -184,7 +185,7 @@ class F1001(Coupling):
     i.e. real, imaginary, amplitude or phase.
     """
     MODEL_COLUMN_PREFIX = COL_F1001
-    error_propagation_funcs: dict[str, Callable] = {
+    error_propagation_funcs: ClassVar[dict[str, Callable]] = {
         REAL: sbs_math.propagate_error_f1001_real,
         IMAG: sbs_math.propagate_error_f1001_imag,
         AMPLITUDE: sbs_math.propagate_error_f1001_amp,
@@ -227,7 +228,7 @@ class F1010(Coupling):
     i.e. real, imaginary, amplitude or phase.
     """
     MODEL_COLUMN_PREFIX = COL_F1010
-    error_propagation_funcs: dict[str, Callable] = {
+    error_propagation_funcs: ClassVar[dict[str, Callable]] = {
         REAL: sbs_math.propagate_error_f1010_real,
         IMAG: sbs_math.propagate_error_f1010_imag,
         AMPLITUDE: sbs_math.propagate_error_f1010_amp,

--- a/omc3/segment_by_segment/propagables/coupling.py
+++ b/omc3/segment_by_segment/propagables/coupling.py
@@ -202,7 +202,7 @@ class F1001(Coupling):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the coupling rdt is in the measurement data. """
         try:
-            meas.f1001
+            _f1001 = meas.f1001  # just testing presence via access
         except FileNotFoundError:
             return False
         return True
@@ -245,7 +245,7 @@ class F1010(Coupling):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the coupling rdt is in the measurement data. """
         try:
-            meas.f1010
+            _f1010 = meas.f1010  # just testing presence via access
         except FileNotFoundError:
             return False
         return True

--- a/omc3/segment_by_segment/propagables/dispersion.py
+++ b/omc3/segment_by_segment/propagables/dispersion.py
@@ -169,7 +169,7 @@ class MomentumDispersion(Propagable):
 
         # get the measured values
         names = self.get_segment_observation_points(plane)
-        momentum_dispersion, err_pdisp = self.get_at(names, self._meas, plane)
+        momentum_dispersion, _err_pdisp = self.get_at(names, self._meas, plane)
 
         # get the propagated values
         model_momentum_dispersion = seg_model.loc[names, f"{MOMENTUM_DISPERSION}{plane}"]

--- a/omc3/segment_by_segment/propagables/dispersion.py
+++ b/omc3/segment_by_segment/propagables/dispersion.py
@@ -49,8 +49,8 @@ class Dispersion(Propagable):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the dispersion is in the measurement data. """
         try:
-            meas.dispersion_x
-            meas.dispersion_y
+            _x = meas.dispersion_x  # just testing presence via access
+            _y = meas.dispersion_y  # just testing presence via access
         except FileNotFoundError:
             return False
         return True
@@ -140,8 +140,8 @@ class MomentumDispersion(Propagable):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the dispersion is in the measurement data. """
         try:
-            meas.dispersion_x
-            meas.dispersion_y
+            _x = meas.dispersion_x  # just testing presence via access
+            _y = meas.dispersion_y  # just testing presence via access
         except FileNotFoundError:
             return False
         return True

--- a/omc3/segment_by_segment/propagables/phase.py
+++ b/omc3/segment_by_segment/propagables/phase.py
@@ -55,8 +55,8 @@ class Phase(Propagable):
     def in_measurement(cls, meas: OpticsMeasurement) -> bool:
         """ Check if the phase is in the measurement data. """
         try:
-            meas.total_phase_x
-            meas.total_phase_y
+            _x = meas.total_phase_x  # just testing presence via access
+            _y = meas.total_phase_y  # just testing presence via access
         except FileNotFoundError:
             return False
         return True

--- a/omc3/segment_by_segment/segments.py
+++ b/omc3/segment_by_segment/segments.py
@@ -135,4 +135,3 @@ class SegmentDiffs(TfsCollection):
 
 class SbsDefinitionError(Exception):
     """ Exception to be raised when the sbs definition is invalid."""
-    pass

--- a/omc3/tune_analysis/constants.py
+++ b/omc3/tune_analysis/constants.py
@@ -189,7 +189,7 @@ def get_action_err_col(plane: str) -> str:
 # Plotting #####################################################################
 
 
-def get_tune_label(plane: str, scale: int = None) -> str:
+def get_tune_label(plane: str, scale: int | None = None) -> str:
     """ Tune label for the action/tune plots. """
     unit = ""
     if scale:

--- a/omc3/tune_analysis/fitting_tools.py
+++ b/omc3/tune_analysis/fitting_tools.py
@@ -190,7 +190,7 @@ def do_2d_kicks_odr(x: ArrayLike, y: ArrayLike, xerr: ArrayLike, yerr: ArrayLike
     def curve_fit_fun(v, *args):
         return first_order_detuning_2d(v, args).ravel()
 
-    beta, beta_cov = curve_fit(f=curve_fit_fun, xdata=x, ydata=y.ravel(), p0=[0] * 5)
+    beta, _beta_cov = curve_fit(f=curve_fit_fun, xdata=x, ydata=y.ravel(), p0=[0] * 5)
 
     res_str = ",\n".join([f"{n:>16} = {b:9.3g}" for n, b in zip(INPUT_ORDER, beta)])
     LOG.info(f"\nDetuning estimate without errors (curve fit):\n{res_str}\n")

--- a/omc3/tune_analysis/kick_file_modifiers.py
+++ b/omc3/tune_analysis/kick_file_modifiers.py
@@ -75,7 +75,7 @@ def _get_ampdet_columns(corrected):
 # Data Addition ################################################################
 
 
-def add_bbq_data(kick_df: pd.DataFrame, bbq_df: pd.DataFrame, column: str, bbq_column: str = None):
+def add_bbq_data(kick_df: pd.DataFrame, bbq_df: pd.DataFrame, column: str, bbq_column: str | None = None):
     """
     Add BBQ values from column to kickac dataframe into same column.
 

--- a/omc3/tune_analysis/kick_file_modifiers.py
+++ b/omc3/tune_analysis/kick_file_modifiers.py
@@ -235,7 +235,7 @@ def get_odr_data(kickac_df: pd.DataFrame, action_plane: str, tune_plane: str,
             odr_data.beta[idx] = kickac_df.headers[header_val(q_plane=tune_plane, j_plane=action_plane, order=idx)]
             odr_data.sd_beta[idx] = kickac_df.headers[header_err(q_plane=tune_plane, j_plane=action_plane, order=idx)]
         except KeyError as e:
-            LOG.debug(f"Fit data for order {order} not found. ({str(e)})")
+            LOG.debug(f"Fit data for order {order} not found. ({e!s})")
     return odr_data
 
 
@@ -266,7 +266,7 @@ def get_ampdet_data(kickac_df: pd.DataFrame, action_plane: str, tune_plane: str,
 
     not_found = [cv for cv in columns.values() if cv not in kickac_df.columns]
     if any(not_found):
-        raise KeyError(f"The following columns were not found in kick-file: '{str(not_found)}'")
+        raise KeyError(f"The following columns were not found in kick-file: '{not_found!s}'")
 
     data = kickac_df.loc[:, list(columns.values())]
     data.columns = columns.keys()

--- a/omc3/tune_analysis/timber_extract.py
+++ b/omc3/tune_analysis/timber_extract.py
@@ -46,7 +46,7 @@ AcceptableTimeStamp = NewType("AcceptableTimeStamp", CERNDatetime | int | float)
 
 
 def lhc_fill_to_tfs(
-    fill_number: int, keys: Sequence[str] = None, names: dict[str, str] = None
+    fill_number: int, keys: Sequence[str] | None = None, names: dict[str, str] | None = None
 ) -> tfs.TfsDataFrame:
     """
     Extracts data for keys of fill from ``Timber``.
@@ -67,8 +67,8 @@ def lhc_fill_to_tfs(
 def extract_between_times(
     t_start: AcceptableTimeStamp,
     t_end: AcceptableTimeStamp,
-    keys: Sequence[str] = None,
-    names: dict[str, str] = None,
+    keys: Sequence[str] | None = None,
+    names: dict[str, str] | None = None,
 ) -> tfs.TfsDataFrame:
     """
     Extracts data for keys between ``t_start`` and ``t_end`` from ``Timber``.

--- a/omc3/utils/iotools.py
+++ b/omc3/utils/iotools.py
@@ -245,7 +245,7 @@ def maybe_add_command(opt: dict, script: str) -> dict:
     return opt
 
 
-def save_config(output_dir: Path, opt: dict, script: str, unknown_opt: dict | list = None):
+def save_config(output_dir: Path, opt: dict, script: str, unknown_opt: dict | list | None = None):
     """
     Quick wrapper for ``save_options_to_config``.
 

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -73,7 +73,7 @@ class DebugMode:
             caller_file: str = _get_caller()
             current_module: str = _get_current_module(caller_file)
 
-            self.logger = logging.getLogger(".".join([current_module, Path(caller_file).name]))
+            self.logger = logging.getLogger(f"{current_module}.{Path(caller_file).name}")
 
             # set level to debug
             self.current_level = self.logger.getEffectiveLevel()
@@ -392,7 +392,7 @@ def _get_caller_logger_name():
     """Returns logger name of the caller."""
     caller_file: str = _get_caller()
     current_module = _get_current_module(caller_file)
-    return ".".join([current_module, Path(caller_file).name])
+    return f"{current_module}.{Path(caller_file).name}"
 
 
 def _maybe_bring_color(format_string, colorlevel=INFO, color_flag=None):

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -81,7 +81,7 @@ class DebugMode:
             self.logger.debug("Running in Debug-Mode.")
 
             # create logfile name:
-            now = f"{datetime.datetime.now().isoformat():s}_"
+            now = f"{datetime.datetime.now(tz=datetime.UTC).isoformat():s}_"
             if log_file is None:
                 log_file = str(Path(caller_file).resolve().with_suffix(".log"))
             self.log_file = str(Path(log_file).parent / (now + Path(log_file).name))

--- a/omc3/utils/logging_tools.py
+++ b/omc3/utils/logging_tools.py
@@ -113,33 +113,6 @@ class DebugMode:
             self.mod_logger.removeHandler(self.console_h)
 
 
-class TempFile:
-    """
-    Context Manager. Lets another function write into a temporary file and logs its contents.
-    It won't open the file, so only the files path is returned.
-
-    Args:
-        file_path (str): Place to write the tempfile to.
-        log_func (func): The function with which the content should be logged (e.g. LOG.info).
-    """
-
-    def __init__(self, file_path: Path | str, log_func):
-        self.path = Path(file_path)
-        self.log_func = log_func
-
-    def __enter__(self) -> Path:
-        return self.path
-
-    def __exit__(self, value, traceback):
-        try:
-            content = Path(self.path).read_text()
-            self.log_func(f"{self.path:s}:\n" + content)
-        except OSError:
-            self.log_func(f"{self.path:s}: -file does not exist-")
-        else:
-            Path(self.path).unlink()
-
-
 @contextmanager
 def log_pandas_settings_with_copy(log_func):
     """Logs pandas ``SettingsWithCopy`` warning to loc_func instead of printing the warning."""

--- a/omc3/utils/outliers.py
+++ b/omc3/utils/outliers.py
@@ -20,7 +20,7 @@ LOGGER = logging_tools.get_logger(__name__)
 
 
 def get_filter_mask(data: ArrayLike, x_data: ArrayLike = None, limit: float = 0.0,
-                    niter: int = 20, nsig: int = None, mask: ArrayLike = None) -> ArrayLike:
+                    niter: int = 20, nsig: int | None = None, mask: ArrayLike | None = None) -> ArrayLike:
     r"""
     Filters the array of values which are meant to be constant or a linear function of the x-data
     array if that is provided, by checking how many sigmas they are deviating from the average.

--- a/omc3/utils/rbac.py
+++ b/omc3/utils/rbac.py
@@ -162,7 +162,7 @@ def get_os_username():
     try:
         return os.getlogin()
     except OSError as e:
-        LOGGER.debug(f"Could not get username from login. {str(e)}")
+        LOGGER.debug(f"Could not get username from login. {e!s}")
 
     for variable in ["LOGNAME", "USERNAME", "USER"]:
         try:

--- a/omc3/utils/rbac.py
+++ b/omc3/utils/rbac.py
@@ -28,7 +28,7 @@ class RBAC:
     _BASE = "https://rbac-pro1.cern.ch:8443/rba/api/v1"
     _KRB5_SERVICE = "RBAC@rbac-pro-lb.cern.ch"
 
-    def __init__(self, base: str = None, krb5_service: str = None,
+    def __init__(self, base: str | None = None, krb5_service: str | None = None,
                  application: str = "omc3", lifetime_minutes: int = 8 * 60):
         """
         Create this RBAC-Communicator instance.
@@ -144,7 +144,7 @@ class RBAC:
         self.token = response.content.decode("utf-8")
         return response.content.decode("utf-8")
 
-    def _set_user(self, user: str = None):
+    def _set_user(self, user: str | None = None):
         """ Set user attribute. """
         self.user = user or self.user or get_os_username()
         LOGGER.debug(f"Set user as '{self.user}'.")

--- a/omc3/utils/stats.py
+++ b/omc3/utils/stats.py
@@ -326,7 +326,7 @@ def unbias_variance(data, weights, axis=None):
     sample_size = effective_sample_size(data, weights, axis=axis)
     try:
         return sample_size / (sample_size - 1)
-    except ZeroDivisionError or RuntimeWarning:
+    except (ZeroDivisionError, RuntimeWarning):
         return np.zeros(sample_size.shape)
 
 

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -127,21 +127,20 @@ def utc_to_local(dt_utc, timezone):
 
 def local_string_to_utc(local_string, timezone):
     """Converts a time string in local time to UTC time."""
-    dt = datetime.strptime(local_string, get_readable_time_format())
-    dt = dt.replace(tzinfo=timezone)
+    dt: datetime = datetime.strptime(
+        local_string, get_readable_time_format()
+    ).replace(tzinfo=timezone)
     return local_to_utc(dt, timezone)
 
 
-def utc_string_to_utc(utc_string):
+def utc_string_to_utc(utc_string) -> datetime:
     """Convert a time string in utc to a UTC datetime object."""
-    dt = datetime.strptime(utc_string, get_readable_time_format())
-    return dt.replace(tzinfo=tz.tzutc())
+    return datetime.strptime(utc_string, get_readable_time_format()).replace(tzinfo=tz.tzutc())
 
 
-def cern_utc_string_to_utc(utc_string):
+def cern_utc_string_to_utc(utc_string) -> datetime:
     """Convert a time string in cern-utc to a utc datetime object."""
-    dt = datetime.strptime(utc_string, get_cern_time_format())
-    return dt.replace(tzinfo=tz.tzutc())
+    return datetime.strptime(utc_string, get_cern_time_format()).replace(tzinfo=tz.tzutc())
 
 
 def check_tz(localized_dt, timezone):

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -11,7 +11,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 
-import dateutil.tz as tz
+from dateutil import tz
 from dateutil.relativedelta import relativedelta
 
 from omc3.definitions.formats import TIME

--- a/omc3/utils/time_tools.py
+++ b/omc3/utils/time_tools.py
@@ -54,7 +54,6 @@ def _parse_time_from_str(time_str: str) -> datetime:
         dt = datetime.fromisoformat(time_str)
     except (TypeError, ValueError):
         LOGGER.debug("Could not parse time string as ISO format")
-        pass
     else:
         if dt.tzinfo is None:
             raise ValueError(
@@ -67,7 +66,6 @@ def _parse_time_from_str(time_str: str) -> datetime:
         return datetime.fromtimestamp(float(time_str), tz=tz.UTC)
     except (TypeError, ValueError):
         LOGGER.debug("Could not parse time string as a timestamp")
-        pass
 
     raise ValueError(f"Couldn't read datetime '{time_str}'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ indent-width = 4
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ignore = [
   "E501",  # line too long
+  "EXE002",  # file executable but shebang not present
   "FBT001",  # boolean-type-hint-positional-argument
   "FBT002",  # boolean-default-value-positional-argument
   "PT019",  # pytest-fixture-param-without-value (but suggested solution fails)


### PR DESCRIPTION
In version `0.16.0` released a few weeks ago, Ruff has started enabling a much larger set of rules by default (413, up from 59): see [the release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.0).

This PR adds some code changes to satisfy the new rules, so other PRs aren't blocked by the `checks` workflow.

**Note:** To satisfy the rules about timezone naive datetimes, I have enabled in a few places a default UTC timezone. This was only in places where we create a time stamp and add it to a file (from corrections for instance) and should not be an issue. Please check.

TODO after merging: adding the merge commit to `.git-blame-ignore-revs`.